### PR TITLE
Update .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,11 @@
 language: ruby
 rvm:
   - 1.9.3
+  - rbx-19mode
 before_script:
   - 'RAILS_ENV=test rake db:create db:schema:load --trace'
 notifications:
   irc: "irc.freenode.org#travis"
+matrix:
+  allow_failures:
+    - rvm: rbx-19mode


### PR DESCRIPTION
I re-enabled Rubinius and set `allow_failures` per the docs here http://about.travis-ci.org/docs/user/build-configuration/. Hopefully I did that correctly.

It seems that allowing failures would be better than adding and removing Rubinius. That way, when it fails, it's easy to point us to a failure.
