### PR TITLE
API v3: no list nesting

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -50,7 +50,7 @@ GIT
 
 GIT
   remote: git://github.com/travis-ci/travis-core.git
-  revision: c70ff174e2ceddebcf28a1b4fd92de5c52d6c74e
+  revision: 21793fc8b01f965b93cf98b7ab1458ee359a5a62
   specs:
     travis-core (0.0.1)
       actionmailer (~> 3.2.19)
@@ -369,6 +369,3 @@ DEPENDENCIES
   travis-yaml!
   unicorn
   yard-sinatra!
-
-BUNDLED WITH
-   1.10.6

--- a/lib/travis/api/v3/query.rb
+++ b/lib/travis/api/v3/query.rb
@@ -54,7 +54,13 @@ module Travis::API::V3
 
     def includes?(key)
       @includes ||= @params['include'.freeze].to_s.split(?,.freeze)
-      key.include?(?.) ? @includes.include?(key) : @includes.any? { |k| k.start_with? key }
+      key = key.to_s if key.is_a? Symbol
+
+      if key.is_a? String
+        key.include?(?.) ? @includes.include?(key) : @includes.any? { |k| k.start_with? key }
+      else
+        @includes.any? { |k| key === k }
+      end
     end
 
     def bool(value)

--- a/lib/travis/api/v3/renderer/collection_renderer.rb
+++ b/lib/travis/api/v3/renderer/collection_renderer.rb
@@ -21,13 +21,14 @@ module Travis::API::V3
       available_attributes << value
     end
 
-    attr_reader :href, :options, :list, :included, :meta_data
+    attr_reader :href, :options, :list, :included, :include, :meta_data
 
-    def initialize(list, href: nil, included: [], meta_data: {}, **options)
+    def initialize(list, href: nil, included: [], include: [], meta_data: {}, **options)
       @href      = href
       @options   = options
       @list      = list
       @included  = included
+      @include   = include
       @meta_data = meta_data
     end
 
@@ -49,11 +50,16 @@ module Travis::API::V3
       result                 = fields
       included               = self.included.dup
       result[collection_key] = list.map do |entry|
-        rendered = render_entry(entry, included: included, mode: representation, **options)
+        rendered = render_entry(entry, included: included, include: filtered_include, mode: representation, **options)
         included << entry
         rendered
       end
       result
+    end
+
+    def filtered_include
+      key = collection_key.to_s
+      include.reject { |entry| entry.split(?..freeze, 2).last == key }
     end
 
     def representation

--- a/spec/v3/services/repositories/for_current_user_spec.rb
+++ b/spec/v3/services/repositories/for_current_user_spec.rb
@@ -89,6 +89,12 @@ describe Travis::API::V3::Services::Repositories::ForCurrentUser do
     }}
   end
 
+  describe "don't nest list of repositories inside a list of repositories even if the user asks for it. user has no idea what they are doing" do
+    before  { get("/v3/repos?include=user.repositories", {}, headers)                          }
+    example { expect(last_response).to be_ok                                                   }
+    example { expect(JSON.load(body)['repositories'].first['owner']['repositories']).to be_nil }
+  end
+
   describe "filter: private=false" do
     before  { get("/v3/repos", {"repository.private" => "false"}, headers)                           }
     example { expect(last_response)                   .to be_ok                                      }


### PR DESCRIPTION
Our db join optimisation and ActiveRecord don't like queries in the style of `/repos?include=user.repositories`, which also is a query that doesn't make a lot of sense (there repos can also be found at top level). However, such queries not having a good use case doesn't keep people from constructing them.

Therefore the logic is extended in the following way: If you already are rendering a collection of type *X*, do not allow eager loading a nested collection of the same type.