### PR TITLE
Handle race condition with creating users more nicely

### DIFF
--- a/lib/travis/api/app/endpoint/authorization.rb
+++ b/lib/travis/api/app/endpoint/authorization.rb
@@ -210,6 +210,7 @@ class Travis::Api::App
           end
 
           def fetch
+            retried ||= false
             user   = ::User.find_by_github_id(data['id'])
             info   = drop_token ? self.info : self.info(github_oauth_token: token)
 
@@ -225,6 +226,11 @@ class Travis::Api::App
             end
 
             user
+          rescue ActiveRecord::RecordNotUnique
+            unless retried
+              retried = true
+              retry
+            end
           end
         end
 


### PR DESCRIPTION
I looked into adding tests for this, but wasn't quite sure how to best do it. If anyone has suggestions, please let me know.

This should handle the race condition where the user is being created somewhere else sometime between `User.find_by_github_id` and `User.create!`, which throws an error due to the unique contraint on github_id.
