### PR TITLE
Add deprecation notice to Event.notify() that writes to log

### DIFF
--- a/vendor/travis-core/lib/travis/event.rb
+++ b/vendor/travis-core/lib/travis/event.rb
@@ -43,6 +43,7 @@ module Travis
     end
 
     def notify(event, *args)
+      Travis.logger.info("DEPRECATED: Event.notify used: event=#{event}, args=#{args}")
       Travis::Event.dispatch(client_event(event, self), self, *args)
     end
 


### PR DESCRIPTION
As discussed with @svenfuchs /cc @aakritigupta @anarosas 