### PR TITLE
add better condition check for rake

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,10 +1,11 @@
 namespace :db do
   env = ENV["RAILS_ENV"]
-  fail "Cannot run rake db:create in production." if env == 'production'
-  desc "Create and migrate the #{env} database"
-  task :create do
-    sh "createdb travis_#{env}" rescue nil
-    sh "psql -q travis_#{env} < #{Gem.loaded_specs['travis-migrations'].full_gem_path}/db/structure.sql"
+  if env != 'production'
+    desc "Create and migrate the #{env} database"
+    task :create do
+      sh "createdb travis_#{env}" rescue nil
+      sh "psql -q travis_#{env} < #{Gem.loaded_specs['travis-migrations'].full_gem_path}/db/structure.sql"
+    end
   end
 end
 


### PR DESCRIPTION
This fixes the problem where the Heroku deploy was failing because the `fail` condition for production was preventing rake from finding the tasks.

Tests are all passing and deployment to staging now works.
