### PR TITLE
Sync users on create and on github_oauth_token changed

### DIFF
--- a/lib/travis/api/app/endpoint/authorization.rb
+++ b/lib/travis/api/app/endpoint/authorization.rb
@@ -258,7 +258,6 @@ class Travis::Api::App
             super
 
             @user = ::User.find_by_github_id(data['id'])
-
           end
 
           def info(attributes = {})
@@ -288,6 +287,7 @@ class Travis::Api::App
               if user
                 rename_repos_owner(user.login, info['login'])
                 user.update_attributes info
+                Travis.run_service(:sync_user, user) if user.previous_changes[:github_oauth_token]
               else
                 self.user = ::User.create! info
                 Travis.run_service(:sync_user, user)

--- a/spec/unit/endpoint/authorization/user_manager_spec.rb
+++ b/spec/unit/endpoint/authorization/user_manager_spec.rb
@@ -35,7 +35,7 @@ describe Travis::Api::App::Endpoint::Authorization::UserManager do
      }
 
     it 'drops the token when drop_token is set to true' do
-      user = stub('user', login: 'drogus', github_id: 456)
+      user = stub('user', login: 'drogus', github_id: 456, previous_changes: {})
       User.expects(:find_by_github_id).with(456).returns(user)
 
       manager = described_class.new(data, 'abc123', true)
@@ -49,26 +49,55 @@ describe Travis::Api::App::Endpoint::Authorization::UserManager do
     end
 
     context 'with existing user' do
-      it 'updates user data' do
-        user = stub('user', login: 'drogus', github_id: 456)
-        User.expects(:find_by_github_id).with(456).returns(user)
-        attributes = { login: 'drogus', github_id: 456, github_oauth_token: 'abc123', education: false }.stringify_keys
-        user.expects(:update_attributes).with(attributes)
-        manager.stubs(:education).returns(false)
+      let!(:user) { FactoryGirl.create(:user, login: 'drogus', github_id: 456, github_oauth_token: token) }
+      let(:token) { nil }
 
+      before do
+        manager.stubs(:education).returns(false)
+      end
+
+      it 'updates user data' do
+        attributes = { login: 'drogus', github_id: 456, github_oauth_token: 'abc123', education: false }.stringify_keys
+        User.any_instance.expects(:update_attributes).with(attributes)
         manager.fetch.should == user
+      end
+
+      describe 'the oauth token has not changed' do
+        let(:token) { 'abc123' }
+
+        it 'syncs the user' do
+          Travis.expects(:run_service).with(:sync_user, user).never
+          manager.fetch
+        end
+      end
+
+      describe 'the oauth token has changed' do
+        let(:token) { 'xyz890' }
+
+        it 'syncs the user' do
+          Travis.expects(:run_service).with(:sync_user, user)
+          manager.fetch
+        end
       end
     end
 
     context 'without existing user' do
-      it 'creates new user' do
-        User.expects(:find_by_github_id).with(456).returns(nil)
-        attributes = { login: 'drogus', github_id: 456, github_oauth_token: 'abc123', education: false }.stringify_keys
-        user = User.create(id: 1, login: 'drogus', github_id: 456)
-        User.expects(:create!).with(attributes).returns(user)
-        manager.stubs(:education).returns(false)
+      let(:user)  { User.create(id: 1, login: 'drogus', github_id: 456) }
+      let(:attrs) { { login: 'drogus', github_id: 456, github_oauth_token: 'abc123', education: false }.stringify_keys }
 
+      before do
+        manager.stubs(:education).returns(false)
+        User.stubs(:create!).with(attrs).returns(user)
+      end
+
+      it 'creates new user' do
+        User.expects(:create!).with(attrs).returns(user)
         manager.fetch.should == user
+      end
+
+      it 'syncs the user' do
+        Travis.expects(:run_service).with(:sync_user, user)
+        manager.fetch
       end
     end
   end


### PR DESCRIPTION
This triggers a sync not only when we first create a user, but also when the `github_oauth_token` changes.

Should help with this scenario: https://github.com/travis-pro/team-teal/issues/1305

/cc @rkh @renee-travisci @joecorcoran 