### PR TITLE
v3 prefix ids with correct tables when ordering

### DIFF
--- a/lib/travis/api/v3/models/branch.rb
+++ b/lib/travis/api/v3/models/branch.rb
@@ -2,7 +2,7 @@ module Travis::API::V3
   class Models::Branch < Model
     belongs_to :repository
     belongs_to :last_build, class_name: 'Travis::API::V3::Models::Build'.freeze
-    has_many   :builds,  foreign_key: [:repository_id, :branch], primary_key: [:repository_id, :name], order: 'id DESC'.freeze, conditions: { event_type: 'push' }
-    has_many   :commits, foreign_key: [:repository_id, :branch], primary_key: [:repository_id, :name], order: 'id DESC'.freeze
+    has_many   :builds,  foreign_key: [:repository_id, :branch], primary_key: [:repository_id, :name], order: 'builds.id DESC'.freeze, conditions: { event_type: 'push' }
+    has_many   :commits, foreign_key: [:repository_id, :branch], primary_key: [:repository_id, :name], order: 'commits.id DESC'.freeze
   end
 end

--- a/lib/travis/api/v3/models/repository.rb
+++ b/lib/travis/api/v3/models/repository.rb
@@ -2,8 +2,8 @@ module Travis::API::V3
   class Models::Repository < Model
     has_many :commits,     dependent: :delete_all
     has_many :requests,    dependent: :delete_all
-    has_many :branches,    dependent: :delete_all, order: 'id DESC'.freeze
-    has_many :builds,      dependent: :delete_all, order: 'id DESC'.freeze
+    has_many :branches,    dependent: :delete_all, order: 'branches.id DESC'.freeze
+    has_many :builds,      dependent: :delete_all, order: 'builds.id DESC'.freeze
     has_many :permissions, dependent: :delete_all
     has_many :users,       through:   :permissions
 


### PR DESCRIPTION
This fixes a bug where ids on the repository and branch models were not set correctly and causing postgres to, in rkh's words "freak out".

This has been tested on staging and all appears to be working.