### PR TITLE
Move API v2 payload definitions to travis-api from travis-core

### DIFF
--- a/lib/travis/api/app/endpoint/repos.rb
+++ b/lib/travis/api/app/endpoint/repos.rb
@@ -41,6 +41,15 @@ class Travis::Api::App
         respond_with service(:find_repo, params.merge(schema: 'cc'))
       end
 
+      get '/:id/settings/ssh_keys' do
+        settings = service(:find_repo_settings, params).run
+        if settings
+          respond_with({ settings: settings.obfuscated }, version: :v2)
+        else
+          status 404
+        end
+      end
+
       # Get settings for a given repository
       #
       get '/:id/settings' do

--- a/lib/travis/api/v2.rb
+++ b/lib/travis/api/v2.rb
@@ -1,0 +1,8 @@
+module Travis
+  module Api
+    module V2
+      require 'travis/api/v2/http'
+    end
+  end
+end
+

--- a/lib/travis/api/v2/http.rb
+++ b/lib/travis/api/v2/http.rb
@@ -1,0 +1,27 @@
+module Travis
+  module Api
+    module V2
+      module Http
+        require 'travis/api/v2/http/accounts'
+        require 'travis/api/v2/http/annotations'
+        require 'travis/api/v2/http/broadcasts'
+        require 'travis/api/v2/http/branch'
+        require 'travis/api/v2/http/branches'
+        require 'travis/api/v2/http/build'
+        require 'travis/api/v2/http/builds'
+        require 'travis/api/v2/http/caches'
+        require 'travis/api/v2/http/hooks'
+        require 'travis/api/v2/http/job'
+        require 'travis/api/v2/http/jobs'
+        require 'travis/api/v2/http/log'
+        require 'travis/api/v2/http/permissions'
+        require 'travis/api/v2/http/repositories'
+        require 'travis/api/v2/http/repository'
+        require 'travis/api/v2/http/requests'
+        require 'travis/api/v2/http/request'
+        require 'travis/api/v2/http/ssl_key'
+        require 'travis/api/v2/http/user'
+      end
+    end
+  end
+end

--- a/lib/travis/api/v2/http/accounts.rb
+++ b/lib/travis/api/v2/http/accounts.rb
@@ -1,0 +1,38 @@
+module Travis
+  module Api
+    module V2
+      module Http
+        class Accounts
+          include Formats
+
+          attr_reader :accounts, :options
+
+          def initialize(accounts, options = {})
+            @accounts = accounts
+            @options = options
+          end
+
+          def data
+            {
+              :accounts => accounts.map { |account| account_data(account) }
+            }
+          end
+
+          private
+
+            def account_data(account)
+              {
+                'id' => account.id,
+                'name' => account.name,
+                'login' => account.login,
+                'type' => account.type.underscore,
+                'repos_count' => account.repos_count
+              }
+            end
+        end
+      end
+    end
+  end
+end
+
+

--- a/lib/travis/api/v2/http/annotations.rb
+++ b/lib/travis/api/v2/http/annotations.rb
@@ -1,0 +1,34 @@
+module Travis
+  module Api
+    module V2
+      module Http
+        class Annotations
+          include Formats
+
+          def initialize(annotations, options = {})
+            @annotations = annotations
+          end
+
+          def data
+            {
+              "annotations" => @annotations.map { |annotation| build_annotation(annotation) },
+            }
+          end
+
+          private
+
+          def build_annotation(annotation)
+            {
+              "id" => annotation.id,
+              "job_id" => annotation.job_id,
+              "description" => annotation.description,
+              "url" => annotation.url,
+              "status" => annotation.status,
+              "provider_name" => annotation.annotation_provider.name,
+            }
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/travis/api/v2/http/branch.rb
+++ b/lib/travis/api/v2/http/branch.rb
@@ -1,0 +1,28 @@
+require 'travis/api/v2/http/branches'
+
+module Travis
+  module Api
+    module V2
+      module Http
+        class Branch < Branches
+          include Formats
+
+          attr_reader :build, :commit, :options
+
+          def initialize(build, options = {})
+            @build   = build
+            @commit  = build.commit
+            @options = options
+          end
+
+          def data
+            {
+              'branch' => build_data(build),
+              'commit' => commit_data(commit)
+            }
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/travis/api/v2/http/branches.rb
+++ b/lib/travis/api/v2/http/branches.rb
@@ -1,0 +1,60 @@
+module Travis
+  module Api
+    module V2
+      module Http
+        class Branches
+          include Formats
+
+          attr_reader :builds, :commits, :options
+
+          def initialize(builds, options = {})
+            builds = builds.last_finished_builds_by_branches if builds.is_a?(Repository) # TODO remove, bc
+            @builds = builds
+            @commits = builds.map(&:commit)
+            @options = options
+          end
+
+          def data
+            {
+              'branches' => builds.map { |build| build_data(build) },
+              'commits' => commits.map { |commit| commit_data(commit) }
+            }
+          end
+
+          private
+
+            def build_data(build)
+              {
+                'id' => build.id,
+                'repository_id' => build.repository_id,
+                'commit_id' => build.commit_id,
+                'number' => build.number,
+                'config' => build.obfuscated_config.stringify_keys,
+                'state' => build.state.to_s,
+                'started_at' => format_date(build.started_at),
+                'finished_at' => format_date(build.finished_at),
+                'duration' => build.duration,
+                'job_ids' => build.matrix.map { |job| job.id },
+                'pull_request' => build.pull_request?
+              }
+            end
+
+            def commit_data(commit)
+              {
+                'id' => commit.id,
+                'sha' => commit.commit,
+                'branch' => commit.branch,
+                'message' => commit.message,
+                'committed_at' => format_date(commit.committed_at),
+                'author_name' => commit.author_name,
+                'author_email' => commit.author_email,
+                'committer_name' => commit.committer_name,
+                'committer_email' => commit.committer_email,
+                'compare_url' => commit.compare_url,
+              }
+            end
+        end
+      end
+    end
+  end
+end

--- a/lib/travis/api/v2/http/broadcasts.rb
+++ b/lib/travis/api/v2/http/broadcasts.rb
@@ -1,0 +1,32 @@
+module Travis
+  module Api
+    module V2
+      module Http
+        class Broadcasts
+          attr_reader :broadcasts, :options
+
+          def initialize(broadcasts, options = {})
+            @broadcasts = broadcasts
+            @options = options
+          end
+
+          def data
+            {
+              'broadcasts' => broadcasts.map { |broadcast| broadcast_data(broadcast) }
+            }
+          end
+
+          private
+
+            def broadcast_data(broadcast)
+              {
+                'id' => broadcast.id,
+                'message' => broadcast.message
+              }
+            end
+        end
+      end
+    end
+  end
+end
+

