### PR TITLE
V3 add branch_name for request

### DIFF
--- a/lib/travis/api/v3/models/request.rb
+++ b/lib/travis/api/v3/models/request.rb
@@ -1,10 +1,20 @@
 module Travis::API::V3
   class Models::Request < Model
+    BRANCH_REF = %r{refs/heads/(.*?)$}
+
     belongs_to :commit
     belongs_to :repository
     belongs_to :owner, polymorphic: true
     has_many   :builds
     serialize  :config
     serialize  :payload
+
+    def branch_name
+      ref =~ BRANCH_REF and $1
+    end
+
+    def ref
+      payload['ref'] if payload
+    end
   end
 end

--- a/lib/travis/api/v3/renderer/request.rb
+++ b/lib/travis/api/v3/renderer/request.rb
@@ -3,6 +3,6 @@ require 'travis/api/v3/renderer/model_renderer'
 module Travis::API::V3
   class Renderer::Request < Renderer::ModelRenderer
     representation(:minimal,  :id)
-    representation(:standard, :id, :repository, :commit, :owner, :created_at, :result, :message, :event_type)
+    representation(:standard, :id, :repository, :branch_name, :commit, :owner, :created_at, :result, :message, :event_type)
   end
 end

--- a/spec/v3/services/requests/find_spec.rb
+++ b/spec/v3/services/requests/find_spec.rb
@@ -1,0 +1,60 @@
+require 'spec_helper'
+
+describe Travis::API::V3::Services::Requests::Find do
+  let(:repo) { Travis::API::V3::Models::Repository.where(owner_name: 'svenfuchs', name: 'minimal').first }
+  let(:request) { repo.requests.first }
+
+  describe "fetching requests on a public repository" do
+    before     { get("/v3/repo/#{repo.id}/requests")     }
+    example    { expect(last_response).to be_ok }
+    example    { expect(JSON.load(body).to_s).to include(
+                  "@type",
+                  "requests",
+                  "/v3/repo/#{repo.id}/requests",
+                  "repository",
+                  "commit",
+                  "message",
+                  "the commit message",
+                  "branch_name",
+                  "representation",
+                  "@pagination",
+                  "owner",
+                  "created_at",
+                  "result",
+                  "sha",
+                  "svenfuchs/minimal",
+                  "event_type",
+                  "push")
+    }
+  end
+
+  describe "fetching requests on private repository, private API, authenticated as user with access" do
+    let(:token)   { Travis::Api::App::AccessToken.create(user: repo.owner, app_id: 1) }
+    let(:headers) {{ 'HTTP_AUTHORIZATION' => "token #{token}"                        }}
+    before        { Travis::API::V3::Models::Permission.create(repository: repo, user: repo.owner, pull: true) }
+    before        { repo.update_attribute(:private, true)                             }
+    before        { get("/v3/repo/#{repo.id}/requests", {}, headers)                             }
+    after         { repo.update_attribute(:private, false)                            }
+    example       { expect(last_response).to be_ok                                    }
+    example       { expect(JSON.load(body).to_s).to include(
+                    "@type",
+                    "requests",
+                    "/v3/repo/#{repo.id}/requests",
+                    "repository",
+                    "commit",
+                    "message",
+                    "the commit message",
+                    "branch_name",
+                    "representation",
+                    "@pagination",
+                    "owner",
+                    "created_at",
+                    "result",
+                    "sha",
+                    "svenfuchs/minimal",
+                    "event_type",
+                    "push")
+    }
+
+  end
+end


### PR DESCRIPTION
This adds a `branch_name` to the request payload.

It has been tested locally and on staging. 
All tests passing on Travis-CI.