### PR TITLE
Add settings to API V3

### DIFF
--- a/lib/travis/api/v3/access_control/generic.rb
+++ b/lib/travis/api/v3/access_control/generic.rb
@@ -92,6 +92,10 @@ module Travis::API::V3
       private_repository_visible?(repository)
     end
 
+    def settings_visible?(settings)
+      repository_visible?(settings.repository)
+    end
+
     def private_repository_visible?(repository)
       false
     end

--- a/lib/travis/api/v3/models/settings.rb
+++ b/lib/travis/api/v3/models/settings.rb
@@ -11,8 +11,10 @@ module Travis::API::V3
     end
 
     def update(settings = {})
-      settings = defaults.merge(settings)
-      repository.update_attributes(settings: JSON.generate(settings))
+      settings = to_h.merge(settings)
+      repository.settings.clear
+      settings.each { |k, v| repository.settings[k] = v }
+      repository.save!
     end
 
     private

--- a/lib/travis/api/v3/models/settings.rb
+++ b/lib/travis/api/v3/models/settings.rb
@@ -1,5 +1,12 @@
 module Travis::API::V3
   class Models::Settings
+    DEFAULTS = {
+      'builds_only_with_travis_yml' => false,
+      'build_pushes' => true,
+      'build_pull_requests' => true,
+      'maximum_number_of_builds' => 0
+    }.freeze
+
     attr_reader :repository
 
     def initialize(repository)
@@ -7,7 +14,7 @@ module Travis::API::V3
     end
 
     def to_h
-      defaults.merge(repository.settings || {})
+      DEFAULTS.merge(repository.settings || {})
     end
 
     def update(settings = {})
@@ -16,16 +23,5 @@ module Travis::API::V3
       settings.each { |k, v| repository.settings[k] = v }
       repository.save!
     end
-
-    private
-
-      def defaults
-        {
-          'builds_only_with_travis_yml' => false,
-          'build_pushes' => true,
-          'build_pull_requests' => true,
-          'maximum_number_of_builds' => 0
-        }
-      end
   end
 end

--- a/lib/travis/api/v3/models/settings.rb
+++ b/lib/travis/api/v3/models/settings.rb
@@ -1,0 +1,29 @@
+module Travis::API::V3
+  class Models::Settings
+    attr_reader :repository
+
+    def initialize(repository)
+      @repository = repository
+    end
+
+    def to_h
+      defaults.merge(repository.settings || {})
+    end
+
+    def update(settings = {})
+      settings = defaults.merge(settings)
+      repository.update_attributes(settings: JSON.generate(settings))
+    end
+
+    private
+
+      def defaults
+        {
+          'builds_only_with_travis_yml' => false,
+          'build_pushes' => true,
+          'build_pull_requests' => true,
+          'maximum_number_of_builds' => 0
+        }
+      end
+  end
+end

--- a/lib/travis/api/v3/queries/settings.rb
+++ b/lib/travis/api/v3/queries/settings.rb
@@ -1,0 +1,15 @@
+module Travis::API::V3
+  class Queries::Settings < Query
+    params :builds_only_with_travis_yml, :build_pushes, :build_pull_requests, :maximum_number_of_builds, prefix: :settings
+
+    def find(repository)
+      Models::Settings.new(repository)
+    end
+
+    def update(repository)
+      settings = find(repository)
+      settings.update(settings_params)
+      settings
+    end
+  end
+end

--- a/lib/travis/api/v3/query.rb
+++ b/lib/travis/api/v3/query.rb
@@ -32,6 +32,15 @@ module Travis::API::V3
       end
     RUBY
 
+    @@prefixed_params_accessor = <<-RUBY
+      def %<prefix>s_params
+        @%<prefix>s ||= begin
+          params = @params.select { |key, _| key.start_with?('%<prefix>s.'.freeze) }
+          Hash[params.map { |key, value| [key.split('.'.freeze).last, value] }]
+        end
+      end
+    RUBY
+
     def self.type
       name[/[^:]+$/].underscore
     end
@@ -48,6 +57,7 @@ module Travis::API::V3
           check_type:  check_type
         })
       end
+      class_eval(@@prefixed_params_accessor % { prefix: prefix })
     end
 
     def self.prefix(input)

--- a/lib/travis/api/v3/renderer/settings.rb
+++ b/lib/travis/api/v3/renderer/settings.rb
@@ -9,8 +9,7 @@ module Travis::API::V3
     end
 
     def render(settings, **)
-      response = { '@type' => 'settings'.freeze }
-      response.merge(settings.to_h)
+      { '@type' => 'settings'.freeze }.merge!(settings.to_h)
     end
   end
 end

--- a/lib/travis/api/v3/renderer/settings.rb
+++ b/lib/travis/api/v3/renderer/settings.rb
@@ -1,0 +1,18 @@
+module Travis::API::V3
+  module Renderer::Settings
+    extend self
+
+    AVAILABLE_ATTRIBUTES = [:settings]
+
+    def available_attributes
+      AVAILABLE_ATTRIBUTES 
+    end
+
+    def render(settings, **)
+      {
+        :@type => 'settings'.freeze,
+        :settings => settings.to_h
+      }
+    end
+  end
+end