--- a/lib/travis/api/v2/http/build.rb
+++ b/lib/travis/api/v2/http/build.rb
@@ -1,0 +1,87 @@
+module Travis
+  module Api
+    module V2
+      module Http
+        class Build
+          include Formats
+
+          attr_reader :build, :options
+
+          def initialize(build, options = {})
+            options[:include_jobs] = true unless options.key?(:include_jobs)
+
+            @build = build
+            @options = options
+          end
+
+          def data
+            {
+              'build'  => build_data(build),
+              'commit' => commit_data(build.commit),
+              'jobs'   => options[:include_jobs] ? build.matrix.map { |job| job_data(job) } : [],
+              'annotations' => options[:include_jobs] ? Annotations.new(annotations(build), @options).data["annotations"] : [],
+            }
+          end
+
+          private
+
+            def build_data(build)
+              {
+                'id' => build.id,
+                'repository_id' => build.repository_id,
+                'commit_id' => build.commit_id,
+                'number' => build.number,
+                'pull_request' => build.pull_request?,
+                'pull_request_title' => build.pull_request_title,
+                'pull_request_number' => build.pull_request_number,
+                'config' => build.obfuscated_config.stringify_keys,
+                'state' => build.state.to_s,
+                'started_at' => format_date(build.started_at),
+                'finished_at' => format_date(build.finished_at),
+                'duration' => build.duration,
+                'job_ids' => build.matrix_ids
+              }
+            end
+
+            def commit_data(commit)
+              {
+                'id' => commit.id,
+                'sha' => commit.commit,
+                'branch' => commit.branch,
+                'message' => commit.message,
+                'committed_at' => format_date(commit.committed_at),
+                'author_name' => commit.author_name,
+                'author_email' => commit.author_email,
+                'committer_name' => commit.committer_name,
+                'committer_email' => commit.committer_email,
+                'compare_url' => commit.compare_url,
+              }
+            end
+
+            def job_data(job)
+              {
+                'id' => job.id,
+                'repository_id' => job.repository_id,
+                'build_id' => job.source_id,
+                'commit_id' => job.commit_id,
+                'log_id' => job.log_id,
+                'state' => job.state.to_s,
+                'number' => job.number,
+                'config' => job.obfuscated_config.stringify_keys,
+                'started_at' => format_date(job.started_at),
+                'finished_at' => format_date(job.finished_at),
+                'queue' => job.queue,
+                'allow_failure' => job.allow_failure,
+                'tags' => job.tags,
+                'annotation_ids' => job.annotation_ids,
+              }
+            end
+
+            def annotations(build)
+              build.matrix.map(&:annotations).flatten
+            end
+        end
+      end
+    end
+  end
+end

--- a/lib/travis/api/v2/http/builds.rb
+++ b/lib/travis/api/v2/http/builds.rb
@@ -1,0 +1,66 @@
+module Travis
+  module Api
+    module V2
+      module Http
+        class Builds
+          include Formats
+
+          attr_reader :builds, :commits, :options
+
+          def initialize(builds, options = {})
+            @builds = builds
+            @commits = builds.map(&:commit)
+            @options = options
+          end
+
+          def data
+            {
+              'builds' => builds.map { |build| build_data(build) },
+              'commits' => commits.map { |commit| commit_data(commit) }
+            }
+          end
+
+          private
+
+            def build_data(build)
+              {
+                'id' => build.id,
+                'repository_id' => build.repository_id,
+                'commit_id' => build.commit_id,
+                'number' => build.number,
+                'pull_request' => build.pull_request?,
+                'pull_request_title' => build.pull_request_title,
+                'pull_request_number' => build.pull_request_number,
+                'config' => build.obfuscated_config.stringify_keys,
+                'state' => build.state.to_s,
+                'started_at' => format_date(build.started_at),
+                'finished_at' => format_date(build.finished_at),
+                'duration' => build.duration,
+                'job_ids' => matrix_ids(build)
+              }
+            end
+
+            def matrix_ids(build)
+              build.cached_matrix_ids || build.matrix_ids
+            end
+
+            def commit_data(commit)
+              {
+                'id' => commit.id,
+                'sha' => commit.commit,
+                'branch' => commit.branch,
+                'message' => commit.message,
+                'committed_at' => format_date(commit.committed_at),
+                'author_name' => commit.author_name,
+                'author_email' => commit.author_email,
+                'committer_name' => commit.committer_name,
+                'committer_email' => commit.committer_email,
+                'compare_url' => commit.compare_url,
+                'pull_request_number' => commit.pull_request_number
+              }
+            end
+        end
+      end
+    end
+  end
+end

--- a/lib/travis/api/v2/http/caches.rb
+++ b/lib/travis/api/v2/http/caches.rb
@@ -1,0 +1,33 @@
+module Travis
+  module Api
+    module V2
+      module Http
+        class Caches
+          include Formats
+          attr_reader :caches, :options
+
+          def initialize(caches, options = {})
+            @caches  = caches
+            @options = options
+          end
+
+          def data
+            { 'caches' => caches.map { |cache| cache_data(cache) } }
+          end
+
+          private
+
+              def cache_data(cache)
+                {
+                  'repository_id' => cache.repository.id,
+                  'size'          => cache.size,
+                  'slug'          => cache.slug,
+                  'branch'        => cache.branch,
+                  'last_modified' => format_date(cache.last_modified)
+                }
+              end
+        end
+      end
+    end
+  end
+end

--- a/lib/travis/api/v2/http/hooks.rb
+++ b/lib/travis/api/v2/http/hooks.rb
@@ -1,0 +1,37 @@
+module Travis
+  module Api
+    module V2
+      module Http
+        class Hooks
+          attr_reader :hooks, :options
+
+          def initialize(hooks, options = {})
+            @hooks = hooks
+            @options = options
+          end
+
+          def data
+            {
+              'hooks' => hooks.map { |hook| hook_data(hook) },
+            }
+          end
+
+          private
+
+            def hook_data(hook)
+              {
+                'id' => hook.id,
+                'name' => hook.name,
+                'owner_name' => hook.owner_name,
+                'description' => hook.description,
+                'active' => hook.active,
+                'private' => hook.private,
+                'admin' => hook.admin?
+              }
+            end
+        end
+      end
+    end
+  end
+end
+

--- a/lib/travis/api/v2/http/job.rb
+++ b/lib/travis/api/v2/http/job.rb
@@ -1,0 +1,63 @@
+module Travis
+  module Api
+    module V2
+      module Http
+        class Job
+          include Formats
+
+          attr_reader :job, :options
+
+          def initialize(job, options = {})
+            @job = job
+            @options = options
+          end
+
+          def data
+            {
+              'job' => job_data(job),
+              'commit' => commit_data(job.commit),
+              'annotations' => Annotations.new(job.annotations, @options).data["annotations"],
+            }
+          end
+
+          private
+
+            def job_data(job)
+              {
+                'id' => job.id,
+                'repository_id' => job.repository_id,
+                'repository_slug' => job.repository.slug,
+                'build_id' => job.source_id,
+                'commit_id' => job.commit_id,
+                'log_id' => job.log_id,
+                'number' => job.number,
+                'config' => job.obfuscated_config.stringify_keys,
+                'state' => job.state.to_s,
+                'started_at' => format_date(job.started_at),
+                'finished_at' => format_date(job.finished_at),
+                'queue' => job.queue,
+                'allow_failure' => job.allow_failure,
+                'tags' => job.tags,
+                'annotation_ids' => job.annotation_ids,
+              }
+            end
+
+            def commit_data(commit)
+              {
+                'id' => commit.id,
+                'sha' => commit.commit,
+                'branch' => commit.branch,
+                'message' => commit.message,
+                'committed_at' => format_date(commit.committed_at),
+                'author_name' => commit.author_name,
+                'author_email' => commit.author_email,
+                'committer_name' => commit.committer_name,
+                'committer_email' => commit.committer_email,
+                'compare_url' => commit.compare_url,
+              }
+            end
+        end
+      end
+    end
+  end
+end

