### PR TITLE
Relax dependency for pg, remove thin

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -98,13 +98,12 @@ PATH
       composite_primary_keys (~> 5.0)
       memcachier
       mustermann (~> 0.4)
-      pg (~> 0.13.2)
+      pg
       rack-contrib (~> 1.1)
       rack-ssl (~> 1.3, >= 1.3.3)
       redcarpet (~> 2.1)
       sinatra (~> 1.3)
       sinatra-contrib (~> 1.3)
-      thin (~> 1.4)
       travis-core
       travis-support
       useragent
@@ -158,7 +157,6 @@ GEM
     composite_primary_keys (5.0.14)
       activerecord (~> 3.2.0, >= 3.2.9)
     connection_pool (2.1.1)
-    daemons (1.1.9)
     dalli (2.7.2)
     data_migrations (0.0.1)
       activerecord
@@ -171,7 +169,6 @@ GEM
     dotenv (0.7.0)
     equalizer (0.0.11)
     erubis (2.7.0)
-    eventmachine (1.0.7)
     factory_girl (2.4.2)
       activesupport
     faraday (0.9.1)
@@ -220,7 +217,7 @@ GEM
     multipart-post (2.0.0)
     net-http-persistent (2.9.4)
     net-http-pipeline (1.0.1)
-    pg (0.13.2)
+    pg (0.18.2)
     polyglot (0.3.5)
     proxies (0.2.1)
     pry (0.10.1)
@@ -306,10 +303,6 @@ GEM
       rack (~> 1.0)
       tilt (~> 1.1, != 1.3.0)
     stackprof (0.2.7)
-    thin (1.6.3)
-      daemons (~> 1.0, >= 1.0.9)
-      eventmachine (~> 1.0)
-      rack (~> 1.0)
     thor (0.14.6)
     thread_safe (0.3.5)
     tilt (1.4.1)
@@ -326,7 +319,7 @@ GEM
       kgio (~> 2.6)
       rack
       raindrops (~> 0.7)
-    useragent (0.10.0)
+    useragent (0.13.3)
     uuidtools (2.1.5)
     virtus (1.0.5)
       axiom-types (~> 0.1)

--- a/travis-api.gemspec
+++ b/travis-api.gemspec
@@ -379,9 +379,8 @@ Gem::Specification.new do |s|
   s.add_dependency 'travis-support'
   s.add_dependency 'travis-core'
 
-  s.add_dependency 'pg',                     '~> 0.13.2'
+  s.add_dependency 'pg'
   s.add_dependency 'composite_primary_keys', '~> 5.0'
-  s.add_dependency 'thin',                   '~> 1.4'
   s.add_dependency 'sinatra',                '~> 1.3'
   s.add_dependency 'sinatra-contrib',        '~> 1.3'
   s.add_dependency 'mustermann',             '~> 0.4'


### PR DESCRIPTION
> The pg gem prior to version 0.14.1 uses the method rb_thread_select. This method was removed in Ruby 2.2.

http://stackoverflow.com/questions/28062592/symbol-lookup-error-since-upgrading-to-ruby-2-2-0

