### PR TITLE
Add an uptime endpoint for Pingdom

### DIFF
--- a/lib/travis/api/app/endpoint/uptime.rb
+++ b/lib/travis/api/app/endpoint/uptime.rb
@@ -7,8 +7,8 @@ class Travis::Api::App
         begin
           ActiveRecord::Base.connection.execute('select 1')
           [200, "OK"]
-        rescue => e
-          [500, "Error: #{e.message}"]
+        rescue Exception => e
+          return [500, "Error: #{e.message}"]
         end
       end
     end

--- a/spec/integration/uptime_spec.rb
+++ b/spec/integration/uptime_spec.rb
@@ -1,0 +1,20 @@
+require 'spec_helper'
+
+describe 'Uptime' do
+  after do
+    ActiveRecord::Base.connection.unstub(:execute)
+  end
+
+  it 'returns a 200 and ok when the request was successful' do
+    response = get '/uptime'
+    response.status.should == 200
+    response.body.should == "OK"
+  end
+
+  it "returns a 500 when the query wasn't successful" do
+    ActiveRecord::Base.connection.stubs(:execute).raises(StandardError, 'error!')
+    response = get '/uptime'
+    response.status.should == 500
+    response.body.should == "Error: error!"
+  end
+end


### PR DESCRIPTION
Sends a simple database query to see if we can still connect
to the database. Should help us detect issues like yesterday's
EC2 issues earlier.