--- a/lib/travis/api/v2/http/jobs.rb
+++ b/lib/travis/api/v2/http/jobs.rb
@@ -1,0 +1,61 @@
+module Travis
+  module Api
+    module V2
+      module Http
+        class Jobs
+          include Formats
+
+          attr_reader :jobs, :options
+
+          def initialize(jobs, options = {})
+            @jobs = jobs
+            @options = options
+          end
+
+          def data
+            {
+              'jobs' => jobs.map { |job| job_data(job) },
+              'commits' => jobs.map { |job| commit_data(job.commit) }
+            }
+          end
+
+          private
+
+            def job_data(job)
+              {
+                'id' => job.id,
+                'repository_id' => job.repository_id,
+                'repository_slug' => job.repository.slug,
+                'build_id' => job.source_id,
+                'commit_id' => job.commit_id,
+                'log_id' => job.log_id,
+                'number' => job.number,
+                'config' => job.obfuscated_config.stringify_keys,
+                'state' => job.state.to_s,
+                'started_at' => format_date(job.started_at),
+                'finished_at' => format_date(job.finished_at),
+                'queue' => job.queue,
+                'allow_failure' => job.allow_failure,
+                'tags' => job.tags
+              }
+            end
+
+            def commit_data(commit)
+              {
+                'id' => commit.id,
+                'sha' => commit.commit,
+                'branch' => commit.branch,
+                'message' => commit.message,
+                'committed_at' => format_date(commit.committed_at),
+                'author_name' => commit.author_name,
+                'author_email' => commit.author_email,
+                'committer_name' => commit.committer_name,
+                'committer_email' => commit.committer_email,
+                'compare_url' => commit.compare_url,
+              }
+            end
+        end
+      end
+    end
+  end
+end

--- a/lib/travis/api/v2/http/log.rb
+++ b/lib/travis/api/v2/http/log.rb
@@ -1,0 +1,54 @@
+module Travis
+  module Api
+    module V2
+      module Http
+        class Log
+          attr_reader :log, :options
+
+          def initialize(log, options = {})
+            @log = log
+            @options = options
+          end
+
+          def data
+            {
+              'log' => options[:chunked] ? chunked_log_data : log_data,
+            }
+          end
+
+          private
+
+            def log_data
+              {
+                'id' => log.id,
+                'job_id' => log.job_id,
+                'type' => log.class.name.demodulize,
+                'body' => log.content
+              }
+            end
+
+            def chunked_log_data
+              {
+                'id' => log.id,
+                'job_id' => log.job_id,
+                'type' => log.class.name.demodulize,
+                'parts' => log_parts
+              }
+            end
+
+            def log_parts
+              log.parts.sort_by(&:number).map do |part|
+                {
+                  'id' => part.id,
+                  'number' => part.number,
+                  'content' => part.content,
+                  'final' => part.final
+                }
+              end
+            end
+        end
+      end
+    end
+  end
+end
+

--- a/lib/travis/api/v2/http/permissions.rb
+++ b/lib/travis/api/v2/http/permissions.rb
@@ -1,0 +1,50 @@
+module Travis
+  module Api
+    module V2
+      module Http
+        class Permissions
+          attr_reader :permissions, :options
+
+          def initialize(permissions, options = {})
+            @permissions = permissions
+            @options = options
+          end
+
+          def data
+            {
+              'permissions' => repo_ids,
+              'admin'       => admin_ids,
+              'pull'        => pull_ids,
+              'push'        => push_ids
+            }
+          end
+
+          private
+            def filtered_ids(perm = nil)
+              if perm
+                permissions.find_all { |p| p.send("#{perm}?") }.map { |permission| permission.repository_id }
+              else
+                permissions.map { |permission| permission.repository_id }
+              end
+            end
+
+            def repo_ids
+              filtered_ids
+            end
+
+            def admin_ids
+              filtered_ids(:admin)
+            end
+
+            def pull_ids
+              filtered_ids(:pull)
+            end
+
+            def push_ids
+              filtered_ids(:push)
+            end
+        end
+      end
+    end
+  end
+end

--- a/lib/travis/api/v2/http/repositories.rb
+++ b/lib/travis/api/v2/http/repositories.rb
@@ -1,0 +1,43 @@
+module Travis
+  module Api
+    module V2
+      module Http
+        class Repositories
+          include Formats
+
+          attr_reader :repositories, :options
+
+          def initialize(repositories, options = {})
+            @repositories = repositories
+            @options = options
+          end
+
+          def data
+            {
+              'repos' => repositories.map { |repository| repository_data(repository) }
+            }
+          end
+
+          private
+
+            def repository_data(repository)
+              {
+                'id' => repository.id,
+                'slug' => repository.slug,
+                'description' => repository.description,
+                'last_build_id' => repository.last_build_id,
+                'last_build_number' => repository.last_build_number,
+                'last_build_state' => repository.last_build_state.to_s,
+                'last_build_duration' => repository.last_build_duration,
+                'last_build_language' => nil,
+                'last_build_started_at' => format_date(repository.last_build_started_at),
+                'last_build_finished_at' => format_date(repository.last_build_finished_at),
+                'active' => repository.active,
+                'github_language' => repository.github_language
+              }
+            end
+        end
+      end
+    end
+  end
+end

--- a/lib/travis/api/v2/http/repository.rb
+++ b/lib/travis/api/v2/http/repository.rb
@@ -1,0 +1,43 @@
+module Travis
+  module Api
+    module V2
+      module Http
+        class Repository
+          include Formats
+
+          attr_reader :repository, :options
+
+          def initialize(repository, options = {})
+            @repository = repository
+          end
+
+          def data
+            {
+              'repo' => repository_data(repository)
+            }
+          end
+
+          private
+
+            # TODO why does this not include the last build? (i.e. 'builds' => { last build here })
+            def repository_data(repository)
+              {
+                'id' => repository.id,
+                'slug' => repository.slug,
+                'description' => repository.description,
+                'last_build_id' => repository.last_build_id,
+                'last_build_number' => repository.last_build_number,
+                'last_build_state' => repository.last_build_state.to_s,
+                'last_build_duration' => repository.last_build_duration,
+                'last_build_language' => nil,
+                'last_build_started_at' => format_date(repository.last_build_started_at),
+                'last_build_finished_at' => format_date(repository.last_build_finished_at),
+                'github_language' => repository.github_language
+              }
+            end
+        end
+      end
+    end
+  end
+end
+

