### PR TITLE
Disable New Relic in console

### DIFF
--- a/script/console
+++ b/script/console
@@ -1,6 +1,8 @@
 #!/usr/bin/env ruby
 # encoding: UTF-8
 
+ENV["NEWRELIC_ENABLE"] = "false"
+
 require 'bundler/setup'
 require 'travis/api/app'
 require 'pry'


### PR DESCRIPTION
This should disable New Relic in the console. I haven't been able to test it, as I actually have to deploy it to test it, so I thought I'd make it a PR so someone else can double-check my logic.

This is what you'd use to get when starting the console:

```
[hh-disable-new-relic-in-console][~/code/travis-api] production console
Running `console` attached to terminal... up, run.8463
I Setting up Travis::Core
** [NewRelic][05/15/13 15:33:41 +0000 <uuid> (2)] INFO : Starting the New Relic agent in "production" environment.
** [NewRelic][05/15/13 15:33:41 +0000 <uuid> (2)] INFO : To prevent agent startup add a NEWRELIC_ENABLE=false environment variable or modify the "production" section of your newrelic.yml.
** [NewRelic][05/15/13 15:33:41 +0000 <uuid> (2)] INFO : Reading configuration from config/newrelic.yml
** [NewRelic][05/15/13 15:33:41 +0000 <uuid> (2)] WARN : Agent is configured not to use SSL when communicating with New Relic's servers
** [NewRelic][05/15/13 15:33:41 +0000 <uuid> (2)] INFO : Environment: production
** [NewRelic][05/15/13 15:33:41 +0000 <uuid> (2)] INFO : No known dispatcher detected.
** [NewRelic][05/15/13 15:33:41 +0000 <uuid> (2)] INFO : Application: travis-api-production
** [NewRelic][05/15/13 15:33:41 +0000 <uuid> (2)] INFO : Installing Sidekiq instrumentation
** [NewRelic][05/15/13 15:33:41 +0000 <uuid> (2)] INFO : Installing Sinatra instrumentation
** [NewRelic][05/15/13 15:33:41 +0000 <uuid> (2)] INFO : Installing Net instrumentation
** [NewRelic][05/15/13 15:33:41 +0000 <uuid> (2)] INFO : Installing ActiveRecord instrumentation
** [NewRelic][05/15/13 15:33:41 +0000 <uuid> (2)] INFO : Finished instrumentation
>>
```
