### PR TITLE
Fixes V3 Update issue

### DIFF
--- a/lib/travis/api/v3/models/settings.rb
+++ b/lib/travis/api/v3/models/settings.rb
@@ -11,7 +11,8 @@ module Travis::API::V3
     end
 
     def update(settings = {})
-      repository.user_settings.update(settings)
+      repository.settings = repository.user_settings.update(settings).to_json
+      repository.settings_will_change!
       repository.save!
     end
   end

--- a/lib/travis/api/v3/query.rb
+++ b/lib/travis/api/v3/query.rb
@@ -35,7 +35,7 @@ module Travis::API::V3
     @@prefixed_params_accessor = <<-RUBY
       def %<prefix>s_params
         @%<prefix>s ||= begin
-          params = @params.select { |key, _| key.start_with?('%<prefix>s.'.freeze) }
+          params.select { |key, _| key.start_with?('%<prefix>s.'.freeze) }
           Hash[params.map { |key, value| [key.split('.'.freeze).last, value] }]
         end
       end

--- a/spec/v3/services/settings_spec.rb
+++ b/spec/v3/services/settings_spec.rb
@@ -91,7 +91,7 @@ describe Travis::API::V3::Services::Settings, set_app: true do
     end
 
     describe 'authenticated, existing repo' do
-      let(:params) { JSON.dump('settings.build_pushes' => false) }
+      let(:params) { JSON.dump('settings.build_pushes' => false, 'maximum_number_of_builds' => 4) }
 
       before do
         repo.update_attributes(settings: JSON.dump('maximum_number_of_builds' => 20))
@@ -105,8 +105,9 @@ describe Travis::API::V3::Services::Settings, set_app: true do
           'builds_only_with_travis_yml' => false,
           'build_pushes' => false,
           'build_pull_requests' => true,
-          'maximum_number_of_builds' => 20
+          'maximum_number_of_builds' => 4
         )
+        expect(repo.reload.user_settings.maximum_number_of_builds).to eq(4)
       end
     end
   end


### PR DESCRIPTION
https://github.com/travis-pro/team-teal/issues/1118 - @sinthetix noticed this on the V3 settings API - this fixes the issue. The update was using the dynamically generated name-of-thing_params (settings_params in this case) and the meta code for the method was calling the wrong params always returning an empty hash no matter what was sent to the API. 