--- a/lib/travis/api/v2/http/request.rb
+++ b/lib/travis/api/v2/http/request.rb
@@ -1,0 +1,67 @@
+module Travis
+  module Api
+    module V2
+      module Http
+        class Request
+          include Formats
+          attr_reader :request, :commit, :options
+
+          def initialize(request, options = {})
+            @request = request
+            @commit = request.commit
+            @options = options
+          end
+
+          def data
+            data = {
+              'request' => request_data
+            }
+            if commit
+              data['commit'] = commit_data
+            end
+            data
+          end
+
+          private
+
+            def request_data
+              {
+                'id' => request.id,
+                'repository_id' => request.repository_id,
+                'commit_id' => request.commit_id,
+                'created_at' => format_date(request.created_at),
+                'owner_id' => request.owner_id,
+                'owner_type' => request.owner_type,
+                'event_type' => request.event_type,
+                'base_commit' => request.base_commit,
+                'head_commit' => request.head_commit,
+                'result' => request.result,
+                'message' => request.message,
+                'pull_request' => request.pull_request?,
+                'pull_request_number' => request.pull_request_number,
+                'pull_request_title' => request.pull_request_title,
+                'branch' => request.branch_name,
+                'tag' => request.tag_name
+              }
+            end
+
+            def commit_data
+              {
+                'id' => commit.id,
+                'sha' => commit.commit,
+                'branch' => commit.branch,
+                'message' => commit.message,
+                'committed_at' => format_date(commit.committed_at),
+                'author_name' => commit.author_name,
+                'author_email' => commit.author_email,
+                'committer_name' => commit.committer_name,
+                'committer_email' => commit.committer_email,
+                'compare_url' => commit.compare_url,
+                'pull_request_number' => commit.pull_request_number
+              }
+            end
+        end
+      end
+    end
+  end
+end

--- a/lib/travis/api/v2/http/requests.rb
+++ b/lib/travis/api/v2/http/requests.rb
@@ -1,0 +1,64 @@
+module Travis
+  module Api
+    module V2
+      module Http
+        class Requests
+          include Formats
+          attr_reader :requests, :commits, :options
+
+          def initialize(requests, options = {})
+            @requests = requests
+            @commits = requests.map(&:commit)
+            @options = options
+          end
+
+          def data
+            {
+              'requests' => requests.map { |request| request_data(request) },
+              'commits' => commits.compact.map { |commit| commit_data(commit) }
+            }
+          end
+
+          private
+
+            def request_data(request)
+              {
+                'id' => request.id,
+                'repository_id' => request.repository_id,
+                'commit_id' => request.commit_id,
+                'created_at' => format_date(request.created_at),
+                'owner_id' => request.owner_id,
+                'owner_type' => request.owner_type,
+                'event_type' => request.event_type,
+                'base_commit' => request.base_commit,
+                'head_commit' => request.head_commit,
+                'result' => request.result,
+                'message' => request.message,
+                'pull_request' => request.pull_request?,
+                'pull_request_number' => request.pull_request_number,
+                'pull_request_title' => request.pull_request_title,
+                'branch' => request.branch_name,
+                'tag' => request.tag_name
+              }
+            end
+
+            def commit_data(commit)
+              {
+                'id' => commit.id,
+                'sha' => commit.commit,
+                'branch' => commit.branch,
+                'message' => commit.message,
+                'committed_at' => format_date(commit.committed_at),
+                'author_name' => commit.author_name,
+                'author_email' => commit.author_email,
+                'committer_name' => commit.committer_name,
+                'committer_email' => commit.committer_email,
+                'compare_url' => commit.compare_url,
+                'pull_request_number' => commit.pull_request_number
+              }
+            end
+        end
+      end
+    end
+  end
+end

--- a/lib/travis/api/v2/http/ssl_key.rb
+++ b/lib/travis/api/v2/http/ssl_key.rb
@@ -1,0 +1,22 @@
+module Travis
+  module Api
+    module V2
+      module Http
+        class SslKey
+          attr_reader :key
+
+          def initialize(key, options = {})
+            @key = key
+          end
+
+          def data
+            {
+              'key' => key.public_key
+            }
+          end
+        end
+      end
+    end
+  end
+end
+

--- a/lib/travis/api/v2/http/user.rb
+++ b/lib/travis/api/v2/http/user.rb
@@ -1,0 +1,43 @@
+module Travis
+  module Api
+    module V2
+      module Http
+        class User
+          include Formats
+
+          attr_reader :user, :options
+
+          def initialize(user, options = {})
+            @user = user
+            @options = options
+          end
+
+          def data
+            {
+              'user' => user_data,
+            }
+          end
+
+          private
+
+            def user_data
+              {
+                'id' => user.id,
+                'name' => user.name,
+                'login' => user.login,
+                'email' => user.email,
+                'gravatar_id' => user.gravatar_id,
+                'locale' => user.locale,
+                'is_syncing' => user.syncing?,
+                'synced_at' => format_date(user.synced_at),
+                'correct_scopes' => user.correct_scopes?,
+                'created_at' => format_date(user.created_at),
+              }
+            end
+        end
+      end
+    end
+  end
+end
+
+

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -11,7 +11,9 @@ require 'travis/api/app'
 require 'travis/testing'
 require 'travis/testing/scenario'
 require 'travis/testing/factories'
+require 'travis/testing/matchers'
 require 'support/matchers'
+require 'support/formats'
 
 Travis.logger = Logger.new(StringIO.new)
 Travis::Api::App.setup

--- a/spec/support/formats.rb
+++ b/spec/support/formats.rb
@@ -1,0 +1,40 @@
+module Support
+  module Formats
+    def json_response
+      response = respond_to?(:last_response) ? last_response : self.response
+      ActiveSupport::JSON.decode(response.body)
+    end
+
+    def xml_response
+      response = respond_to?(:last_response) ? last_response : self.response
+      ActiveSupport::XmlMini.parse(response.body)
+    end
+
+    def json_for_http(object, options = {})
+      normalize_json(Travis::Renderer.json(object, options))
+    end
+
+    def json_for_pusher(event, object)
+      normalize_json(Travis::Event::Handler::Pusher::Payload.new(event, object).to_hash)
+    end
+
+    def json_for_webhook(object)
+      normalize_json(Travis::Event::Handler::Webhook::Payload.new(object).to_hash)
+    end
+
+    def json_for_worker(object, extra = {})
+      normalize_json(Travis::Event::Handler::Worker::Payload.new(object).to_hash)
+    end
+
+    # normalizes datetime objects to strings etc. more similar to what the client would see.
+    def normalize_json(json)
+      json = json.to_json unless json.is_a?(String)
+      JSON.parse(json)
+    end
+
+    def json_format_time(time)
+      time.strftime('%Y-%m-%dT%H:%M:%SZ')
+    end
+  end
+end
+

--- a/spec/unit/api/v2/http/accounts_spec.rb
+++ b/spec/unit/api/v2/http/accounts_spec.rb
@@ -1,0 +1,19 @@
+require 'spec_helper'
+
+describe Travis::Api::V2::Http::Accounts do
+  include Travis::Testing::Stubs, Support::Formats
+
+  let(:user)     { { 'id' => 1, 'type' => 'User', 'login' => 'sven', 'name' => 'Sven', 'repos_count' => 2 } }
+  let(:org)      { { 'id' => 1, 'type' => 'Organization', 'login' => 'travis', 'name' => 'Travis', 'repos_count' => 1 } }
+
+  let(:accounts) { [Account.new(user), Account.new(org)] }
+  let(:data)     { Travis::Api::V2::Http::Accounts.new(accounts).data }
+
+  it 'accounts' do
+    data[:accounts].should == [
+      { 'id' => 1, 'login' => 'sven', 'name' => 'Sven', 'type' => 'user', 'repos_count' => 2 },
+      { 'id' => 1, 'login' => 'travis', 'name' => 'Travis', 'type' => 'organization', 'repos_count' => 1 }
+    ]
+  end
+end
+

