### PR TITLE
Add ability to sort repos by default_branch.last_build

### DIFF
--- a/lib/travis/api/v3/queries/repositories.rb
+++ b/lib/travis/api/v3/queries/repositories.rb
@@ -1,7 +1,7 @@
 module Travis::API::V3
   class Queries::Repositories < Query
     params :active, :private, :starred, prefix: :repository
-    sortable_by :id, :github_id, :owner_name, :name, active: sort_condition(:active), :'default_branch.last_build' => 'builds.id'
+    sortable_by :id, :github_id, :owner_name, :name, active: sort_condition(:active), :'default_branch.last_build' => 'builds.started_at'
 
     def for_member(user, **options)
       all(user: user, **options).joins(:users).where(users: user_condition(user), invalidated_at: nil)

--- a/lib/travis/api/v3/queries/repositories.rb
+++ b/lib/travis/api/v3/queries/repositories.rb
@@ -1,7 +1,7 @@
 module Travis::API::V3
   class Queries::Repositories < Query
     params :active, :private, :starred, prefix: :repository
-    sortable_by :id, :github_id, :owner_name, :name, active: sort_condition(:active), default_branch: 'builds.id'
+    sortable_by :id, :github_id, :owner_name, :name, active: sort_condition(:active), :'default_branch.last_build' => 'builds.id'
 
     def for_member(user, **options)
       all(user: user, **options).joins(:users).where(users: user_condition(user), invalidated_at: nil)

--- a/lib/travis/api/v3/queries/repositories.rb
+++ b/lib/travis/api/v3/queries/repositories.rb
@@ -1,7 +1,7 @@
 module Travis::API::V3
   class Queries::Repositories < Query
     params :active, :private, :starred, prefix: :repository
-    sortable_by :id, :github_id, :owner_name, :name, active: sort_condition(:active)
+    sortable_by :id, :github_id, :owner_name, :name, active: sort_condition(:active), default_branch: 'builds.id'
 
     def for_member(user, **options)
       all(user: user, **options).joins(:users).where(users: user_condition(user), invalidated_at: nil)

--- a/spec/v3/services/repositories/for_owner_spec.rb
+++ b/spec/v3/services/repositories/for_owner_spec.rb
@@ -106,7 +106,7 @@ describe Travis::API::V3::Services::Repositories::ForOwner do
   end
 
   describe "sorting by default_branch.last_build" do
-    before  { repo2 = Travis::API::V3::Models::Repository.create(owner_name: 'svenfuchs', name: 'maximal', owner_id: 1, owner_type: "User", last_build_state: "passed", active: true, last_build_id: 1788, next_build_number: 3) }
+    before  { repo2 = Travis::API::V3::Models::Repository.create(id: 5, owner_name: 'svenfuchs', name: 'maximal', owner_id: 1, owner_type: "User", last_build_state: "passed", active: true, last_build_id: 1788, next_build_number: 3) }
     before  { get("/v3/owner/svenfuchs/repos?sort_by=default_branch.last_build", {}, headers) }
     example { expect(last_response).to be_ok }
     example { expect(JSON.load(body)['@href'])        .to be == "/v3/owner/svenfuchs/repos?sort_by=default_branch.last_build" }
@@ -140,7 +140,7 @@ describe Travis::API::V3::Services::Repositories::ForOwner do
           "name"          => "master" },
         "starred"         => false }, {
         "@type"           => "repository",
-        "@href"           => "/v3/repo/#{repo2.id}",
+        "@href"           => "/v3/repo/5",
         "@representation" => "standard",
         "@permissions"    => {
           "read"          => true,
@@ -149,7 +149,7 @@ describe Travis::API::V3::Services::Repositories::ForOwner do
           "star"          => false,
           "unstar"        => false,
           "create_request"=> false },
-        "id"              => repo2.id,
+        "id"              => 5,
         "name"            => "maximal",
         "slug"            => "svenfuchs/maximal",
         "description"     => nil,
@@ -163,7 +163,7 @@ describe Travis::API::V3::Services::Repositories::ForOwner do
           "@href"         => "/v3/user/1" },
         "default_branch"  => {
           "@type"         => "branch",
-          "@href"         => "/v3/repo/#{repo2.id}/branch/master",
+          "@href"         => "/v3/repo/5/branch/master",
           "@representation"=>"minimal",
           "name"           =>"master" },
           "starred"=>false}]}

