### PR TITLE
Add `is_on_default_branch` field to build's V2 payload

### DIFF
--- a/lib/travis/api/v2/http/build.rb
+++ b/lib/travis/api/v2/http/build.rb
@@ -40,7 +40,8 @@ module Travis
                 'started_at' => format_date(build.started_at),
                 'finished_at' => format_date(build.finished_at),
                 'duration' => build.duration,
-                'job_ids' => build.matrix_ids
+                'job_ids' => build.matrix_ids,
+                'is_on_default_branch' => on_default_branch?(build)
               }
             end
 
@@ -76,6 +77,10 @@ module Travis
                 'tags' => job.tags,
                 'annotation_ids' => job.annotation_ids,
               }
+            end
+
+            def on_default_branch?(build)
+              build.repository.default_branch == build.commit.branch
             end
 
             def annotations(build)

--- a/spec/unit/api/v2/http/build_spec.rb
+++ b/spec/unit/api/v2/http/build_spec.rb
@@ -20,7 +20,8 @@ describe Travis::Api::V2::Http::Build do
       'state' => 'passed',
       'started_at' => json_format_time(Time.now.utc - 1.minute),
       'finished_at' => json_format_time(Time.now.utc),
-      'duration' => 60
+      'duration' => 60,
+      'is_on_default_branch' => true
     }
   end
 


### PR DESCRIPTION
This field will make it easier to deal with default branch when using builds from V2 API.