--- a/spec/unit/api/v2/http/annotations_spec.rb
+++ b/spec/unit/api/v2/http/annotations_spec.rb
@@ -1,0 +1,18 @@
+require 'spec_helper'
+
+describe Travis::Api::V2::Http::Annotations do
+  include Travis::Testing::Stubs, Support::Formats
+
+  let(:data) { described_class.new([annotation]).data }
+
+  it "annotations" do
+    data["annotations"].should eq([{
+      'id' => annotation.id,
+      'job_id' => test.id,
+      'description' => annotation.description,
+      'url' => annotation.url,
+      'provider_name' => 'Travis CI',
+      'status' => '',
+    }])
+  end
+end

--- a/spec/unit/api/v2/http/branch_spec.rb
+++ b/spec/unit/api/v2/http/branch_spec.rb
@@ -1,0 +1,40 @@
+require 'spec_helper'
+
+describe Travis::Api::V2::Http::Branch do
+  include Travis::Testing::Stubs, Support::Formats
+
+  let(:data) { Travis::Api::V2::Http::Branch.new(branch).data }
+  let(:branch) { build }
+
+  specify 'branch' do
+    data['branch'].should be == {
+      'id' => 1,
+      'repository_id' => 1,
+      'commit_id' => 1,
+      'job_ids' => [1, 2],
+      'number' => 2,
+      'config' => { 'rvm' => ['1.8.7', '1.9.2'], 'gemfile' => ['test/Gemfile.rails-2.3.x', 'test/Gemfile.rails-3.0.x'] },
+      'state' => 'passed',
+      'started_at' => json_format_time(Time.now.utc - 1.minute),
+      'finished_at' => json_format_time(Time.now.utc),
+      'duration' => 60,
+      'pull_request' => false
+    }
+  end
+
+  specify 'commit' do
+    data['commit'].should be == {
+      'id' => 1,
+      'sha' => '62aae5f70ceee39123ef',
+      'branch' => 'master',
+      'message' => 'the commit message',
+      'compare_url' => 'https://github.com/svenfuchs/minimal/compare/master...develop',
+      'committed_at' => json_format_time(Time.now.utc - 1.hour),
+      'committer_email' => 'svenfuchs@artweb-design.de',
+      'committer_name' => 'Sven Fuchs',
+      'author_name' => 'Sven Fuchs',
+      'author_email' => 'svenfuchs@artweb-design.de',
+      'compare_url' => 'https://github.com/svenfuchs/minimal/compare/master...develop',
+    }
+  end
+end

--- a/spec/unit/api/v2/http/branches_spec.rb
+++ b/spec/unit/api/v2/http/branches_spec.rb
@@ -1,0 +1,40 @@
+require 'spec_helper'
+
+describe Travis::Api::V2::Http::Branches do
+  include Travis::Testing::Stubs, Support::Formats
+
+  let(:data) { Travis::Api::V2::Http::Branches.new(branches).data }
+  let(:branches) { [build] }
+
+  it 'branches' do
+    data['branches'].first.should == {
+      'id' => 1,
+      'repository_id' => 1,
+      'commit_id' => 1,
+      'job_ids' => [1, 2],
+      'number' => 2,
+      'config' => { 'rvm' => ['1.8.7', '1.9.2'], 'gemfile' => ['test/Gemfile.rails-2.3.x', 'test/Gemfile.rails-3.0.x'] },
+      'state' => 'passed',
+      'started_at' => json_format_time(Time.now.utc - 1.minute),
+      'finished_at' => json_format_time(Time.now.utc),
+      'duration' => 60,
+      'pull_request' => false
+    }
+  end
+
+  it 'commits' do
+    data['commits'].first.should == {
+      'id' => 1,
+      'sha' => '62aae5f70ceee39123ef',
+      'branch' => 'master',
+      'message' => 'the commit message',
+      'compare_url' => 'https://github.com/svenfuchs/minimal/compare/master...develop',
+      'committed_at' => json_format_time(Time.now.utc - 1.hour),
+      'committer_email' => 'svenfuchs@artweb-design.de',
+      'committer_name' => 'Sven Fuchs',
+      'author_name' => 'Sven Fuchs',
+      'author_email' => 'svenfuchs@artweb-design.de',
+      'compare_url' => 'https://github.com/svenfuchs/minimal/compare/master...develop',
+    }
+  end
+end

--- a/spec/unit/api/v2/http/broadcasts_spec.rb
+++ b/spec/unit/api/v2/http/broadcasts_spec.rb
@@ -1,0 +1,15 @@
+require 'spec_helper'
+
+describe Travis::Api::V2::Http::Broadcasts do
+  include Support::Formats
+
+  let(:broadcast) { stub(:id => 1, :message => 'yo hey!') }
+  let(:data)      { Travis::Api::V2::Http::Broadcasts.new([broadcast]).data }
+
+  it 'broadcasts' do
+    data['broadcasts'].first.should == {
+      'id' => 1,
+      'message' => 'yo hey!'
+    }
+  end
+end

--- a/spec/unit/api/v2/http/build_spec.rb
+++ b/spec/unit/api/v2/http/build_spec.rb
@@ -1,0 +1,86 @@
+require 'spec_helper'
+
+describe Travis::Api::V2::Http::Build do
+  include Travis::Testing::Stubs, Support::Formats
+
+  let(:data) { Travis::Api::V2::Http::Build.new(build).data }
+
+  it 'build' do
+    data['build'].should == {
+      'id' => 1,
+      'repository_id' => 1,
+      'commit_id' => 1,
+      'job_ids' => [1, 2],
+      'number' => 2,
+      'pull_request' => false,
+      'pull_request_title' => nil,
+      'pull_request_number' => nil,
+      'config' => { 'rvm' => ['1.8.7', '1.9.2'], 'gemfile' => ['test/Gemfile.rails-2.3.x', 'test/Gemfile.rails-3.0.x'] },
+      'state' => 'passed',
+      'started_at' => json_format_time(Time.now.utc - 1.minute),
+      'finished_at' => json_format_time(Time.now.utc),
+      'duration' => 60
+    }
+  end
+
+  it 'commit' do
+    data['commit'].should == {
+      'id' => 1,
+      'sha' => '62aae5f70ceee39123ef',
+      'branch' => 'master',
+      'message' => 'the commit message',
+      'compare_url' => 'https://github.com/svenfuchs/minimal/compare/master...develop',
+      'committed_at' => json_format_time(Time.now.utc - 1.hour),
+      'committer_email' => 'svenfuchs@artweb-design.de',
+      'committer_name' => 'Sven Fuchs',
+      'author_name' => 'Sven Fuchs',
+      'author_email' => 'svenfuchs@artweb-design.de',
+      'compare_url' => 'https://github.com/svenfuchs/minimal/compare/master...develop',
+    }
+  end
+
+  describe 'pull request' do
+    let(:build) do
+      stub_build pull_request?: true,
+                 pull_request_title: 'A pull request',
+                 pull_request_number: 44
+    end
+    let(:data) { Travis::Api::V2::Http::Build.new(build).data }
+
+    it 'returns pull request data' do
+      data['build']['pull_request'].should be_true
+      data['build']['pull_request_title'].should == 'A pull request'
+      data['build']['pull_request_number'].should == 44
+    end
+
+  end
+
+  context 'with encrypted env vars' do
+    let(:build) do
+      stub_build(:obfuscated_config => { 'env' => 'FOO=[secure]' })
+    end
+
+    it 'shows encrypted env vars in human readable way' do
+      data['build']['config']['env'].should == 'FOO=[secure]'
+    end
+  end
+
+  context 'without logs' do
+    before { build.matrix.first.stubs(:log).returns(nil) }
+
+    it 'returns null log_id' do
+      data['log_id'].should be_nil
+    end
+  end
+end
+
+describe 'Travis::Api::V2::Http::Build using Travis::Services::Builds::FindOne' do
+  let!(:record) { Factory(:build) }
+  let(:build)   { Travis.run_service(:find_build, nil, :id => record.id) }
+  let(:data)    { Travis::Api::V2::Http::Build.new(build).data }
+
+  it 'queries' do
+    lambda { data }.should issue_queries(6)
+  end
+end
+

