### PR TITLE
[Backport] Don't run Rack::Attack for Enterprise.

### DIFF
--- a/lib/travis/api/app.rb
+++ b/lib/travis/api/app.rb
@@ -129,7 +129,7 @@ module Travis::Api
         use Travis::Api::App::Middleware::UserAgentTracker
 
         # make sure this is below ScopeCheck so we have the token
-        use Rack::Attack if Endpoint.production?
+        use Rack::Attack if Endpoint.production? and not Travis.config.enterprise
 
         # if this is a v3 API request, ignore everything after
         use Travis::API::V3::OptIn


### PR DESCRIPTION
This PR Backports https://github.com/travis-ci/travis-api/pull/287 for Enterprise. 

/cc @rkh as the original author. 