### PR TITLE
More `current_build` work

### DIFF
--- a/lib/travis/api/v3/queries/repositories.rb
+++ b/lib/travis/api/v3/queries/repositories.rb
@@ -3,7 +3,14 @@ module Travis::API::V3
     params :active, :private, :starred, prefix: :repository
     sortable_by :id, :github_id, :owner_name, :name, active: sort_condition(:active),
                 :'default_branch.last_build' => 'builds.started_at',
-                :current_build_id => "repositories.current_build_id %{order} NULLS LAST"
+                :current_build => "repositories.current_build_id %{order} NULLS LAST"
+
+    # this is a hack for a bug in AR that generates invalid query when it tries
+    # to include `current_build` and join it at the same time. We don't actually
+    # need the join, but it will be automatically added, because `current_build`
+    # is an association. This prevents adding the join. We will probably be able
+    # to remove it once we move to newer AR versions
+    prevent_sortable_join :current_build
 
     def for_member(user, **options)
       all(user: user, **options).joins(:users).where(users: user_condition(user), invalidated_at: nil)

--- a/lib/travis/api/v3/queries/repositories.rb
+++ b/lib/travis/api/v3/queries/repositories.rb
@@ -11,6 +11,7 @@ module Travis::API::V3
     # is an association. This prevents adding the join. We will probably be able
     # to remove it once we move to newer AR versions
     prevent_sortable_join :current_build
+    experimental_sortable_by :current_build
 
     def for_member(user, **options)
       all(user: user, **options).joins(:users).where(users: user_condition(user), invalidated_at: nil)
@@ -44,7 +45,7 @@ module Travis::API::V3
       end
 
       list = list.includes(default_branch: :last_build)
-      list = list.includes(:current_build)
+      list = list.includes(:current_build) if includes? 'repository.current_build'.freeze
       list = list.includes(default_branch: { last_build: :commit }) if includes? 'build.commit'.freeze
       sort list
     end

--- a/lib/travis/api/v3/query.rb
+++ b/lib/travis/api/v3/query.rb
@@ -79,6 +79,17 @@ module Travis::API::V3
       @dont_join ||= superclass.dont_join.dup
     end
 
+    @experimental_sortable_by = []
+    def self.experimental_sortable_by(*fields)
+      @experimental_sortable_by ||= []
+
+      if fields.first
+        @experimental_sortable_by.push(*fields.map(&:to_s))
+      end
+
+      @experimental_sortable_by
+    end
+
     def self.sort_condition(condition)
       if condition.is_a? Hash
         condition = condition.map { |e| e.map { |v| prefix(v) }.join(" = ".freeze) }.join(" and ".freeze)

--- a/lib/travis/api/v3/query.rb
+++ b/lib/travis/api/v3/query.rb
@@ -70,6 +70,15 @@ module Travis::API::V3
       mapping.each { |key, value| sort_by[key.to_s]   = prefix(value) }
     end
 
+    def self.prevent_sortable_join(*fields)
+      dont_join.push(*fields.map(&:to_s))
+    end
+
+    @dont_join = []
+    def self.dont_join
+      @dont_join ||= superclass.dont_join.dup
+    end
+
     def self.sort_condition(condition)
       if condition.is_a? Hash
         condition = condition.map { |e| e.map { |v| prefix(v) }.join(" = ".freeze) }.join(" and ".freeze)
@@ -172,6 +181,7 @@ module Travis::API::V3
     end
 
     def sort_join?(collection, field)
+      return if self.class.dont_join.include?(field)
       !collection.reflect_on_association(field.to_sym).nil?
     end
 

--- a/lib/travis/api/v3/renderer/model_renderer.rb
+++ b/lib/travis/api/v3/renderer/model_renderer.rb
@@ -26,6 +26,17 @@ module Travis::API::V3
       @representations ||= superclass.representations.dup
     end
 
+    @experimental_representations = []
+    def self.experimental_representations(*representations)
+      @experimental_representations ||= superclass.experimental_representations.dup
+
+      if representations.first
+        @experimental_representations.push(*representations)
+      end
+
+      @experimental_representations
+    end
+
     @available_attributes = Set.new
     def self.available_attributes
       @available_attributes ||= superclass.available_attributes.dup

