### PR TITLE
Add api builds rate limit to API

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,0 +1,3 @@
+--colour
+--tty
+--format documentation

--- a/lib/travis/api/attack.rb
+++ b/lib/travis/api/attack.rb
@@ -50,9 +50,9 @@ class Rack::Attack
   # Ban time:     5 hours
   # Ban after:    10 POST requests within five minutes to /auth/github
   blacklist('hammering /auth/github') do |request|
-     Rack::Attack::Allow2Ban.filter(request.identifier, maxretry: 2, findtime: 5.minutes, bantime: bantime(5.hours)) do
-       request.post? and request.path == '/auth/github'
-     end
+    Rack::Attack::Allow2Ban.filter(request.identifier, maxretry: 2, findtime: 5.minutes, bantime: bantime(5.hours)) do
+      request.post? and request.path == '/auth/github'
+    end
   end
 
   ####
@@ -60,9 +60,9 @@ class Rack::Attack
   # Ban time:     1 hour
   # Ban after:    10 POST requests within 30 seconds
   blacklist('spamming with POST requests') do |request|
-     Rack::Attack::Allow2Ban.filter(request.identifier, maxretry: 10, findtime: 30.seconds, bantime: bantime(1.hour)) do
-       request.post? and not POST_WHITELISTED.include? request.path
-     end
+    Rack::Attack::Allow2Ban.filter(request.identifier, maxretry: 10, findtime: 30.seconds, bantime: bantime(1.hour)) do
+      request.post? and not POST_WHITELISTED.include? request.path
+    end
   end
 
 

--- a/lib/travis/api/v3/models/repository.rb
+++ b/lib/travis/api/v3/models/repository.rb
@@ -62,5 +62,9 @@ module Travis::API::V3
 
       __send__(name, *args, &block)
     end
+
+    def settings
+      @settings ||= JSON.load(super)
+    end
   end
 end

--- a/lib/travis/api/v3/services/requests/create.rb
+++ b/lib/travis/api/v3/services/requests/create.rb
@@ -22,14 +22,19 @@ module Travis::API::V3
       accepted(remaining_requests: remaining, repository: repository, request: payload)
     end
 
-    def limit
-      Travis.config.requests_create_api_limit || LIMIT
+    def limit(repository)
+      if repository.settings.nil?
+        LIMIT
+      else
+        repository.settings["api_builds_rate_limit"] || LIMIT
+      end
     end
 
     def remaining_requests(repository)
-      return limit if access_control.full_access?
+      api_builds_rate_limit = limit(repository)
+      return api_builds_rate_limit if access_control.full_access?
       count = query(:requests).count(repository, TIME_FRAME)
-      count > limit ? 0 : limit - count
+      count > api_builds_rate_limit ? 0 : api_builds_rate_limit - count
     end
   end
 end


### PR DESCRIPTION
This addresses issue: https://github.com/travis-pro/team-teal/issues/659

It detects whether the `settings` on a `repository` has a `api_builds_rate_limit` set and adjusts this rate in order to allow or disallow requests on a repository.

Specs have been added and are passing on Travis CI.

It has also been deployed to staging and tested there, along with the required changes to `admin` and `core`.