### PR TITLE
Only allow image responses for repositories

### DIFF
--- a/lib/travis/api/app/responders/image.rb
+++ b/lib/travis/api/app/responders/image.rb
@@ -11,6 +11,10 @@ module Travis::Api::App::Responders
       send_file(filename, type: :png, last_modified: last_modified)
     end
 
+    def apply?
+      super && resource.is_a?(Repository)
+    end
+
     private
 
       def content_type


### PR DESCRIPTION
Should turn a bunch of 500 errors that I see in Sentry into 406 errors instead.
