### PR TITLE
Use `HEROKU_SLUG_COMMIT` instead of last-commit-sha-buildpack

### DIFF
--- a/.buildpacks
+++ b/.buildpacks
@@ -1,3 +1,2 @@
 https://github.com/heroku/heroku-buildpack-ruby.git
-https://github.com/drogus/last-commit-sha-buildpack.git
 https://github.com/ryandotsmith/nginx-buildpack.git

--- a/lib/travis/api/app.rb
+++ b/lib/travis/api/app.rb
@@ -26,6 +26,7 @@ require 'metriks/reporter/logger'
 require 'metriks/librato_metrics_reporter'
 require 'travis/support/log_subscriber/active_record_metrics'
 require 'fileutils'
+require 'securerandom'
 
 module Travis::Api
 end
@@ -81,11 +82,7 @@ module Travis::Api
     end
 
     def self.deploy_sha
-      @deploy_sha ||= File.exist?(deploy_sha_path) ? File.read(deploy_sha_path)[0..7] : 'deploy-sha'
-    end
-
-    def self.deploy_sha_path
-      File.expand_path('../../../../.deploy-sha', __FILE__)
+      @deploy_sha ||= ENV['HEROKU_SLUG_COMMIT'] || SecureRandom.hex(5)
     end
 
     attr_accessor :app


### PR DESCRIPTION
We used last-commit-sha-buildpack in order to fetch the sha of the last
deployed commit during building the app and save it to use it later.
This was done using undocumented Heroku properties, for example it
assumed a certain path to git files. It turns out that there's another
way to do it now. We can enable [dyno-metadata](https://devcenter.heroku.com/articles/dyno-metadata) feature on heroku and
use `HEROKU_SLUG_COMMIT`