--- a/lib/travis/api/v3/renderer/settings.rb
+++ b/lib/travis/api/v3/renderer/settings.rb
@@ -9,10 +9,8 @@ module Travis::API::V3
     end
 
     def render(settings, **)
-      {
-        :@type => 'settings'.freeze,
-        :settings => settings.to_h
-      }
+      response = { '@type' => 'settings'.freeze }
+      response.merge(settings.to_h)
     end
   end
 end

--- a/lib/travis/api/v3/routes.rb
+++ b/lib/travis/api/v3/routes.rb
@@ -117,6 +117,12 @@ module Travis::API::V3
         get  :find
         post :create
       end
+
+      resource :settings do
+        route '/settings'
+        get   :find
+        patch :update
+      end
     end
 
     resource :user do

--- a/lib/travis/api/v3/routes/dsl.rb
+++ b/lib/travis/api/v3/routes/dsl.rb
@@ -60,6 +60,10 @@ module Travis::API::V3
       current_resource.add_service('POST'.freeze, *args)
     end
 
+    def patch(*args)
+      current_resource.add_service('PATCH'.freeze, *args)
+    end
+
     def delete(*args)
       current_resource.add_service('DELETE'.freeze, *args)
     end

--- a/lib/travis/api/v3/services.rb
+++ b/lib/travis/api/v3/services.rb
@@ -20,6 +20,7 @@ module Travis::API::V3
     Repositories  = Module.new { extend Services }
     Repository    = Module.new { extend Services }
     Requests      = Module.new { extend Services }
+    Settings      = Module.new { extend Services }
     User          = Module.new { extend Services }
 
     def result_type

--- a/lib/travis/api/v3/services/settings/find.rb
+++ b/lib/travis/api/v3/services/settings/find.rb
@@ -1,0 +1,9 @@
+module Travis::API::V3
+  class Services::Settings::Find < Service
+    def run!
+      raise LoginRequired unless access_control.logged_in? or access_control.full_access?
+      raise NotFound      unless repo = find(:repository)
+      find(:settings, repo)
+    end
+  end
+end

--- a/lib/travis/api/v3/services/settings/update.rb
+++ b/lib/travis/api/v3/services/settings/update.rb
@@ -1,0 +1,11 @@
+module Travis::API::V3
+  class Services::Settings::Update < Service
+    params :builds_only_with_travis_yml, :build_pushes, :build_pull_requests, :maximum_number_of_builds, prefix: :settings
+
+    def run!
+      raise LoginRequired unless access_control.logged_in? or access_control.full_access?
+      raise NotFound unless repository = find(:repository)
+      query.update(repository)
+    end
+  end
+end

--- a/spec/v3/services/settings_spec.rb
+++ b/spec/v3/services/settings_spec.rb
@@ -1,0 +1,127 @@
+require 'spec_helper'
+
+describe Travis::API::V3::Services::Settings do
+  let(:repo)  { Travis::API::V3::Models::Repository.where(owner_name: 'svenfuchs', name: 'minimal').first_or_create }
+  let(:token) { Travis::Api::App::AccessToken.create(user: repo.owner, app_id: 1) }
+  let(:auth_headers) { { 'HTTP_AUTHORIZATION' => "token #{token}" } }
+  let(:json_headers) { { 'CONTENT_TYPE' => 'application/json' } }
+
+  describe :Find do
+    describe 'not authenticated' do
+      before { get("/v3/repo/#{repo.id}/settings") }
+      example { expect(last_response.status).to eq(403) }
+      example do
+        expect(JSON.load(body)).to eq(
+          '@type' => 'error',
+          'error_type' => 'login_required',
+          'error_message' => 'login required'
+        )
+      end
+    end
+
+    describe 'authenticated, missing repo' do
+      before { get('/v3/repo/9999999999/settings', {}, auth_headers) }
+
+      example { expect(last_response.status).to eq(404) }
+      example do
+        expect(JSON.load(body)).to eq(
+          '@type' => 'error',
+          'error_type' => 'not_found',
+          'error_message' => 'repository not found (or insufficient access)',
+          'resource_type' => 'repository'
+        )
+      end
+    end
+
+    describe 'authenticated, existing repo, repo has no settings' do
+      before { get("/v3/repo/#{repo.id}/settings", {}, auth_headers) }
+
+      example { expect(last_response.status).to eq(200) }
+      example do
+        expect(JSON.load(body)).to eq(
+          '@type' => 'settings',
+          'settings' => {
+            'builds_only_with_travis_yml' => false,
+            'build_pushes' => true,
+            'build_pull_requests' => true,
+            'maximum_number_of_builds' => 0
+          }
+        )
+      end 
+    end
+
+    describe 'authenticated, existing repo, repo has some settings' do
+      before do
+        repo.update_attributes(settings: JSON.dump('build_pushes' => false))
+        get("/v3/repo/#{repo.id}/settings", {}, auth_headers)
+      end
+
+      example { expect(last_response.status).to eq(200) }
+      example do
+        expect(JSON.load(body)).to eq(
+          '@type' => 'settings',
+          'settings' => {
+            'builds_only_with_travis_yml' => false,
+            'build_pushes' => false,
+            'build_pull_requests' => true,
+            'maximum_number_of_builds' => 0
+          }
+        )
+      end 
+    end
+  end
+
+  describe :Update do
+    describe 'not authenticated' do
+      before do
+        patch("/v3/repo/#{repo.id}/settings", JSON.dump(build_pushes: false), json_headers)
+      end
+
+      example { expect(last_response.status).to eq(403) }
+      example do
+        expect(JSON.load(body)).to eq(
+          '@type' => 'error',
+          'error_type' => 'login_required',
+          'error_message' => 'login required'
+        )
+      end
+    end
+
+    describe 'authenticated, missing repo' do
+      before do
+        patch('/v3/repo/9999999999/settings', JSON.dump(build_pushes: false), json_headers.merge(auth_headers))
+      end
+
+      example { expect(last_response.status).to eq(404) }
+      example do
+        expect(JSON.load(body)).to eq(
+          '@type' => 'error',
+          'error_type' => 'not_found',
+          'error_message' => 'repository not found (or insufficient access)',
+          'resource_type' => 'repository'
+        )
+      end
+    end
+
+    describe 'authenticated, existing repo' do
+      let(:params) { JSON.dump('settings.build_pushes' => false) }
+
+      before do
+        patch("/v3/repo/#{repo.id}/settings", params, json_headers.merge(auth_headers))
+      end
+
+      example { expect(last_response.status).to eq(200) }
+      example do
+        expect(JSON.load(body)).to eq(
+          '@type' => 'settings',
+          'settings' => {
+            'builds_only_with_travis_yml' => false,
+            'build_pushes' => false,
+            'build_pull_requests' => true,
+            'maximum_number_of_builds' => 0
+          }
+        )
+      end 
+    end
+  end
+end