--- a/spec/v3/services/repositories/for_owner_spec.rb
+++ b/spec/v3/services/repositories/for_owner_spec.rb
@@ -140,7 +140,7 @@ describe Travis::API::V3::Services::Repositories::ForOwner do
           "name"          => "master" },
         "starred"         => false }, {
         "@type"           => "repository",
-        "@href"           => "/v3/repo/5",
+        "@href"           => "/v3/repo/#{repo.id}",
         "@representation" => "standard",
         "@permissions"    => {
           "read"          => true,
@@ -149,7 +149,7 @@ describe Travis::API::V3::Services::Repositories::ForOwner do
           "star"          => false,
           "unstar"        => false,
           "create_request"=> false },
-        "id"              => 5,
+        "id"              => repo.id,
         "name"            => "maximal",
         "slug"            => "svenfuchs/maximal",
         "description"     => nil,
@@ -163,7 +163,7 @@ describe Travis::API::V3::Services::Repositories::ForOwner do
           "@href"         => "/v3/user/1" },
         "default_branch"  => {
           "@type"         => "branch",
-          "@href"         => "/v3/repo/5/branch/master",
+          "@href"         => "/v3/repo/#{repo.id}/branch/master",
           "@representation"=>"minimal",
           "name"           =>"master" },
           "starred"=>false}]}

--- a/spec/v3/services/repositories/for_owner_spec.rb
+++ b/spec/v3/services/repositories/for_owner_spec.rb
@@ -103,4 +103,26 @@ describe Travis::API::V3::Services::Repositories::ForOwner do
     example { expect(JSON.load(body)['@href'])        .to be == "/v3/repos?starred=false"    }
     example { expect(JSON.load(body)['repositories']) .to be_empty                           }
   end
+
+  describe "sorting by default_branch.last_build" do
+    before  { get("/v3/owner/svenfuchs/repos?sort_by=default_branch.last_build") }
+    example { expect(last_response).to be_ok }
+    example { expect(parsed_body["@pagination"]).to be == {
+        "limit"           => 100,
+        "offset"          => 0,
+        "count"           => 0,
+        "is_first"        => true,
+        "is_last"         => true,
+        "next"            => nil,
+        "prev"            => nil,
+        "first"           => {
+          "@href"         => "/v3/owner/svenfuchs/repos?sort_by=default_branch.last_build",
+          "offset"        => 0,
+          "limit"         => 100 },
+        "last"            => {
+          "@href"         =>"/v3/owner/svenfuchs/repos?limit=100&offset=-100&sort_by=default_branch.last_build",
+          "offset"        => -100,
+          "limit"         => 100 }}
+    }
+  end
 end

--- a/spec/v3/services/repositories/for_owner_spec.rb
+++ b/spec/v3/services/repositories/for_owner_spec.rb
@@ -140,7 +140,7 @@ describe Travis::API::V3::Services::Repositories::ForOwner do
           "name"          => "master" },
         "starred"         => false }, {
         "@type"           => "repository",
-        "@href"           => "/v3/repo/#{repo.id}",
+        "@href"           => "/v3/repo/#{repo2.id}",
         "@representation" => "standard",
         "@permissions"    => {
           "read"          => true,
@@ -149,7 +149,7 @@ describe Travis::API::V3::Services::Repositories::ForOwner do
           "star"          => false,
           "unstar"        => false,
           "create_request"=> false },
-        "id"              => repo.id,
+        "id"              => repo2.id,
         "name"            => "maximal",
         "slug"            => "svenfuchs/maximal",
         "description"     => nil,
@@ -163,7 +163,7 @@ describe Travis::API::V3::Services::Repositories::ForOwner do
           "@href"         => "/v3/user/1" },
         "default_branch"  => {
           "@type"         => "branch",
-          "@href"         => "/v3/repo/#{repo.id}/branch/master",
+          "@href"         => "/v3/repo/#{repo2.id}/branch/master",
           "@representation"=>"minimal",
           "name"           =>"master" },
           "starred"=>false}]}

--- a/spec/v3/services/repositories/for_owner_spec.rb
+++ b/spec/v3/services/repositories/for_owner_spec.rb
@@ -11,6 +11,7 @@ describe Travis::API::V3::Services::Repositories::ForOwner do
   before        { repo.update_attribute(:private, true)                             }
   after         { repo.update_attribute(:private, false)                            }
 
+
   describe "private repository, private API, authenticated as user with access" do
     before  { get("/v3/owner/svenfuchs/repos", {}, headers) }
     example { expect(last_response).to be_ok }
@@ -105,24 +106,66 @@ describe Travis::API::V3::Services::Repositories::ForOwner do
   end
 
   describe "sorting by default_branch.last_build" do
-    before  { get("/v3/owner/svenfuchs/repos?sort_by=default_branch.last_build") }
+    before  { repo2 = Travis::API::V3::Models::Repository.create(owner_name: 'svenfuchs', name: 'maximal', owner_id: 1, owner_type: "User", last_build_state: "passed", active: true, last_build_id: 1788, next_build_number: 3) }
+    before  { get("/v3/owner/svenfuchs/repos?sort_by=default_branch.last_build", {}, headers) }
     example { expect(last_response).to be_ok }
