### PR TITLE
Remove hard coded request path to allow whitelisted request paths

### DIFF
--- a/lib/travis/api/attack.rb
+++ b/lib/travis/api/attack.rb
@@ -61,7 +61,7 @@ class Rack::Attack
   # Ban after:    10 POST requests within 30 seconds
   blacklist('spamming with POST requests') do |request|
      Rack::Attack::Allow2Ban.filter(request.identifier, maxretry: 10, findtime: 30.seconds, bantime: bantime(1.hour)) do
-       request.post? and not POST_WHITELISTED.include? '/auth/github'
+       request.post? and not POST_WHITELISTED.include? request.path
      end
   end
 


### PR DESCRIPTION
This is to prevent internal developers from being locked out by the rate limiting.

Tests passing locally and on travis-ci