### PR TITLE
better request throttling and auto-banning

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -50,7 +50,7 @@ GIT
 
 GIT
   remote: git://github.com/travis-ci/travis-core.git
-  revision: 3bf0ef70894375578a9af55e0eb9566eb9424294
+  revision: d76e7aa7bac71737553fe127fe825981b8a2bbf6
   specs:
     travis-core (0.0.1)
       actionmailer (~> 3.2.19)
@@ -81,7 +81,7 @@ GIT
 
 GIT
   remote: git://github.com/travis-ci/travis-support.git
-  revision: e7f81093f83bd029cca6508739c5720e57e3d571
+  revision: a56f184c84f1f243da40daeaaf07f4ba931e6384
   specs:
     travis-support (0.0.1)
 

--- a/lib/travis/api/app.rb
+++ b/lib/travis/api/app.rb
@@ -125,7 +125,7 @@ module Travis::Api
         use Travis::Api::App::Middleware::Metriks
 
         # make sure this is below ScopeCheck so we have the token
-        use Travis::Api::Attack
+        use Rack::Attack
 
         # if this is a v3 API request, ignore everything after
         use Travis::API::V3::OptIn

--- a/lib/travis/api/app.rb
+++ b/lib/travis/api/app.rb
@@ -125,7 +125,7 @@ module Travis::Api
         use Travis::Api::App::Middleware::Metriks
 
         # make sure this is below ScopeCheck so we have the token
-        use Rack::Attack
+        use Rack::Attack if Endpoint.production?
 
         # if this is a v3 API request, ignore everything after
         use Travis::API::V3::OptIn

--- a/lib/travis/api/attack.rb
+++ b/lib/travis/api/attack.rb
@@ -2,6 +2,8 @@ require 'rack/attack'
 
 class Rack::Attack
   class Request
+    TOKEN = 'travis.access_token'.freeze
+
     def travis_token
       env.fetch(TOKEN)
     end

--- a/lib/travis/api/attack.rb
+++ b/lib/travis/api/attack.rb
@@ -2,6 +2,8 @@ require 'rack/attack'
 
 module Travis::Api
   class Attack < Rack::Attack
+    DalliProxy = Rack::Attack::DalliProxy # ?
+
     module Request
       TOKEN = 'travis.access_token'.freeze
       Rack::Attack::Request.prepend(self)

--- a/lib/travis/api/attack.rb
+++ b/lib/travis/api/attack.rb
@@ -1,10 +1,7 @@
 require 'rack/attack'
 
 class Rack::Attack
-  module RequestMixin
-    TOKEN = 'travis.access_token'.freeze
-    Rack::Attack::Request.prepend(self)
-
+  class Request
     def travis_token
       env.fetch(TOKEN)
     end
@@ -16,10 +13,6 @@ class Rack::Attack
     def identifier
       authenticated? ? travis_token.to_s : ip
     end
-  end
-
-  def self.cache
-    Rack::Attack.cache
   end
 
   ####

--- a/lib/travis/api/attack.rb
+++ b/lib/travis/api/attack.rb
@@ -1,0 +1,70 @@
+require 'rack/attack'
+
+module Travis::Api
+  class Attack < Rack::Attack
+    module Request
+      TOKEN = 'travis.access_token'.freeze
+      Rack::Attack::Request.prepend(self)
+
+      def travis_token
+        env.fetch(TOKEN)
+      end
+
+      def authenticated?
+        env.include? TOKEN
+      end
+
+      def identifier
+        authenticated? ? travis_token.to_s : ip
+      end
+    end
+
+    def self.cache
+      Rack::Attack.cache
+    end
+
+    ####
+    # Ban based on: IP address
+    # Ban time:     indefinite
+    # Ban after:    manually banned
+    blacklist('block client requesting from redis') do |request|
+      Travis.redis.sismember(:api_blacklisted_ips, request.ip)
+    end
+
+    ####
+    # Ban based on: IP address or access token
+    # Ban time:     1 hour
+    # Ban after:    10 POST requests within one minute to /auth/github
+    blacklist('hammering /auth/github') do |request|
+       Rack::Attack::Allow2Ban.filter(request.identifier, maxretry: 10, findtime: 1.minute, bantime: 1.hour) do
+         request.post? and request.path == '/auth/github'
+       end
+    end
+
+    ###
+    # Throttle:  unauthenticated requests - 50 per minute
+    # Scoped by: IP address
+    throttle('req/ip/1min', limit: 50, period: 1.minute) do |request|
+      request.ip unless request.authenticated?
+    end
+
+    ###
+    # Throttle:  authenticated requests - 100 per minute
+    # Scoped by: access token
+    throttle('req/token/1min', limit: 100, period: 1.minute) do |request|
+      request.identifier
+    end
+
+    if ENV["MEMCACHIER_SERVERS"]
+      cache.store = Dalli::Client.new(
+        ENV["MEMCACHIER_SERVERS"].split(","),
+        username:             ENV["MEMCACHIER_USERNAME"],
+        password:             ENV["MEMCACHIER_PASSWORD"],
+        failover:             true,
+        socket_timeout:       1.5,
+        socket_failure_delay: 0.2)
+    else
+      cache.store = ActiveSupport::Cache::MemoryStore.new
+    end
+  end
+end

