### PR TITLE
Fixes https://github.com/travis-ci/travis-ci/issues/5457

### DIFF
--- a/lib/travis/api/app/endpoint/jobs.rb
+++ b/lib/travis/api/app/endpoint/jobs.rb
@@ -11,6 +11,7 @@ class Travis::Api::App
 
       get '/' do
         prefer_follower do
+          params['ids'] = params['ids'].split(',') if params['ids'].respond_to?(:split)
           respond_with service(:find_jobs, params)
         end
       end


### PR DESCRIPTION
Fixes https://github.com/travis-ci/travis-ci/issues/5457 : the params['ids'] may be a string of comma-separated job identifiers, but wasn't split into an array.

The split code was copied as-is from [the one for `/builds?ids=…`](https://github.com/travis-ci/travis-api/blob/542592ae415a3af8361275696f92c2555084d16f/lib/travis/api/app/endpoint/builds.rb#L13).