### PR TITLE
better branches filtering and sorting

### DIFF
--- a/lib/travis/api/v3/queries/branches.rb
+++ b/lib/travis/api/v3/queries/branches.rb
@@ -1,5 +1,7 @@
 module Travis::API::V3
   class Queries::Branches < Query
+    params :exists_on_github, prefix: :branch
+
     sortable_by :name,
       last_build: "builds.started_at".freeze,
       exists_on_github: "(case when branches.exists_on_github then 1 else 2 end)".freeze
@@ -7,7 +9,12 @@ module Travis::API::V3
     default_sort "last_build:desc"
 
     def find(repository)
-      sort repository.branches
+      sort filter(repository.branches)
+    end
+
+    def filter(list)
+      list = list.where(exists_on_github: bool(exists_on_github)) unless exists_on_github.nil?
+      list
     end
   end
 end

--- a/lib/travis/api/v3/queries/branches.rb
+++ b/lib/travis/api/v3/queries/branches.rb
@@ -1,6 +1,9 @@
 module Travis::API::V3
   class Queries::Branches < Query
-    sortable_by :name, last_build: "builds.started_at".freeze
+    sortable_by :name,
+      last_build: "builds.started_at".freeze,
+      exists_on_github: "(case when branches.exists_on_github then 1 else 2 end)".freeze
+
     default_sort "last_build:desc"
 
     def find(repository)

--- a/lib/travis/api/v3/queries/branches.rb
+++ b/lib/travis/api/v3/queries/branches.rb
@@ -3,13 +3,26 @@ module Travis::API::V3
     params :exists_on_github, prefix: :branch
 
     sortable_by :name,
-      last_build: "builds.started_at".freeze,
-      exists_on_github: "(case when branches.exists_on_github then 1 else 2 end)".freeze
+      last_build:       "builds.started_at".freeze,
+      exists_on_github: sort_condition(:exists_on_github),
+      default_branch:   sort_condition(name: "repositories.default_branch")
 
     default_sort "last_build:desc"
 
     def find(repository)
-      sort filter(repository.branches)
+      sort(filter(repository.branches), repository: repository)
+    end
+
+    def sort_by(collection, field, repository: nil, **options)
+      return super unless field == "default_branch".freeze
+
+      if repository
+        options[:sql] = sort_condition(name: quote(repository.default_branch_name))
+      else
+        collection    = collection.joins(:repository)
+      end
+
+      super(collection, field, **options)
     end
 
     def filter(list)

--- a/lib/travis/api/v3/queries/branches.rb
+++ b/lib/travis/api/v3/queries/branches.rb
@@ -7,7 +7,7 @@ module Travis::API::V3
       exists_on_github: sort_condition(:exists_on_github),
       default_branch:   sort_condition(name: "repositories.default_branch")
 
-    default_sort "last_build:desc"
+    default_sort "default_branch,exists_on_github,last_build:desc"
 
     def find(repository)
       sort(filter(repository.branches), repository: repository)

--- a/lib/travis/api/v3/services/branches/find.rb
+++ b/lib/travis/api/v3/services/branches/find.rb
@@ -1,5 +1,6 @@
 module Travis::API::V3
   class Services::Branches::Find < Service
+    params :exists_on_github, prefix: :branch
     paginate
 
     def run!

--- a/spec/v3/services/branches/find_spec.rb
+++ b/spec/v3/services/branches/find_spec.rb
@@ -172,6 +172,20 @@ describe Travis::API::V3::Services::Branches::Find do
     }
   end
 
+  describe "filtering by exists_on_github" do
+    describe "false" do
+      before     { get("/v3/repo/#{repo.id}/branches?branch.exists_on_github=false") }
+      example    { expect(last_response).to be_ok }
+      example    { expect(parsed_body["branches"]).to be_empty }
+    end
+
+    describe "true" do
+      before     { get("/v3/repo/#{repo.id}/branches?branch.exists_on_github=true") }
+      example    { expect(last_response).to be_ok }
+      example    { expect(parsed_body["branches"]).not_to be_empty }
+    end
+  end
+
   describe "sorting by name" do
     before  { get("/v3/repo/#{repo.id}/branches?sort_by=name&limit=1") }
     example { expect(last_response).to be_ok }

--- a/spec/v3/services/branches/find_spec.rb
+++ b/spec/v3/services/branches/find_spec.rb
@@ -216,6 +216,28 @@ describe Travis::API::V3::Services::Branches::Find do
     }
   end
 
+  describe "sorting by exists_on_github" do
+    before  { get("/v3/repo/#{repo.id}/branches?sort_by=exists_on_github&limit=1") }
+    example { expect(last_response).to be_ok }
+    example { expect(parsed_body["@pagination"]).to be == {
+        "limit"            => 1,
+        "offset"           => 0,
+        "count"            => 1,
+        "is_first"         => true,
+        "is_last"          => true,
+        "next"             => nil,
+        "prev"             => nil,
+        "first"            => {
+          "@href"          => "/v3/repo/#{repo.id}/branches?sort_by=exists_on_github&limit=1",
+          "offset"         => 0,
+          "limit"          => 1 },
+        "last"             => {
+          "@href"          => "/v3/repo/#{repo.id}/branches?sort_by=exists_on_github&limit=1",
+          "offset"         => 0,
+          "limit"          => 1 }}
+    }
+  end
+
   describe "sorting by unknown sort field" do
     before  { get("/v3/repo/#{repo.id}/branches?sort_by=name:desc,foo&limit=1") }
     example { expect(last_response).to be_ok }

--- a/spec/v3/services/branches/find_spec.rb
+++ b/spec/v3/services/branches/find_spec.rb
@@ -252,6 +252,28 @@ describe Travis::API::V3::Services::Branches::Find do
     }
   end
 
+  describe "sorting by default_branch" do
+    before  { get("/v3/repo/#{repo.id}/branches?sort_by=default_branch&limit=1") }
+    example { expect(last_response).to be_ok }
+    example { expect(parsed_body["@pagination"]).to be == {
+        "limit"            => 1,
+        "offset"           => 0,
+        "count"            => 1,
+        "is_first"         => true,
+        "is_last"          => true,
+        "next"             => nil,
+        "prev"             => nil,
+        "first"            => {
+          "@href"          => "/v3/repo/#{repo.id}/branches?sort_by=default_branch&limit=1",
+          "offset"         => 0,
+          "limit"          => 1 },
+        "last"             => {
+          "@href"          => "/v3/repo/#{repo.id}/branches?sort_by=default_branch&limit=1",
+          "offset"         => 0,
+          "limit"          => 1 }}
+    }
+  end
+
   describe "sorting by unknown sort field" do
     before  { get("/v3/repo/#{repo.id}/branches?sort_by=name:desc,foo&limit=1") }
     example { expect(last_response).to be_ok }


### PR DESCRIPTION
* allow filtering branches via `?branch.exists_on_github=[true|false]`
* allow sorting branches by `exists_on_github`
* allow sorting branches by `default_branch`
* default sort for branches changed to `default_branch,exists_on_github,last_build`

This branch is currently deployed to staging.