### PR TITLE
Rename current_build sort to current_build_id

### DIFF
--- a/lib/travis/api/v3/queries/repositories.rb
+++ b/lib/travis/api/v3/queries/repositories.rb
@@ -4,7 +4,7 @@ module Travis::API::V3
     sortable_by :id, :github_id, :owner_name, :name, active: sort_condition(:active), :'default_branch.last_build' => 'builds.started_at'
     sortable_by :id, :github_id, :owner_name, :name, active: sort_condition(:active),
                 :'default_branch.last_build' => 'builds.started_at',
-                :current_build => "repositories.current_build_id %{order} NULLS LAST"
+                :current_build_id => "repositories.current_build_id %{order} NULLS LAST"
 
     def for_member(user, **options)
       all(user: user, **options).joins(:users).where(users: user_condition(user), invalidated_at: nil)


### PR DESCRIPTION
This a quick workaround for sorting by current_build. When the field
that we use to sort is the same as one of the associations name API V3
will try to join the association. So in this case it will try to join
:current_build, which fails. This needs a better solution, but I want to
get this working for now.