--- a/spec/v3/services/settings_spec.rb
+++ b/spec/v3/services/settings_spec.rb
@@ -107,6 +107,7 @@ describe Travis::API::V3::Services::Settings do
       let(:params) { JSON.dump('settings.build_pushes' => false) }
 
       before do
+        repo.update_attributes(settings: JSON.dump('maximum_number_of_builds' => 20))
         patch("/v3/repo/#{repo.id}/settings", params, json_headers.merge(auth_headers))
       end
 
@@ -118,7 +119,7 @@ describe Travis::API::V3::Services::Settings do
             'builds_only_with_travis_yml' => false,
             'build_pushes' => false,
             'build_pull_requests' => true,
-            'maximum_number_of_builds' => 0
+            'maximum_number_of_builds' => 20
           }
         )
       end 

--- a/spec/v3/services/settings_spec.rb
+++ b/spec/v3/services/settings_spec.rb
@@ -40,12 +40,10 @@ describe Travis::API::V3::Services::Settings do
       example do
         expect(JSON.load(body)).to eq(
           '@type' => 'settings',
-          'settings' => {
-            'builds_only_with_travis_yml' => false,
-            'build_pushes' => true,
-            'build_pull_requests' => true,
-            'maximum_number_of_builds' => 0
-          }
+          'builds_only_with_travis_yml' => false,
+          'build_pushes' => true,
+          'build_pull_requests' => true,
+          'maximum_number_of_builds' => 0
         )
       end 
     end
@@ -60,12 +58,10 @@ describe Travis::API::V3::Services::Settings do
       example do
         expect(JSON.load(body)).to eq(
           '@type' => 'settings',
-          'settings' => {
-            'builds_only_with_travis_yml' => false,
-            'build_pushes' => false,
-            'build_pull_requests' => true,
-            'maximum_number_of_builds' => 0
-          }
+          'builds_only_with_travis_yml' => false,
+          'build_pushes' => false,
+          'build_pull_requests' => true,
+          'maximum_number_of_builds' => 0
         )
       end 
     end
@@ -115,12 +111,10 @@ describe Travis::API::V3::Services::Settings do
       example do
         expect(JSON.load(body)).to eq(
           '@type' => 'settings',
-          'settings' => {
-            'builds_only_with_travis_yml' => false,
-            'build_pushes' => false,
-            'build_pull_requests' => true,
-            'maximum_number_of_builds' => 20
-          }
+          'builds_only_with_travis_yml' => false,
+          'build_pushes' => false,
+          'build_pull_requests' => true,
+          'maximum_number_of_builds' => 20
         )
       end 
     end


### PR DESCRIPTION
This adds `/repo/{repository.id}/settings` endpoints for reading
and updating repo settings.

Main points:

1. Sets up Settings as a first class resource instead of as an
   attribute of Repository
2. Adds new meta-programmed method to Query for accessing all
   prefixed params as a hash.