### PR TITLE
Add webhook to `/config` endpoint

### DIFF
--- a/lib/travis/api/app/endpoint/home.rb
+++ b/lib/travis/api/app/endpoint/home.rb
@@ -13,7 +13,7 @@ class Travis::Api::App
         assets: Travis.config.assets,
         pusher: (Travis.config.pusher_ws || Travis.config.pusher || {}).to_hash.slice(:scheme, :host, :port, :path, :key, :secure, :private),
         github: { api_url: GH.current.api_host.to_s, scopes: Travis.config.oauth2.try(:scope).to_s.split(?,) },
-        webhook: { signing_public_key: Travis.config.webhook.signing_public_key }
+        notifications: { webhook: { signing_public_key: Travis.config.webhook.signing_public_key } }
 
       # Landing point. Redirects web browsers to [API documentation](#/docs/).
       get '/' do

--- a/lib/travis/api/app/endpoint/home.rb
+++ b/lib/travis/api/app/endpoint/home.rb
@@ -12,7 +12,8 @@ class Travis::Api::App
         shorten_host: Travis.config.shorten_host,
         assets: Travis.config.assets,
         pusher: (Travis.config.pusher_ws || Travis.config.pusher || {}).to_hash.slice(:scheme, :host, :port, :path, :key, :secure, :private),
-        github: { api_url: GH.current.api_host.to_s, scopes: Travis.config.oauth2.try(:scope).to_s.split(?,) }
+        github: { api_url: GH.current.api_host.to_s, scopes: Travis.config.oauth2.try(:scope).to_s.split(?,) },
+        webhook: { signing_public_key: Travis.config.webhook.signing_public_key }
 
       # Landing point. Redirects web browsers to [API documentation](#/docs/).
       get '/' do

--- a/lib/travis/api/app/endpoint/home.rb
+++ b/lib/travis/api/app/endpoint/home.rb
@@ -13,7 +13,7 @@ class Travis::Api::App
         assets: Travis.config.assets,
         pusher: (Travis.config.pusher_ws || Travis.config.pusher || {}).to_hash.slice(:scheme, :host, :port, :path, :key, :secure, :private),
         github: { api_url: GH.current.api_host.to_s, scopes: Travis.config.oauth2.try(:scope).to_s.split(?,) },
-        notifications: { webhook: { signing_public_key: Travis.config.webhook.signing_public_key } }
+        notifications: { webhook: { public_key: Travis.config.webhook.public_key } }
 
       # Landing point. Redirects web browsers to [API documentation](#/docs/).
       get '/' do

--- a/lib/travis/config/defaults.rb
+++ b/lib/travis/config/defaults.rb
@@ -48,7 +48,7 @@ module Travis
                              rate_limit: { defaults: { api_builds: 10 }, maximums: { api_builds: 200 } } },
             endpoints:     {},
             oauth2:        {},
-            webhook:       { signing_public_key: nil }
+            webhook:       { public_key: nil }
 
     default :_access => [:key]
 

--- a/lib/travis/config/defaults.rb
+++ b/lib/travis/config/defaults.rb
@@ -47,7 +47,8 @@ module Travis
             settings:      { timeouts: { defaults: { hard_limit: 50, log_silence: 10 }, maximums: { hard_limit: 180, log_silence: 60 } },
                              rate_limit: { defaults: { api_builds: 10 }, maximums: { api_builds: 200 } } },
             endpoints:     {},
-            oauth2:        {}
+            oauth2:        {},
+            webhook:       { signing_public_key: nil }
 
     default :_access => [:key]
 


### PR DESCRIPTION
`webhook.private_key` contains the public key corresponding
to the private key which `travis-tasks` uses to sign the webhook
payload.

See https://github.com/travis-ci/travis-tasks/pull/65