### PR TITLE
Mention the Travis API host name

### DIFF
--- a/docs/00_overview.md
+++ b/docs/00_overview.md
@@ -2,9 +2,9 @@
 
 **This documentation is for the v2 API. However, this endpoint does also serve the v1 API (undocumented).**
 
-Welcome to the Travis API documentation. This is the API used by the official
-[Travis CI](https://next.travis-ci.org) web interface, so everything the web
-interface is able to do is also accomplishable via the API.
+Welcome to the API documentation for [api.travis-ci.org](https://api.travis-ci.org/)
+
+This is the API used by the official Travis CI web interface, so everything the web interface is able to do is also accomplishable via the API.
 
 ## Media Types
 


### PR DESCRIPTION
Mentions the host name in the docs overview, as it's not mentioned anywhere.

Also removes the link to next.travis-ci.org
