### PR TITLE
Fix Repo count

### DIFF
--- a/vendor/travis-core/lib/travis/model/repository.rb
+++ b/vendor/travis-core/lib/travis/model/repository.rb
@@ -93,7 +93,7 @@ class Repository < Travis::Model
     end
 
     def counts_by_owner_names(owner_names)
-      query = %(SELECT owner_name, count(*) FROM repositories WHERE owner_name IN (?) AND invalidated_at IS NULL GROUP BY owner_name)
+      query = %(SELECT owner_name, count(*) FROM repositories WHERE owner_name IN (?) AND invalidated_at IS NULL AND active = 't' GROUP BY owner_name)
       query = sanitize_sql([query, owner_names])
       rows = connection.select_all(query, owner_names)
       Hash[*rows.map { |row| [row['owner_name'], row['count'].to_i] }.flatten]


### PR DESCRIPTION
@svenfuchs do you know how the active column is populated? Is this correct logic for the count? 

  If not, we could also do a self join to the table to filter out repos that were deleted and have come back, but we might need to add some tricky date logic about when they were invalidated.... I'm not sure. I tried that here and it worked, but this is not an optimized query:
``` ruby
query = %(SELECT repo1.owner_name, count(DISTINCT(repo1.name)) FROM repositories repo1, repositories repo2  WHERE repo1.owner_name IN (?) AND repo2.owner_name IN (?) AND repo1.invalidated_at IS NULL AND repo2.invalidated_at IS NOT NULL AND repo1.name <> repo2.name GROUP BY repo1.owner_name)
```