### PR TITLE
safelist build status image requests coming from github

### DIFF
--- a/lib/travis/api/attack.rb
+++ b/lib/travis/api/attack.rb
@@ -25,7 +25,7 @@ class Rack::Attack
     end
   end
 
-  POST_WHITELISTED = [
+  POST_SAFELIST = [
     "/auth/handshake",
     "/auth/post_message",
     "/auth/post_message/iframe"
@@ -61,7 +61,7 @@ class Rack::Attack
   # Ban after:    10 POST requests within 30 seconds
   blacklist('spamming with POST requests') do |request|
     Rack::Attack::Allow2Ban.filter(request.identifier, maxretry: 10, findtime: 30.seconds, bantime: bantime(1.hour)) do
-      request.post? and not POST_WHITELISTED.include? request.path
+      request.post? and not POST_SAFELIST.include? request.path
     end
   end
 

--- a/lib/travis/api/attack.rb
+++ b/lib/travis/api/attack.rb
@@ -31,10 +31,16 @@ class Rack::Attack
     "/auth/post_message/iframe"
   ]
 
+  IMAGE_PATTERN = /^\/([a-z0-9_-]+)\/([a-z0-9_-]+)\.(png|svg)$/
+
   ####
   # Whitelisted IP addresses
   whitelist('whitelist client requesting from redis') do |request|
     Travis.redis.sismember(:api_whitelisted_ips, request.ip)
+  end
+
+  whitelist('safelist build status images when requested by github') do |request|
+    request.user_agent and request.user_agent.start_with?('github-camo') and IMAGE_PATTERN.match(request.path)
   end
 
   ####


### PR DESCRIPTION
Currently almost all calls against API are being rate limited, including build status images. This leads to common requesters such as GitHub's camo proxy to get rate limited and receive a 429 response code.

This patch attempts to allow those requests.