--- a/lib/travis/api/v3/renderer/repository.rb
+++ b/lib/travis/api/v3/renderer/repository.rb
@@ -3,7 +3,10 @@ require 'travis/api/v3/renderer/model_renderer'
 module Travis::API::V3
   class Renderer::Repository < Renderer::ModelRenderer
     representation(:minimal,  :id, :name, :slug)
-    representation(:standard, :id, :name, :slug, :description, :github_language, :active, :private, :owner, :default_branch, :starred, :current_build)
+    representation(:standard, :id, :name, :slug, :description, :github_language, :active, :private, :owner, :default_branch, :starred)
+    representation(:experimental, :id, :name, :slug, :description, :github_language, :active, :private, :owner, :default_branch, :starred, :current_build)
+
+    experimental_representations(:experimental)
 
     def active
       !!model.active

--- a/spec/v3/services/owner/find_spec.rb
+++ b/spec/v3/services/owner/find_spec.rb
@@ -79,8 +79,7 @@ describe Travis::API::V3::Services::Owner::Find, set_app: true do
             "@href"           => "/v3/repo/#{repo.id}/branch/master",
             "@representation" => "minimal",
             "name"            => "master"},
-          "starred"           => false,
-          "current_build"     => nil
+          "starred"           => false
         }]
       }}
     end
@@ -128,8 +127,7 @@ describe Travis::API::V3::Services::Owner::Find, set_app: true do
             "@href"         => "/v3/repo/#{repo.id}/branch/master",
             "@representation"=> "minimal",
             "name"          => "master"},
-          "starred"         => false,
-          "current_build"   => nil
+          "starred"         => false
         }]
       }}
     end

--- a/spec/v3/services/repositories/for_current_user_spec.rb
+++ b/spec/v3/services/repositories/for_current_user_spec.rb
@@ -2,7 +2,6 @@ describe Travis::API::V3::Services::Repositories::ForCurrentUser, set_app: true 
   let(:repo)  { Travis::API::V3::Models::Repository.where(owner_name: 'svenfuchs', name: 'minimal').first }
   let(:build) { repo.builds.first }
   let(:jobs)  { Travis::API::V3::Models::Build.find(build.id).jobs }
-  let(:current_build) { repo.builds.first }
 
   let(:token)   { Travis::Api::App::AccessToken.create(user: repo.owner, app_id: 1)             }
   let(:headers) {{ 'HTTP_AUTHORIZATION' => "token #{token}"                                    }}
@@ -11,7 +10,6 @@ describe Travis::API::V3::Services::Repositories::ForCurrentUser, set_app: true 
   after         { repo.update_attribute(:private, false)                                        }
 
   describe "private repository, private API, authenticated as user with access" do
-    before  { repo.update_attribute(:current_build_id, current_build.id) }
     before  { get("/v3/repos", {}, headers)    }
     example { expect(last_response).to be_ok   }
     example { expect(JSON.load(body)).to be == {
@@ -64,18 +62,6 @@ describe Travis::API::V3::Services::Repositories::ForCurrentUser, set_app: true 
           "@representation"  => "minimal",
           "name"             => "master"},
         "starred"            => false,
-        "current_build"      => {
-          "@type"            => "build",
-          "@href"            => "/v3/build/#{current_build.id}",
-          "@representation"  => "minimal",
-          "id"               => current_build.id.to_i,
-          "number"           => current_build.number,
-          "state"            => current_build.state,
-          "duration"         => current_build.duration,
-          "event_type"       => current_build.event_type,
-          "previous_state"   => current_build.previous_state,
-          "started_at"       => current_build.started_at.strftime("%Y-%m-%dT%H:%M:%SZ"),
-          "finished_at"      => nil},
         }]
     }}
   end

--- a/spec/v3/services/repositories/for_owner_spec.rb
+++ b/spec/v3/services/repositories/for_owner_spec.rb
@@ -63,7 +63,6 @@ describe Travis::API::V3::Services::Repositories::ForOwner, set_app: true do
           "@representation"  => "minimal",
           "name"             => "master"},
           "starred"          => false,
