### PR TITLE
increase throttle limit for authenticated requests

### DIFF
--- a/lib/travis/api/attack.rb
+++ b/lib/travis/api/attack.rb
@@ -43,9 +43,9 @@ class Rack::Attack
   end
 
   ###
-  # Throttle:  authenticated requests - 100 per minute
+  # Throttle:  authenticated requests - 200 per minute
   # Scoped by: access token
-  throttle('req/token/1min', limit: 100, period: 1.minute) do |request|
+  throttle('req/token/1min', limit: 200, period: 1.minute) do |request|
     request.identifier
   end
 


### PR DESCRIPTION
Following feedback from organization Sonarc Source, who monitor the status of each of their 94 apps twice per minute, we have increased the throttle limit for authenticated requests to accommodate their use case.