### PR TITLE
Use valid JSON for error responses

### DIFF
--- a/lib/travis/api/app.rb
+++ b/lib/travis/api/app.rb
@@ -32,6 +32,8 @@ module Travis::Api
 
     Rack.autoload :SSL, 'rack/ssl'
 
+    ERROR_RESPONSE = JSON.generate(error: 'Travis encountered an error, sorry :(')
+
     # Used to track if setup already ran.
     def self.setup?
       @setup ||= false
@@ -113,7 +115,7 @@ module Travis::Api
       app.call(env)
     rescue
       if Endpoint.production?
-        [500, {'Content-Type' => 'application/json'}, ["{'error': 'Travis encountered an error, sorry :('}"]]
+        [500, {'Content-Type' => 'application/json'}, [ERROR_RESPONSE]]
       else
         raise
       end


### PR DESCRIPTION
Currently, the error response is not valid JSON. 
I haven't written a test as it is guarded behind the `Endpoint.production?` check. 
