### PR TITLE
Allow to set sidekiq concurrency separately from web workers

### DIFF
--- a/lib/travis/sidekiq.rb
+++ b/lib/travis/sidekiq.rb
@@ -7,6 +7,7 @@ require 'travis/api/workers/job_cancellation'
 require 'travis/api/workers/job_restart'
 require 'travis/support/amqp'
 
+Travis.config.database[:pool] = ENV['SIDEKIQ_DB_POOL_SIZE'] || 5
 Travis::Database.connect
 
 if Travis.config.logs_database


### PR DESCRIPTION
```
Unicorn, which we use to serve the API, uses forked workers that need
only one connection per instance. Sidekiq on the other hand runs several
instances in memory, so it needs a higher concurrency setting. This
commit introduces a way to set sidekiq db pool using
SIDEKIQ_DB_POOL_SIZE
```