-          "current_build"    => nil
         }]}}
   end
 
@@ -140,8 +139,7 @@ describe Travis::API::V3::Services::Repositories::ForOwner, set_app: true do
           "@href"         => "/v3/repo/1/branch/master",
           "@representation"=>"minimal",
           "name"          => "master" },
-        "starred"         => false,
-        "current_build"   => nil }, {
+        "starred"         => false }, {
         "@type"           => "repository",
         "@href"           => "/v3/repo/#{repo2.id}",
         "@representation" => "standard",
@@ -170,7 +168,6 @@ describe Travis::API::V3::Services::Repositories::ForOwner, set_app: true do
           "@href"         => "/v3/repo/#{repo2.id}/branch/master",
           "@representation"=>"minimal",
           "name"           =>"master" },
-          "starred"        => false,
-          "current_build"  => nil}]}
+          "starred"        => false}]}
   end
 end

--- a/spec/v3/services/repository/find_spec.rb
+++ b/spec/v3/services/repository/find_spec.rb
@@ -54,7 +54,6 @@ describe Travis::API::V3::Services::Repository::Find, set_app: true do
         "@representation"  => "minimal",
         "name"             => "master"},
       "starred"            => false,
-      "current_build"      => nil
     }}
   end
 
@@ -133,7 +132,6 @@ describe Travis::API::V3::Services::Repository::Find, set_app: true do
         "@representation"  => "minimal",
         "name"             => "master"},
       "starred"            => false,
-      "current_build"      => nil
     }}
   end
 
@@ -197,7 +195,6 @@ describe Travis::API::V3::Services::Repository::Find, set_app: true do
         "@representation"  => "minimal",
         "name"             => "master"},
       "starred"            => false,
-      "current_build"      => nil
     }}
   end
 
@@ -267,7 +264,6 @@ describe Travis::API::V3::Services::Repository::Find, set_app: true do
         "@representation"  => "minimal",
         "name"             => "master"},
       "starred"            => false,
-      "current_build"      => nil
     }}
   end
 


### PR DESCRIPTION
After talking with @rkh about changes in API we decided that it would be best to somehow mark `current_build` as experimental. This PR is a rough first try to do it and I'm submitting it for discussion. At the moment I'm just hiding all the things that are marked as experimental, but after thinking about this more I'm not sure that's the best way, because if we ever decide to write a client that would use index page, there would be no way to use experimental features.

Another way would be to either mark them experimental in the index or make it possible to fetch "regular" index and "experimental" index. I'm not really sure what would be best here.

Another thing is that there're no tests for most of the things added here. I could add tests for it in `spec/v3/service_index_spec.rb`, but there's a broader problem here. In API we deal with 2 kinds of code - a "framework" code and application code. Technically we're using Sinatra as a framework, but I would call all of the code that's not a business logic "framework" as well. So for example `Travis::API::V3::Queries::Repositories` is application code, but `Travis::API::V3::Query` is framework code. At the moment we don't have any way to test most of the framework code, which leads to a style of development that I don't really like. Typically I would first add a feature to "framework code" and test it separately from the business logic and then I'd use it where I need it. Currently, however, the only way of testing framework code is to use it in application code and test the result. This has many drawbacks, but one of the biggest drawbacks is that if we ever need to remove some parts of the application code, we may loose tests for framework code.

For example I added `experimental_representations` method to renderer and used it in `Repository` renderer. Now I can test it by checking if the output of index is correct for repositories. When at some point we decide to remove experimental representation from repository the tests will break and we will need to remove them essentially removing any tests for `experimental_representations`. One can argue that we should write tests for index page every time we use methods as `experimental_representations`, but I'd say that's just extra work with not much gains. If `experimental_representations` method was tested separately from application code, I wouldn't even add tests for actual index.

For now I can add a test for actual index, but I wanted to bring this up and see if others have similar feelings and maybe if there're plans to change test suite to make "framework code" easier to test.