### PR TITLE
Talk to Sync 2.0's queue

### DIFF
--- a/lib/travis/api/v3/queries/user.rb
+++ b/lib/travis/api/v3/queries/user.rb
@@ -1,6 +1,6 @@
 module Travis::API::V3
   class Queries::User < Query
-    setup_sidekiq(:user_sync, queue: :user_sync, class_name: "Travis::GithubSync::Workers::SyncUser")
+    setup_sidekiq(:user_sync, queue: :sync, class_name: "Travis::GithubSync::Worker")
     params :id, :login, :email, :github_id, :is_syncing
 
     def find
@@ -21,7 +21,7 @@ module Travis::API::V3
 
     def sync(user)
       raise AlreadySyncing if user.is_syncing?
-      perform_async(:user_sync, user.id)
+      perform_async(:user_sync, :sync_user, user_id: user.id)
       user.update_column(:is_syncing, true)
       user
     end

--- a/spec/lib/services/sync_user_spec.rb
+++ b/spec/lib/services/sync_user_spec.rb
@@ -11,7 +11,11 @@ describe Travis::Services::SyncUser do
     end
 
     it 'enqueues a sync job' do
-      Travis::Sidekiq::SynchronizeUser.expects(:perform_async).with(user.id)
+      Sidekiq::Client.expects(:push).with(
+        'queue' => 'sync',
+        'class' => 'Travis::GithubSync::Worker',
+        'args'  => [:sync_user, { user_id: user.id }]
+      )
       service.run
     end
 

--- a/spec/v3/services/user/sync_spec.rb
+++ b/spec/v3/services/user/sync_spec.rb
@@ -1,7 +1,7 @@
 describe Travis::API::V3::Services::User::Sync, set_app: true do
   let(:user)  { Travis::API::V3::Models::User.find_by_login('svenfuchs') }
   let(:user2) { Travis::API::V3::Models::User.create(login: 'carlad', is_syncing: true) }
-  let(:sidekiq_payload) { JSON.load(Sidekiq::Client.last['args'].last.to_json) }
+  let(:sidekiq_payload) { JSON.load(Sidekiq::Client.last['args'].to_json) }
   let(:sidekiq_params)  { Sidekiq::Client.last['args'].last.deep_symbolize_keys }
 
   before do
@@ -60,10 +60,10 @@ describe Travis::API::V3::Services::User::Sync, set_app: true do
       "true")
     }
 
-    example { expect(sidekiq_payload).to be == user.id }
+    example { expect(sidekiq_payload).to be == ['sync_user', 'user_id' => 1] }
 
-    example { expect(Sidekiq::Client.last['queue']).to be == :user_sync                }
-    example { expect(Sidekiq::Client.last['class']).to be == 'Travis::GithubSync::Workers::SyncUser' }
+    example { expect(Sidekiq::Client.last['queue']).to be == :sync                        }
+    example { expect(Sidekiq::Client.last['class']).to be == 'Travis::GithubSync::Worker' }
   end
 
   describe "existing user, current user does not have sync access " do


### PR DESCRIPTION
This makes API talk to the new queue and worker class in Sync 2.0

API v2 and v3 have been both tested on staging. I think this is ready to be merged.

v3 can be triggered like this:

```
curl -X PUT 'https://api-staging.travis-ci.org/user/3664/sync' \
  -H 'Authorization: token **********************' \
  -H 'Travis-API-Version: 3' \
  -H 'Accept: application/json' 
```