### PR TITLE
Fix Time Dependent Tests

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -62,3 +62,12 @@ RSpec.configure do |c|
     end
   end
 end
+
+require 'timecop'
+Timecop.freeze(Time.now.utc)
+
+describe Time do
+  let(:time) { Time.now.utc }
+  example { expect(Time.now.utc).to eq(time) }
+  example { expect(Time.now.utc + 5.minutes ).to eq(time + 5.minutes) }
+end

--- a/spec/unit/serialize/v2/http/jobs_spec.rb
+++ b/spec/unit/serialize/v2/http/jobs_spec.rb
@@ -2,6 +2,7 @@ describe Travis::Api::Serialize::V2::Http::Jobs do
   include Travis::Testing::Stubs, Support::Formats
 
   let(:data) { described_class.new([test]).data }
+  let!(:time) { Time.now.utc }
 
   it 'jobs' do
     data['jobs'].first.should == {
@@ -13,8 +14,8 @@ describe Travis::Api::Serialize::V2::Http::Jobs do
       'log_id' => 1,
       'number' => '2.1',
       'state' => 'passed',
-      'started_at' => json_format_time(Time.now.utc - 1.minute),
-      'finished_at' => json_format_time(Time.now.utc),
+      'started_at' => json_format_time(time - 1.minute),
+      'finished_at' => json_format_time(time),
       'config' => { 'rvm' => '1.8.7', 'gemfile' => 'test/Gemfile.rails-2.3.x' },
       'queue' => 'builds.linux',
       'allow_failure' => false,
@@ -28,7 +29,7 @@ describe Travis::Api::Serialize::V2::Http::Jobs do
       'sha' => '62aae5f70ceee39123ef',
       'branch' => 'master',
       'message' => 'the commit message',
-      'committed_at' => json_format_time(Time.now.utc - 1.hour),
+      'committed_at' => json_format_time(time - 1.hour),
       'committer_name' => 'Sven Fuchs',
       'committer_email' => 'svenfuchs@artweb-design.de',
       'author_name' => 'Sven Fuchs',
@@ -50,4 +51,3 @@ describe Travis::Api::Serialize::V2::Http::Jobs, 'using Travis::Services::Jobs::
     lambda { data }.should issue_queries(4)
   end
 end
-

--- a/spec/v3/models/cron_spec.rb
+++ b/spec/v3/models/cron_spec.rb
@@ -1,5 +1,3 @@
-require 'timecop'
-
 describe Travis::API::V3::Models::Cron do
   let(:repo) { Travis::API::V3::Models::Repository.where(owner_name: 'svenfuchs', name: 'minimal').first }
   let(:branch) { Travis::API::V3::Models::Branch.create(repository: repo, name: 'cron test') }

--- a/spec/v3/models/cron_spec.rb
+++ b/spec/v3/models/cron_spec.rb
@@ -7,11 +7,13 @@ describe Travis::API::V3::Models::Cron do
   describe "next build time is calculated correctly on year changes" do
 
     before do
+      Timecop.return
       Timecop.travel(DateTime.new(2015, 12, 31, 16))
     end
 
     after do
       Timecop.return
+      Timecop.freeze(Time.now.utc)
     end
 
     it "for daily builds" do


### PR DESCRIPTION
builds occasionally fail when the timestamps are a second off, this should fix that. 