### PR TITLE
Unsmart loading app extensions

### DIFF
--- a/lib/travis/api/app/extensions.rb
+++ b/lib/travis/api/app/extensions.rb
@@ -1,8 +1,4 @@
-require 'travis/api/app'
-
-class Travis::Api::App
-  # Namespace for Sinatra extensions.
-  module Extensions
-    Dir.glob("#{__dir__}/extensions/*.rb").each { |f| require f[%r[(?<=lib/).+(?=\.rb$)]] }
-  end
-end
+require 'travis/api/app/extensions/expose_pattern'
+require 'travis/api/app/extensions/scoping'
+require 'travis/api/app/extensions/smart_constants'
+require 'travis/api/app/extensions/subclass_tracker'


### PR DESCRIPTION
For not entirely 100% clear reasons this suddenly starts breaking in certain contexts (where `lib` is part of a parent directory on the matched path).

After debugging this with @tyranja and @drogus we've decided to unsmart this.