### PR TITLE
Clear debug options when restarting job

### DIFF
--- a/lib/travis/api/v3/models/build.rb
+++ b/lib/travis/api/v3/models/build.rb
@@ -33,5 +33,9 @@ module Travis::API::V3
     def branch_name=(value)
       write_attribute(:branch, value)
     end
+
+    def clear_debug_options!
+      jobs.each { |j| j.update_attribute(:debug_options, nil) }
+    end
   end
 end

--- a/lib/travis/api/v3/services/build/restart.rb
+++ b/lib/travis/api/v3/services/build/restart.rb
@@ -5,6 +5,7 @@ module Travis::API::V3
       build = check_login_and_find(:build)
       access_control.permissions(build).restart!
 
+      build.clear_debug_options!
       query.restart(access_control.user)
       accepted(build: build, state_change: :restart)
     end

--- a/lib/travis/api/v3/services/job/restart.rb
+++ b/lib/travis/api/v3/services/job/restart.rb
@@ -5,6 +5,7 @@ module Travis::API::V3
       job = check_login_and_find(:job)
       access_control.permissions(job).restart!
 
+      job.update_attribute(:debug_options, nil)
       query.restart(access_control.user)
       accepted(job: job, state_change: :restart)
     end

--- a/spec/v3/services/build/restart_spec.rb
+++ b/spec/v3/services/build/restart_spec.rb
@@ -127,7 +127,14 @@ describe Travis::API::V3::Services::Build::Restart, set_app: true do
       Travis::Features.stubs(:owner_active?).with(:enqueue_to_hub, repo.owner).returns(true)
     end
 
+    shared_examples 'clears debug_options for all jobs' do
+      before  { build.jobs.each { |j| j.update_attribute(:debug_options, { 'foo' => 'bar' }) } }
+      example { build.jobs.each { |j| expect(j.reload.debug_options).to be_nil } }
+    end
+
     describe "errored state" do
+      include_examples 'clears debug_options for all jobs'
+
       before do
         build.update_attribute(:state, "errored")
         post("/v3/build/#{build.id}/restart", params, headers)
@@ -156,6 +163,8 @@ describe Travis::API::V3::Services::Build::Restart, set_app: true do
     end
 
     describe "passed state" do
+      include_examples 'clears debug_options for all jobs'
+
       before        { build.update_attribute(:state, "passed")                                                  }
       before        { post("/v3/build/#{build.id}/restart", params, headers)                                    }
 
@@ -182,6 +191,8 @@ describe Travis::API::V3::Services::Build::Restart, set_app: true do
     end
 
     describe "failed state" do
+      include_examples 'clears debug_options for all jobs'
+
       before        { build.update_attribute(:state, "failed")                                                  }
       before        { post("/v3/build/#{build.id}/restart", params, headers)                                    }
 
@@ -208,6 +219,8 @@ describe Travis::API::V3::Services::Build::Restart, set_app: true do
     end
 
     describe "canceled state" do
+      include_examples 'clears debug_options for all jobs'
+
       before        { build.update_attribute(:state, "canceled")                                                  }
       before        { post("/v3/build/#{build.id}/restart", params, headers)                                      }
 

--- a/spec/v3/services/job/restart_spec.rb
+++ b/spec/v3/services/job/restart_spec.rb
@@ -85,7 +85,14 @@ describe Travis::API::V3::Services::Job::Restart, set_app: true do
       Travis::Features.stubs(:owner_active?).with(:enqueue_to_hub, repo.owner).returns(true)
     end
 
+    shared_examples 'clears debug_options' do
+      before  { job.update_attribute(:debug_options, { 'foo' => 'bar' }) }
+      example { expect(job.reload.debug_options).to be_nil }
+    end
+
     describe "canceled state" do
+      include_examples 'clears debug_options'
+
       before        { job.update_attribute(:state, "canceled")                                                }
       before        { post("/v3/job/#{job.id}/restart", params, headers)                                      }
 
@@ -110,7 +117,10 @@ describe Travis::API::V3::Services::Job::Restart, set_app: true do
       example { expect(Sidekiq::Client.last['queue']).to be == 'hub'                }
       example { expect(Sidekiq::Client.last['class']).to be == 'Travis::Hub::Sidekiq::Worker' }
     end
+
     describe "errored state" do
+      include_examples 'clears debug_options'
+
       before        { job.update_attribute(:state, "errored")                                                }
       before        { post("/v3/job/#{job.id}/restart", params, headers)                                      }
 
@@ -135,7 +145,10 @@ describe Travis::API::V3::Services::Job::Restart, set_app: true do
       example { expect(Sidekiq::Client.last['queue']).to be == 'hub'                }
       example { expect(Sidekiq::Client.last['class']).to be == 'Travis::Hub::Sidekiq::Worker' }
     end
+
     describe "failed state" do
+      include_examples 'clears debug_options'
+
       before        { job.update_attribute(:state, "failed")                                                }
       before        { post("/v3/job/#{job.id}/restart", params, headers)                                      }
 
@@ -160,7 +173,10 @@ describe Travis::API::V3::Services::Job::Restart, set_app: true do
       example { expect(Sidekiq::Client.last['queue']).to be == 'hub'                }
       example { expect(Sidekiq::Client.last['class']).to be == 'Travis::Hub::Sidekiq::Worker' }
     end
+
     describe "passed state" do
+      include_examples 'clears debug_options'
+
       before        { job.update_attribute(:state, "passed")                                                }
       before        { post("/v3/job/#{job.id}/restart", params, headers)                                      }
 


### PR DESCRIPTION
Trying to address https://github.com/travis-pro/team-teal/issues/1234

We believe that when restarting a job via the API, we should
clear the debug_options attribute so that the job can run as normal.