### PR TITLE
add error rescue for cron start method

### DIFF
--- a/lib/travis/api/v3/queries/crons.rb
+++ b/lib/travis/api/v3/queries/crons.rb
@@ -30,6 +30,8 @@ module Travis::API::V3
       class_name, queue = Query.sidekiq_queue(:build_request)
       ::Sidekiq::Client.push('queue'.freeze => queue, 'class'.freeze => class_name, 'args'.freeze => [{type: 'cron'.freeze, payload: JSON.dump(payload), credentials: {}}])
       true
+    rescue => e
+      puts e.message, e.backtrace
     end
   end
 end


### PR DESCRIPTION
There's an issue where any error in the `start` method is not rescued, and will bubble up to the `start_all` method, causing all subsequent crons to be aborted.

This change has been deployed to staging and everything seems to be working.

