### PR TITLE
Only allow XML response if repo has a build

### DIFF
--- a/lib/travis/api/app/responders/xml.rb
+++ b/lib/travis/api/app/responders/xml.rb
@@ -16,7 +16,7 @@ module Travis::Api::App::Responders
     }
 
     def apply?
-      super && resource.is_a?(Repository)
+      super && resource.is_a?(Repository) && last_build
     end
 
     def apply


### PR DESCRIPTION
Should fix [this error](https://app.getsentry.com/travis-ci/travis-api/group/7983882/) in Sentry.
