### PR TITLE
Security improvement - don't respond `resource.to_json`

### DIFF
--- a/lib/travis/api/app/responders/json.rb
+++ b/lib/travis/api/app/responders/json.rb
@@ -8,17 +8,21 @@ class Travis::Api::App
       end
 
       def apply
-        halt result.to_json
+        halt (result ? result.to_json : 404)
       end
 
       private
 
         def result
-          builder ? builder.new(resource, request.params).data : resource
+          builder ? builder.new(resource, request.params).data : basic_type_resource
         end
 
         def builder
           @builder ||= Travis::Api.builder(resource, { :version => accept_version }.merge(options))
+        end
+
+        def basic_type_resource
+          resource if resource.is_a?(Hash)
         end
     end
   end

--- a/spec/unit/responders/json_spec.rb
+++ b/spec/unit/responders/json_spec.rb
@@ -1,0 +1,54 @@
+require 'spec_helper'
+
+module Travis::Api::App::Responders
+  describe Json do
+    class MyJson < Json
+    end
+
+    let(:request)  { stub 'request', accept: ['application/vnd.travis-ci.2+json'], params: {} }
+    let(:endpoint) { stub 'endpoint', request: request }
+    let(:resource) { stub 'resource' }
+    let(:options)  { {} }
+    let(:json)  { MyJson.new(endpoint, resource, options) }
+
+    context 'with resource not associated with Api data class' do
+      it 'returns nil result' do
+        json.expects(:halt).with(404)
+        json.apply
+      end
+    end
+
+    context 'with resource being' do
+      context 'a Hash instance' do
+        let(:resource) { { foo: 'bar' } }
+
+        it 'returns resource converted to_json' do
+          json.expects(:halt).with({ foo: 'bar' }.to_json)
+          json.apply
+        end
+      end
+
+      context 'nil' do
+        let(:resource) { nil }
+
+        it 'responds with 404' do
+          json.expects(:halt).with(404)
+          json.apply
+        end
+      end
+    end
+
+    context 'with resource associated with Api data class' do
+      let(:builder)       { stub 'builder', data: { foo: 'bar' } }
+      let(:builder_class) { stub 'builder class', new: builder }
+      before do
+        json.stubs :builder => builder_class
+      end
+
+      it 'returns proper data converted to json' do
+        json.expects(:halt).with({ foo: 'bar' }.to_json)
+        json.apply
+      end
+    end
+  end
+end


### PR DESCRIPTION
From commit description:

```
In order to protect us from rendering a resource simply converted to
json, without processing it with API data class, this commit changes
JSON responder behavior to render 404 if we can't find associated data
class. The only exception to that rule is when resource is already a
Hash, meaning that it was processed before - we sometimes return for
example simple Hash responses like { result: true }.

The Hash exception could allow to accidentally pass resource.as_json to
responder, but in travis-ci/travis-support@124b8b6 I disabled default
as_json method on AR::Base classes, so the risk of such mistake is
lowered.
```