--- a/spec/unit/api/v2/http/builds_spec.rb
+++ b/spec/unit/api/v2/http/builds_spec.rb
@@ -1,0 +1,77 @@
+require 'spec_helper'
+
+describe Travis::Api::V2::Http::Builds do
+  include Travis::Testing::Stubs, Support::Formats
+
+  let(:data) { Travis::Api::V2::Http::Builds.new([build]).data }
+
+  it 'builds' do
+    data['builds'].first.should == {
+      'id' => 1,
+      'repository_id' => 1,
+      'commit_id' => 1,
+      'job_ids' => [1, 2],
+      'number' => 2,
+      'pull_request' => false,
+      'pull_request_title' => nil,
+      'pull_request_number' => nil,
+      'config' => { 'rvm' => ['1.8.7', '1.9.2'], 'gemfile' => ['test/Gemfile.rails-2.3.x', 'test/Gemfile.rails-3.0.x'] },
+      'state' => 'passed',
+      'started_at' => json_format_time(Time.now.utc - 1.minute),
+      'finished_at' => json_format_time(Time.now.utc),
+      'duration' => 60
+    }
+  end
+
+  it 'commit' do
+    data['commits'].first.should == {
+      'id' => commit.id,
+      'sha' => '62aae5f70ceee39123ef',
+      'branch' => 'master',
+      'message' => 'the commit message',
+      'compare_url' => 'https://github.com/svenfuchs/minimal/compare/master...develop',
+      'committed_at' => json_format_time(Time.now.utc - 1.hour),
+      'committer_email' => 'svenfuchs@artweb-design.de',
+      'committer_name' => 'Sven Fuchs',
+      'author_name' => 'Sven Fuchs',
+      'author_email' => 'svenfuchs@artweb-design.de',
+      'compare_url' => 'https://github.com/svenfuchs/minimal/compare/master...develop',
+      'pull_request_number' => nil,
+    }
+  end
+
+  it 'uses uses cached_matrix_ids if the column exists in DB' do
+    build = stub_build
+    build.expects(:cached_matrix_ids).returns([1, 2, 3])
+    data = Travis::Api::V2::Http::Builds.new([build]).data
+    data['builds'].first['job_ids'].should == [1, 2, 3]
+  end
+
+  describe 'with a pull request' do
+    let(:build) do
+      stub_build pull_request?: true,
+                 pull_request_title: 'A pull request',
+                 pull_request_number: 44
+    end
+
+    it 'returns pull request data' do
+      data['builds'].first['pull_request'].should be_true
+      data['builds'].first['pull_request_number'].should == 44
+    end
+  end
+end
+
+describe 'Travis::Api::V2::Http::Builds using Travis::Services::Builds::FindAll' do
+  let!(:repo)  { Factory(:repository) }
+  let(:builds) { Travis.run_service(:find_builds, nil, :event_type => 'push', :repository_id => repo.id) }
+  let(:data)   { Travis::Api::V2::Http::Builds.new(builds).data }
+
+  before :each do
+    3.times { Factory(:build, :repository => repo) }
+  end
+
+  it 'queries' do
+    lambda { data }.should issue_queries(3)
+  end
+end
+

--- a/spec/unit/api/v2/http/caches_spec.rb
+++ b/spec/unit/api/v2/http/caches_spec.rb
@@ -1,0 +1,16 @@
+require 'spec_helper'
+
+describe Travis::Api::V2::Http::Branch do
+  include Travis::Testing::Stubs, Support::Formats
+  let(:data) { Travis::Api::V2::Http::Caches.new([cache]).data }
+
+  specify 'caches' do
+    data['caches'].should be == [{
+      "repository_id" => 1,
+      "size"          => 1000,
+      "slug"          => "cache",
+      "branch"        => "master",
+      "last_modified" => "1970-01-01T00:00:00Z"
+    }]
+  end
+end

--- a/spec/unit/api/v2/http/hooks_spec.rb
+++ b/spec/unit/api/v2/http/hooks_spec.rb
@@ -1,0 +1,25 @@
+require 'spec_helper'
+
+describe Travis::Api::V2::Http::Hooks do
+  include Travis::Testing::Stubs
+
+  let(:data) {
+    r = repository
+    r.stubs(:admin?).returns(true)
+    Travis::Api::V2::Http::Hooks.new([r]).data
+  }
+
+  it 'hooks' do
+    data['hooks'].should == [
+      {
+        'id' => 1,
+        'name' => 'minimal',
+        'owner_name' => 'svenfuchs',
+        'description' => 'the repo description',
+        'active' => true,
+        'private' => false,
+        'admin' => true
+      }
+    ]
+  end
+end

