### PR TITLE
no longer test against user agent for github rate-limit, since it is not consistently github-camo

### DIFF
--- a/lib/travis/api/attack.rb
+++ b/lib/travis/api/attack.rb
@@ -31,16 +31,14 @@ class Rack::Attack
     "/auth/post_message/iframe"
   ]
 
-  IMAGE_PATTERN = /^\/([a-z0-9_-]+)\/([a-z0-9_-]+)\.(png|svg)$/
+  whitelist('safelist build status images') do |request|
+    /\.(png|svg)$/.match(request.path)
+  end
 
   ####
   # Whitelisted IP addresses
   whitelist('whitelist client requesting from redis') do |request|
     Travis.redis.sismember(:api_whitelisted_ips, request.ip)
-  end
-
-  whitelist('safelist build status images when requested by github') do |request|
-    request.user_agent and request.user_agent.start_with?('github-camo') and IMAGE_PATTERN.match(request.path)
   end
 
   ####

--- a/spec/unit/attack_spec.rb
+++ b/spec/unit/attack_spec.rb
@@ -1,0 +1,23 @@
+describe Rack::Attack do
+  describe 'image request' do
+    let(:request) {
+      env = Rack::MockRequest.env_for("https://api-test.travis-ci.org/travis-ci/travis-github-sync.png")
+      Rack::Attack::Request.new(env)
+    }
+
+    it 'should be safelisted' do
+      expect(Rack::Attack.whitelisted?(request)).to be_truthy
+    end
+  end
+
+  describe 'non-image API request' do
+    let(:request) {
+      env = Rack::MockRequest.env_for("https://api-test.travis-ci.org/repos/rails/rails/branches")
+      Rack::Attack::Request.new(env)
+    }
+
+    it 'should not be safelisted' do
+      expect(Rack::Attack.whitelisted?(request)).to be_falsy
+    end
+  end
+end


### PR DESCRIPTION
@renee-travisci and myself finally tracked this down.

We were getting 429 responses on GitHub. Upon further investigation, we determined that while some of the GitHub proxy requests have a `github-camo` user agent, this was not always the case. Some of them also had a user agent of `Go-http-client/1.1`, most likely an alternative to camo that github is testing.

By relaxing the restrictions on rate-limiting to always allow requests to build images, this should get rid of those 429 responses for good.