### PR TITLE
Update spec/support/matchers.rb

### DIFF
--- a/spec/support/matchers.rb
+++ b/spec/support/matchers.rb
@@ -26,7 +26,7 @@ end
 
 RSpec::Matchers.define :deliver_result_image_for do |name|
   match do |response|
-    actual = files.detect do |(name, content)|
+    actual = files.detect do |name, content|
       response.body.to_s.force_encoding('ascii') == content.to_s.force_encoding('ascii') # TODO ummmmmmmm?
     end
     actual = actual && actual[0]


### PR DESCRIPTION
Rubinius does not yet destructure block (or method) arguments correctly in all cases in 1.9 mode. This change makes the specs pass on Rubinius.

It's not clear to me why the extra destructering is being used here. The #files method is returning an Array of two-element Arrays. Ruby will already destructure that Array into `name, content`.

I'm working on a smaller repro and I'll file an issue on Rubinius tracker when I get that.
