### PR TITLE
Don't run Rack::Attack for Enterprise

### DIFF
--- a/lib/travis/api/app.rb
+++ b/lib/travis/api/app.rb
@@ -132,7 +132,7 @@ module Travis::Api
         use Travis::Api::App::Middleware::UserAgentTracker
 
         # make sure this is below ScopeCheck so we have the token
-        use Rack::Attack if Endpoint.production?
+        use Rack::Attack if Endpoint.production? and not Travis.config.enterprise
 
         # if this is a v3 API request, ignore everything after
         use Travis::API::V3::OptIn


### PR DESCRIPTION
On enterprise, the reverse proxy is not correctly set up, and therefore the client IP address not passed through properly. For that reason, all requests look like they originate from the same client, and if one gets blocked, everyone gets blocked.