### PR TITLE
Include event_type to build payloads

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -50,7 +50,7 @@ GIT
 
 GIT
   remote: git://github.com/travis-ci/travis-core.git
-  revision: 21156bf88fcc623d45b87d5b5de427c1746f7f55
+  revision: 1dbb86846491b05c189e9b7bb842a52e018e8dd3
   specs:
     travis-core (0.0.1)
       actionmailer (~> 3.2.19)
@@ -138,7 +138,7 @@ GEM
     activesupport (3.2.21)
       i18n (~> 0.6, >= 0.6.4)
       multi_json (~> 1.0)
-    addressable (2.3.7)
+    addressable (2.3.8)
     arel (3.0.3)
     atomic (1.1.99)
     avl_tree (1.1.3)
@@ -320,7 +320,7 @@ GEM
     treetop (1.4.15)
       polyglot
       polyglot (>= 0.3.1)
-    tzinfo (0.3.43)
+    tzinfo (0.3.44)
     unicorn (4.8.3)
       kgio (~> 2.6)
       rack

--- a/lib/travis/api/v2/http/build.rb
+++ b/lib/travis/api/v2/http/build.rb
@@ -31,6 +31,7 @@ module Travis
                 'repository_id' => build.repository_id,
                 'commit_id' => build.commit_id,
                 'number' => build.number,
+                'event_type' => build.event_type,
                 'pull_request' => build.pull_request?,
                 'pull_request_title' => build.pull_request_title,
                 'pull_request_number' => build.pull_request_number,

--- a/lib/travis/api/v2/http/builds.rb
+++ b/lib/travis/api/v2/http/builds.rb
@@ -28,6 +28,7 @@ module Travis
                 'repository_id' => build.repository_id,
                 'commit_id' => build.commit_id,
                 'number' => build.number,
+                'event_type' => build.event_type,
                 'pull_request' => build.pull_request?,
                 'pull_request_title' => build.pull_request_title,
                 'pull_request_number' => build.pull_request_number,

--- a/spec/unit/api/v2/http/build_spec.rb
+++ b/spec/unit/api/v2/http/build_spec.rb
@@ -15,6 +15,7 @@ describe Travis::Api::V2::Http::Build do
       'pull_request' => false,
       'pull_request_title' => nil,
       'pull_request_number' => nil,
+      'event_type' => 'push',
       'config' => { 'rvm' => ['1.8.7', '1.9.2'], 'gemfile' => ['test/Gemfile.rails-2.3.x', 'test/Gemfile.rails-3.0.x'] },
       'state' => 'passed',
       'started_at' => json_format_time(Time.now.utc - 1.minute),

--- a/spec/unit/api/v2/http/builds_spec.rb
+++ b/spec/unit/api/v2/http/builds_spec.rb
@@ -15,6 +15,7 @@ describe Travis::Api::V2::Http::Builds do
       'pull_request' => false,
       'pull_request_title' => nil,
       'pull_request_number' => nil,
+      'event_type' => 'push',
       'config' => { 'rvm' => ['1.8.7', '1.9.2'], 'gemfile' => ['test/Gemfile.rails-2.3.x', 'test/Gemfile.rails-3.0.x'] },
       'state' => 'passed',
       'started_at' => json_format_time(Time.now.utc - 1.minute),


### PR DESCRIPTION
So that the proper build even_type for builds triggered via API can be displayed

/cc @drogus @rkh 