--- a/spec/unit/api/v2/http/job_spec.rb
+++ b/spec/unit/api/v2/http/job_spec.rb
@@ -1,0 +1,74 @@
+require 'spec_helper'
+
+describe Travis::Api::V2::Http::Job do
+  include Travis::Testing::Stubs, Support::Formats
+
+  let(:data) { Travis::Api::V2::Http::Job.new(test).data }
+
+  it 'job' do
+    data['job'].should == {
+      'id' => 1,
+      'repository_id' => 1,
+      'repository_slug' => 'svenfuchs/minimal',
+      'build_id' => 1,
+      'commit_id' => 1,
+      'log_id' => 1,
+      'number' => '2.1',
+      'state' => 'passed',
+      'started_at' => json_format_time(Time.now.utc - 1.minute),
+      'finished_at' => json_format_time(Time.now.utc),
+      'config' => { 'rvm' => '1.8.7', 'gemfile' => 'test/Gemfile.rails-2.3.x' },
+      'queue' => 'builds.linux',
+      'allow_failure' => false,
+      'tags' => 'tag-a,tag-b',
+      'annotation_ids' => [1],
+    }
+  end
+
+  it 'commit' do
+    data['commit'].should == {
+      'id' => 1,
+      'sha' => '62aae5f70ceee39123ef',
+      'message' => 'the commit message',
+      'branch' => 'master',
+      'message' => 'the commit message',
+      'committed_at' => json_format_time(Time.now.utc - 1.hour),
+      'committer_name' => 'Sven Fuchs',
+      'committer_email' => 'svenfuchs@artweb-design.de',
+      'author_name' => 'Sven Fuchs',
+      'author_email' => 'svenfuchs@artweb-design.de',
+      'compare_url' => 'https://github.com/svenfuchs/minimal/compare/master...develop',
+    }
+  end
+
+  it 'annotations' do
+    data['annotations'].should eq([{
+      'id' => 1,
+      'job_id' => 1,
+      'description' => 'The job passed.',
+      'url' => 'https://travis-ci.org/travis-ci/travis-ci/12345',
+      'provider_name' => 'Travis CI',
+      'status' => '',
+    }])
+  end
+
+  context 'with encrypted env vars' do
+    let(:test) do
+      stub_test(:obfuscated_config => { 'env' => 'FOO=[secure]' })
+    end
+
+    it 'shows encrypted env vars in human readable way' do
+      data['job']['config']['env'].should == 'FOO=[secure]'
+    end
+  end
+end
+
+describe 'Travis::Api::V2::Http::Job using Travis::Services::Jobs::FindOne' do
+  let!(:record) { Factory(:test) }
+  let(:job)     { Travis.run_service(:find_job, nil, :id => record.id) }
+  let(:data)    { Travis::Api::V2::Http::Job.new(job).data }
+
+  it 'queries' do
+    lambda { data }.should issue_queries(5)
+  end
+end

--- a/spec/unit/api/v2/http/jobs_spec.rb
+++ b/spec/unit/api/v2/http/jobs_spec.rb
@@ -1,0 +1,56 @@
+require 'spec_helper'
+
+describe Travis::Api::V2::Http::Jobs do
+  include Travis::Testing::Stubs, Support::Formats
+
+  let(:data) { Travis::Api::V2::Http::Jobs.new([test]).data }
+
+  it 'jobs' do
+    data['jobs'].first.should == {
+      'id' => 1,
+      'repository_id' => 1,
+      'repository_slug' => 'svenfuchs/minimal',
+      'build_id' => 1,
+      'commit_id' => 1,
+      'log_id' => 1,
+      'number' => '2.1',
+      'state' => 'passed',
+      'started_at' => json_format_time(Time.now.utc - 1.minute),
+      'finished_at' => json_format_time(Time.now.utc),
+      'config' => { 'rvm' => '1.8.7', 'gemfile' => 'test/Gemfile.rails-2.3.x' },
+      'queue' => 'builds.linux',
+      'allow_failure' => false,
+      'tags' => 'tag-a,tag-b'
+    }
+  end
+
+  it 'commits' do
+    data['commits'].first.should == {
+      'id' => 1,
+      'sha' => '62aae5f70ceee39123ef',
+      'message' => 'the commit message',
+      'branch' => 'master',
+      'message' => 'the commit message',
+      'committed_at' => json_format_time(Time.now.utc - 1.hour),
+      'committer_name' => 'Sven Fuchs',
+      'committer_email' => 'svenfuchs@artweb-design.de',
+      'author_name' => 'Sven Fuchs',
+      'author_email' => 'svenfuchs@artweb-design.de',
+      'compare_url' => 'https://github.com/svenfuchs/minimal/compare/master...develop',
+    }
+  end
+end
+
+describe 'Travis::Api::V2::Http::Jobs using Travis::Services::Jobs::FindAll' do
+  let(:jobs) { Travis.run_service(:find_jobs, nil) }
+  let(:data) { Travis::Api::V2::Http::Jobs.new(jobs).data }
+
+  before :each do
+    3.times { Factory(:test) }
+  end
+
+  it 'queries' do
+    lambda { data }.should issue_queries(4)
+  end
+end
+

--- a/spec/unit/api/v2/http/log_spec.rb
+++ b/spec/unit/api/v2/http/log_spec.rb
@@ -1,0 +1,33 @@
+require 'spec_helper'
+
+describe Travis::Api::V2::Http::Log do
+  include Travis::Testing::Stubs
+
+  let(:data) { described_class.new(log).data }
+
+  it 'log' do
+    data['log'].should == {
+      'id' => 1,
+      'job_id' => 1,
+      'type' => 'Log',
+      'body' => 'the test log'
+    }
+  end
+
+  describe 'chunked log' do
+    let(:log) do
+      stub_log(parts: [
+        stub_log_part(id: 2, number: 2, content: 'bar', final: true),
+        stub_log_part(id: 1, number: 1, content: 'foo')
+      ])
+    end
+    let(:data) { described_class.new(log, chunked: true).data }
+
+    it 'returns ordered parts' do
+      data['log']['parts'].should == [
+        { 'id' => 1, 'number' => 1, 'content' => 'foo', 'final' => false },
+        { 'id' => 2, 'number' => 2, 'content' => 'bar', 'final' => true }
+      ]
+    end
+  end
+end

--- a/spec/unit/api/v2/http/permissions_spec.rb
+++ b/spec/unit/api/v2/http/permissions_spec.rb
@@ -1,0 +1,32 @@
+require 'spec_helper'
+
+describe Travis::Api::V2::Http::Permissions do
+  include Travis::Testing::Stubs
+
+  let(:permissions) do
+    [
+      stub(:repository_id => 1, :admin? => true, :pull? => false, :push? => false),
+      stub(:repository_id => 2, :admin? => false, :pull? => true, :push? => false),
+      stub(:repository_id => 3, :admin? => false, :pull? => false, :push? => true)
+    ]
+  end
+
+  let(:data) { Travis::Api::V2::Http::Permissions.new(permissions).data }
+
+  it 'permissions' do
+    data['permissions'].should == [1, 2, 3]
+  end
+
+  it 'finds admin perms' do
+    data['admin'].should == [1]
+  end
+
+  it 'finds pull perms' do
+    data['pull'].should == [2]
+  end
+
+  it 'finds push perms' do
+    data['push'].should == [3]
+  end
+end
+

--- a/spec/unit/api/v2/http/repositories_spec.rb
+++ b/spec/unit/api/v2/http/repositories_spec.rb
@@ -1,0 +1,38 @@
+require 'spec_helper'
+
+describe Travis::Api::V2::Http::Repositories do
+  include Travis::Testing::Stubs, Support::Formats
+
+  let(:data) { Travis::Api::V2::Http::Repositories.new([repository]).data }
+
+  it 'repositories' do
+    data['repos'].first.should == {
+      'id' => repository.id,
+      'slug' => 'svenfuchs/minimal',
+      'description' => 'the repo description',
+      'last_build_id' => 1,
+      'last_build_number' => 2,
+      'last_build_started_at' => json_format_time(Time.now.utc - 1.minute),
+      'last_build_finished_at' => json_format_time(Time.now.utc),
+      'last_build_state' => 'passed',
+      'last_build_language' => nil,
+      'last_build_duration' => 60,
+      'active' => true,
+      'github_language' => 'ruby'
+    }
+  end
+end
+
+describe 'Travis::Api::V2::Http::Repositories using Travis::Services::FindRepos' do
+  let(:repos) { Travis.run_service(:find_repos) }
+  let(:data)  { Travis::Api::V2::Http::Repositories.new(repos).data }
+
+  before :each do
+    3.times { |i| Factory(:repository, :name => i) }
+  end
+
+  it 'queries' do
+    lambda { data }.should issue_queries(1)
+  end
+end
+