-    example { expect(parsed_body["@pagination"]).to be == {
-        "limit"           => 100,
-        "offset"          => 0,
-        "count"           => 0,
-        "is_first"        => true,
-        "is_last"         => true,
-        "next"            => nil,
-        "prev"            => nil,
-        "first"           => {
-          "@href"         => "/v3/owner/svenfuchs/repos?sort_by=default_branch.last_build",
-          "offset"        => 0,
-          "limit"         => 100 },
-        "last"            => {
-          "@href"         =>"/v3/owner/svenfuchs/repos?limit=100&offset=-100&sort_by=default_branch.last_build",
-          "offset"        => -100,
-          "limit"         => 100 }}
-    }
+    example { expect(JSON.load(body)['@href'])        .to be == "/v3/owner/svenfuchs/repos?sort_by=default_branch.last_build" }
+    example { expect(JSON.load(body)['repositories'])   .to be == [{
+        "@type"           => "repository",
+        "@href"           => "/v3/repo/1",
+        "@representation" => "standard",
+        "@permissions"    => {
+          "read"          => true,
+          "enable"        => false,
+          "disable"       => false,
+          "star"          => false,
+          "unstar"        => false,
+          "create_request"=> false },
+        "id"              => 1,
+        "name"            => "minimal",
+        "slug"            => "svenfuchs/minimal",
+        "description"     => nil,
+        "github_language" => nil,
+        "active"          => true,
+        "private"         => true,
+        "owner"           => {
+          "@type"         => "user",
+          "id"            => 1,
+          "login"         => "svenfuchs",
+          "@href"         => "/v3/user/1" },
+        "default_branch"  => {
+          "@type"         => "branch",
+          "@href"         => "/v3/repo/1/branch/master",
+          "@representation"=>"minimal",
+          "name"          => "master" },
+        "starred"         => false }, {
+        "@type"           => "repository",
+        "@href"           => "/v3/repo/5",
+        "@representation" => "standard",
+        "@permissions"    => {
+          "read"          => true,
+          "enable"        => false,
+          "disable"       => false,
+          "star"          => false,
+          "unstar"        => false,
+          "create_request"=> false },
+        "id"              => 5,
+        "name"            => "maximal",
+        "slug"            => "svenfuchs/maximal",
+        "description"     => nil,
+        "github_language" => nil,
+        "active"          => true,
+        "private"         => false,
+        "owner"           => {
+          "@type"         => "user",
+          "id"            => 1,
+          "login"         => "svenfuchs",
+          "@href"         => "/v3/user/1" },
+        "default_branch"  => {
+          "@type"         => "branch",
+          "@href"         => "/v3/repo/5/branch/master",
+          "@representation"=>"minimal",
+          "name"           =>"master" },
+          "starred"=>false}]}
   end
 end

--- a/spec/v3/services/repositories/for_owner_spec.rb
+++ b/spec/v3/services/repositories/for_owner_spec.rb
@@ -106,7 +106,8 @@ describe Travis::API::V3::Services::Repositories::ForOwner do
   end
 
   describe "sorting by default_branch.last_build" do
-    before  { repo2 = Travis::API::V3::Models::Repository.create(id: 5, owner_name: 'svenfuchs', name: 'maximal', owner_id: 1, owner_type: "User", last_build_state: "passed", active: true, last_build_id: 1788, next_build_number: 3) }
+    let(:repo2)  { Travis::API::V3::Models::Repository.create(owner_name: 'svenfuchs', name: 'maximal', owner_id: 1, owner_type: "User", last_build_state: "passed", active: true, last_build_id: 1788, next_build_number: 3) }
+    before  { repo2.save! }
     before  { get("/v3/owner/svenfuchs/repos?sort_by=default_branch.last_build", {}, headers) }
     example { expect(last_response).to be_ok }
     example { expect(JSON.load(body)['@href'])        .to be == "/v3/owner/svenfuchs/repos?sort_by=default_branch.last_build" }
@@ -140,7 +141,7 @@ describe Travis::API::V3::Services::Repositories::ForOwner do
           "name"          => "master" },
         "starred"         => false }, {
         "@type"           => "repository",
-        "@href"           => "/v3/repo/5",
+        "@href"           => "/v3/repo/#{repo2.id}",
         "@representation" => "standard",
         "@permissions"    => {
           "read"          => true,
@@ -149,7 +150,7 @@ describe Travis::API::V3::Services::Repositories::ForOwner do
           "star"          => false,
           "unstar"        => false,
           "create_request"=> false },
-        "id"              => 5,
+        "id"              => repo2.id,
         "name"            => "maximal",
         "slug"            => "svenfuchs/maximal",
         "description"     => nil,
@@ -163,7 +164,7 @@ describe Travis::API::V3::Services::Repositories::ForOwner do
           "@href"         => "/v3/user/1" },
         "default_branch"  => {
           "@type"         => "branch",
-          "@href"         => "/v3/repo/5/branch/master",
+          "@href"         => "/v3/repo/#{repo2.id}/branch/master",
           "@representation"=>"minimal",
           "name"           =>"master" },
           "starred"=>false}]}


### PR DESCRIPTION
Right now it sorts by id. 
It could also sort by finished_at, which would change the behaviour for builds that haven't finished running.
We could also add both. What do you think @drogus?

To check what is returned use `... /repos?sort_by=default_branch.last_build`

This addresses this issue: https://github.com/travis-pro/team-teal/issues/732