### PR TITLE
expose active flag in repo payload in v2

### DIFF
--- a/lib/travis/api/v2/http/repository.rb
+++ b/lib/travis/api/v2/http/repository.rb
@@ -24,6 +24,7 @@ module Travis
               {
                 'id' => repository.id,
                 'slug' => repository.slug,
+                'active' => repository.active,
                 'description' => repository.description,
                 'last_build_id' => repository.last_build_id,
                 'last_build_number' => repository.last_build_number,

--- a/spec/unit/api/v2/http/repository_spec.rb
+++ b/spec/unit/api/v2/http/repository_spec.rb
@@ -11,6 +11,7 @@ describe Travis::Api::V2::Http::Repository do
       'id' => repository.id,
       'slug' => 'svenfuchs/minimal',
       'description' => 'the repo description',
+      'active' => true,
       'last_build_id' => 1,
       'last_build_number' => 2,
       'last_build_started_at' => json_format_time(Time.now.utc - 1.minute),


### PR DESCRIPTION
Interestingly, it's already part of the repositories payload, just not of the repository payload in v2.