--- a/spec/unit/api/v2/http/repository_spec.rb
+++ b/spec/unit/api/v2/http/repository_spec.rb
@@ -1,0 +1,34 @@
+require 'spec_helper'
+
+describe Travis::Api::V2::Http::Repository do
+  include Travis::Testing::Stubs
+  include Support::Formats
+
+  let(:data) { Travis::Api::V2::Http::Repository.new(repository).data }
+
+  it 'repository' do
+    data['repo'].should == {
+      'id' => repository.id,
+      'slug' => 'svenfuchs/minimal',
+      'description' => 'the repo description',
+      'last_build_id' => 1,
+      'last_build_number' => 2,
+      'last_build_started_at' => json_format_time(Time.now.utc - 1.minute),
+      'last_build_finished_at' => json_format_time(Time.now.utc),
+      'last_build_state' => 'passed',
+      'last_build_language' => nil,
+      'last_build_duration' => 60,
+      'github_language' => 'ruby'
+    }
+  end
+end
+
+describe 'Travis::Api::V2::Http::Repository using Travis::Services::FindRepo' do
+  let!(:record) { Factory(:repository) }
+  let(:repo)    { Travis.run_service(:find_repo, :id => record.id) }
+  let(:data)    { Travis::Api::V2::Http::Repository.new(repo).data }
+
+  it 'queries' do
+    lambda { data }.should issue_queries(1)
+  end
+end

--- a/spec/unit/api/v2/http/request_spec.rb
+++ b/spec/unit/api/v2/http/request_spec.rb
@@ -1,0 +1,47 @@
+require 'spec_helper'
+
+describe Travis::Api::V2::Http::Request do
+  include Travis::Testing::Stubs, Support::Formats
+
+  let(:data) {
+    Travis::Api::V2::Http::Request.new(request).data
+  }
+
+  it 'returns request data' do
+    data['request'].should == {
+      'id' => 1,
+      'repository_id' => 1,
+      'commit_id' => 1,
+      'created_at' => '2013-01-01T00:00:00Z',
+      'owner_id' => 1,
+      'owner_type' => 'User',
+      'event_type' => 'push',
+      'base_commit' => 'base-commit',
+      'head_commit' => 'head-commit',
+      'result' => :accepted,
+      'message' => 'a message',
+      'branch' => 'master',
+      'tag' => nil,
+      'pull_request' => false,
+      'pull_request_title' => nil,
+      'pull_request_number' => nil
+    }
+  end
+
+  it 'returns commit data' do
+    data['commit'].should == {
+      'id' => commit.id,
+      'sha' => '62aae5f70ceee39123ef',
+      'branch' => 'master',
+      'message' => 'the commit message',
+      'compare_url' => 'https://github.com/svenfuchs/minimal/compare/master...develop',
+      'committed_at' => json_format_time(Time.now.utc - 1.hour),
+      'committer_email' => 'svenfuchs@artweb-design.de',
+      'committer_name' => 'Sven Fuchs',
+      'author_name' => 'Sven Fuchs',
+      'author_email' => 'svenfuchs@artweb-design.de',
+      'compare_url' => 'https://github.com/svenfuchs/minimal/compare/master...develop',
+      'pull_request_number' => nil,
+    }
+  end
+end

--- a/spec/unit/api/v2/http/requests_spec.rb
+++ b/spec/unit/api/v2/http/requests_spec.rb
@@ -1,0 +1,61 @@
+require 'spec_helper'
+
+describe Travis::Api::V2::Http::Requests do
+  include Travis::Testing::Stubs, Support::Formats
+
+  let(:data) {
+    Travis::Api::V2::Http::Requests.new([request]).data
+  }
+
+  it 'returns requests data' do
+    data['requests'].should == [
+      {
+        'id' => 1,
+        'repository_id' => 1,
+        'commit_id' => 1,
+        'created_at' => '2013-01-01T00:00:00Z',
+        'owner_id' => 1,
+        'owner_type' => 'User',
+        'event_type' => 'push',
+        'base_commit' => 'base-commit',
+        'head_commit' => 'head-commit',
+        'result' => :accepted,
+        'message' => 'a message',
+        'branch' => 'master',
+        'tag' => nil,
+        'pull_request' => false,
+        'pull_request_title' => nil,
+        'pull_request_number' => nil
+      }
+    ]
+  end
+
+  it 'returns commits data' do
+    data['commits'].first.should == {
+      'id' => commit.id,
+      'sha' => '62aae5f70ceee39123ef',
+      'branch' => 'master',
+      'message' => 'the commit message',
+      'compare_url' => 'https://github.com/svenfuchs/minimal/compare/master...develop',
+      'committed_at' => json_format_time(Time.now.utc - 1.hour),
+      'committer_email' => 'svenfuchs@artweb-design.de',
+      'committer_name' => 'Sven Fuchs',
+      'author_name' => 'Sven Fuchs',
+      'author_email' => 'svenfuchs@artweb-design.de',
+      'compare_url' => 'https://github.com/svenfuchs/minimal/compare/master...develop',
+      'pull_request_number' => nil,
+    }
+  end
+
+  context "without commits" do
+    let(:data) {
+      request = stub_request
+      request.stubs(:commit).returns(nil)
+      Travis::Api::V2::Http::Requests.new([request]).data
+    }
+
+    it "doesn't fail if there is no commit data for a given request" do
+      data['commits'].should == []
+    end
+  end
+end

--- a/spec/unit/api/v2/http/ssl_key_spec.rb
+++ b/spec/unit/api/v2/http/ssl_key_spec.rb
@@ -1,0 +1,12 @@
+require 'spec_helper'
+
+describe Travis::Api::V2::Http::Repository do
+  include Travis::Testing::Stubs
+  include Support::Formats
+
+  let(:data) { Travis::Api::V2::Http::SslKey.new(stub_key).data }
+
+  it 'key' do
+    data['key'].should == '-----BEGIN PUBLIC KEY-----'
+  end
+end

--- a/spec/unit/api/v2/http/user_spec.rb
+++ b/spec/unit/api/v2/http/user_spec.rb
@@ -1,0 +1,23 @@
+require 'spec_helper'
+
+describe Travis::Api::V2::Http::User do
+  include Travis::Testing::Stubs, Support::Formats
+
+  let(:data) { Travis::Api::V2::Http::User.new(user).data }
+
+  it 'user' do
+    data['user'].should == {
+      'id' => 1,
+      'name' => 'Sven Fuchs',
+      'login' => 'svenfuchs',
+      'email' => 'svenfuchs@artweb-design.de',
+      'gravatar_id' => '402602a60e500e85f2f5dc1ff3648ecb',
+      'locale' => 'de',
+      'is_syncing' => false,
+      'synced_at' => json_format_time(Time.now.utc - 1.hour),
+      'correct_scopes' => true,
+      'created_at' => json_format_time(Time.now.utc - 2.hours),
+    }
+  end
+end
+


### PR DESCRIPTION
This PR adds API v2 payloads from travis-core removed in travis-ci/travis-core#369