--- a/lib/travis/api/attack.rb
+++ b/lib/travis/api/attack.rb
@@ -1,72 +1,68 @@
 require 'rack/attack'
 
-module Travis::Api
-  class Attack < Rack::Attack
-    DalliProxy = Rack::Attack::DalliProxy # ?
+class Rack::Attack
+  module RequestMixin
+    TOKEN = 'travis.access_token'.freeze
+    Rack::Attack::Request.prepend(self)
 
-    module Request
-      TOKEN = 'travis.access_token'.freeze
-      Rack::Attack::Request.prepend(self)
-
-      def travis_token
-        env.fetch(TOKEN)
-      end
-
-      def authenticated?
-        env.include? TOKEN
-      end
-
-      def identifier
-        authenticated? ? travis_token.to_s : ip
-      end
+    def travis_token
+      env.fetch(TOKEN)
     end
 
-    def self.cache
-      Rack::Attack.cache
+    def authenticated?
+      env.include? TOKEN
     end
 
-    ####
-    # Ban based on: IP address
-    # Ban time:     indefinite
-    # Ban after:    manually banned
-    blacklist('block client requesting from redis') do |request|
-      Travis.redis.sismember(:api_blacklisted_ips, request.ip)
+    def identifier
+      authenticated? ? travis_token.to_s : ip
     end
+  end
 
-    ####
-    # Ban based on: IP address or access token
-    # Ban time:     1 hour
-    # Ban after:    10 POST requests within one minute to /auth/github
-    blacklist('hammering /auth/github') do |request|
-       Rack::Attack::Allow2Ban.filter(request.identifier, maxretry: 10, findtime: 1.minute, bantime: 1.hour) do
-         request.post? and request.path == '/auth/github'
-       end
-    end
+  def self.cache
+    Rack::Attack.cache
+  end
 
-    ###
-    # Throttle:  unauthenticated requests - 50 per minute
-    # Scoped by: IP address
-    throttle('req/ip/1min', limit: 50, period: 1.minute) do |request|
-      request.ip unless request.authenticated?
-    end
+  ####
+  # Ban based on: IP address
+  # Ban time:     indefinite
+  # Ban after:    manually banned
+  blacklist('block client requesting from redis') do |request|
+    Travis.redis.sismember(:api_blacklisted_ips, request.ip)
+  end
 
-    ###
-    # Throttle:  authenticated requests - 100 per minute
-    # Scoped by: access token
-    throttle('req/token/1min', limit: 100, period: 1.minute) do |request|
-      request.identifier
-    end
+  ####
+  # Ban based on: IP address or access token
+  # Ban time:     1 hour
+  # Ban after:    10 POST requests within one minute to /auth/github
+  blacklist('hammering /auth/github') do |request|
+     Rack::Attack::Allow2Ban.filter(request.identifier, maxretry: 10, findtime: 1.minute, bantime: 1.hour) do
+       request.post? and request.path == '/auth/github'
+     end
+  end
 
-    if ENV["MEMCACHIER_SERVERS"]
-      cache.store = Dalli::Client.new(
-        ENV["MEMCACHIER_SERVERS"].split(","),
-        username:             ENV["MEMCACHIER_USERNAME"],
-        password:             ENV["MEMCACHIER_PASSWORD"],
-        failover:             true,
-        socket_timeout:       1.5,
-        socket_failure_delay: 0.2)
-    else
-      cache.store = ActiveSupport::Cache::MemoryStore.new
-    end
+  ###
+  # Throttle:  unauthenticated requests - 50 per minute
+  # Scoped by: IP address
+  throttle('req/ip/1min', limit: 50, period: 1.minute) do |request|
+    request.ip unless request.authenticated?
+  end
+
+  ###
+  # Throttle:  authenticated requests - 100 per minute
+  # Scoped by: access token
+  throttle('req/token/1min', limit: 100, period: 1.minute) do |request|
+    request.identifier
+  end
+
+  if ENV["MEMCACHIER_SERVERS"]
+    cache.store = Dalli::Client.new(
+      ENV["MEMCACHIER_SERVERS"].split(","),
+      username:             ENV["MEMCACHIER_USERNAME"],
+      password:             ENV["MEMCACHIER_PASSWORD"],
+      failover:             true,
+      socket_timeout:       1.5,
+      socket_failure_delay: 0.2)
+  else
+    cache.store = ActiveSupport::Cache::MemoryStore.new
   end
 end


### PR DESCRIPTION
Base throttling on access token if the call is authenticated, rather than on IP address, improve throttling rules.

Rules:

* Throttle unauthenticated calls to 50/min based on IP address.
* Throttle authenticated calls to 100/min based on access token (no more blocking in large offices).
* Ban clients for one hour if sending 10 or more POST requests to /auth/github within one minute. Ban unauthenticated calls based on IP address and authenticated calls based on access token.
* Ban clients manually with their IP address listed in the `api_blacklisted_ips` Redis set.