### PR TITLE
Sync users on sign in

### DIFF
--- a/lib/travis/api/app/endpoint/authorization.rb
+++ b/lib/travis/api/app/endpoint/authorization.rb
@@ -287,10 +287,8 @@ class Travis::Api::App
               if user
                 rename_repos_owner(user.login, info['login'])
                 user.update_attributes info
-                Travis.run_service(:sync_user, user) if user.previous_changes[:github_oauth_token]
               else
                 self.user = ::User.create! info
-                Travis.run_service(:sync_user, user)
               end
 
               Travis::Github::Oauth.update_scopes(user) # unless Travis.env == 'test'
@@ -298,12 +296,17 @@ class Travis::Api::App
               nullify_logins(user.github_id, user.login)
             end
 
+            Travis.run_service(:sync_user, user) if sync_user?(user)
             user
           rescue ActiveRecord::RecordNotUnique
             unless retried
               retried = true
               retry
             end
+          end
+
+          def sync_user?(user)
+            user.recently_signed_up? || user.previous_changes[:github_oauth_token]
           end
         end
 

--- a/lib/travis/api/app/endpoint/authorization.rb
+++ b/lib/travis/api/app/endpoint/authorization.rb
@@ -258,7 +258,6 @@ class Travis::Api::App
             super
 
             @user = ::User.find_by_github_id(data['id'])
-
           end
 
           def info(attributes = {})
@@ -288,6 +287,7 @@ class Travis::Api::App
               if user
                 rename_repos_owner(user.login, info['login'])
                 user.update_attributes info
+                Travis.run_service(:sync_user, user) if user.previous_changes[:github_oauth_token]
               else
                 self.user = ::User.create! info
                 Travis.run_service(:sync_user, user)

--- a/lib/travis/api/app/endpoint/authorization.rb
+++ b/lib/travis/api/app/endpoint/authorization.rb
@@ -296,17 +296,12 @@ class Travis::Api::App
               nullify_logins(user.github_id, user.login)
             end
 
-            Travis.run_service(:sync_user, user) if sync_user?(user)
             user
           rescue ActiveRecord::RecordNotUnique
             unless retried
               retried = true
               retry
             end
-          end
-
-          def sync_user?(user)
-            user.recently_signed_up? || user.previous_changes[:github_oauth_token]
           end
         end
 
@@ -326,6 +321,9 @@ class Travis::Api::App
 
           user   = manager.fetch
           halt 403, 'not a Travis user' if user.nil?
+
+          Travis.run_service(:sync_user, user)
+
           user
         rescue GH::Error
           # not a valid token actually, but we don't want to expose that info

--- a/spec/unit/endpoint/authorization/user_manager_spec.rb
+++ b/spec/unit/endpoint/authorization/user_manager_spec.rb
@@ -35,7 +35,7 @@ describe Travis::Api::App::Endpoint::Authorization::UserManager do
      }
 
     it 'drops the token when drop_token is set to true' do
-      user = stub('user', login: 'drogus', github_id: 456, previous_changes: {})
+      user = stub('user', login: 'drogus', github_id: 456, previous_changes: {}, recently_signed_up?: false)
       User.expects(:find_by_github_id).with(456).returns(user)
 
       manager = described_class.new(data, 'abc123', true)

--- a/spec/unit/endpoint/authorization/user_manager_spec.rb
+++ b/spec/unit/endpoint/authorization/user_manager_spec.rb
@@ -35,7 +35,7 @@ describe Travis::Api::App::Endpoint::Authorization::UserManager do
      }
 
     it 'drops the token when drop_token is set to true' do
-      user = stub('user', login: 'drogus', github_id: 456)
+      user = stub('user', login: 'drogus', github_id: 456, previous_changes: {})
       User.expects(:find_by_github_id).with(456).returns(user)
 
       manager = described_class.new(data, 'abc123', true)
@@ -49,26 +49,55 @@ describe Travis::Api::App::Endpoint::Authorization::UserManager do
     end
 
     context 'with existing user' do
-      it 'updates user data' do
-        user = stub('user', login: 'drogus', github_id: 456)
-        User.expects(:find_by_github_id).with(456).returns(user)
-        attributes = { login: 'drogus', github_id: 456, github_oauth_token: 'abc123', education: false }.stringify_keys
-        user.expects(:update_attributes).with(attributes)
-        manager.stubs(:education).returns(false)
+      let!(:user) { FactoryGirl.create(:user, login: 'drogus', github_id: 456, github_oauth_token: token) }
+      let(:token) { nil }
 
+      before do
+        manager.stubs(:education).returns(false)
+      end
+
+      it 'updates user data' do
+        attributes = { login: 'drogus', github_id: 456, github_oauth_token: 'abc123', education: false }.stringify_keys
+        User.any_instance.expects(:update_attributes).with(attributes)
         manager.fetch.should == user
+      end
+
+      describe 'the oauth token has not changed' do
+        let(:token) { 'abc123' }
+
+        it 'syncs the user' do
+          Travis.expects(:run_service).with(:sync_user, user).never
+          manager.fetch
+        end
+      end
+
+      describe 'the oauth token has changed' do
+        let(:token) { 'xyz890' }
+
+        it 'syncs the user' do
+          Travis.expects(:run_service).with(:sync_user, user)
+          manager.fetch
+        end
       end
     end
 
     context 'without existing user' do
-      it 'creates new user' do
-        User.expects(:find_by_github_id).with(456).returns(nil)
-        attributes = { login: 'drogus', github_id: 456, github_oauth_token: 'abc123', education: false }.stringify_keys
-        user = User.create(id: 1, login: 'drogus', github_id: 456)
-        User.expects(:create!).with(attributes).returns(user)
-        manager.stubs(:education).returns(false)
+      let(:user)  { User.create(id: 1, login: 'drogus', github_id: 456) }
+      let(:attrs) { { login: 'drogus', github_id: 456, github_oauth_token: 'abc123', education: false }.stringify_keys }
 
+      before do
+        manager.stubs(:education).returns(false)
+        User.stubs(:create!).with(attrs).returns(user)
+      end
+
+      it 'creates new user' do
+        User.expects(:create!).with(attrs).returns(user)
         manager.fetch.should == user
+      end
+
+      it 'syncs the user' do
+        Travis.expects(:run_service).with(:sync_user, user)
+        manager.fetch
       end
     end
   end

--- a/spec/unit/endpoint/authorization/user_manager_spec.rb
+++ b/spec/unit/endpoint/authorization/user_manager_spec.rb
@@ -61,24 +61,6 @@ describe Travis::Api::App::Endpoint::Authorization::UserManager do
         User.any_instance.expects(:update_attributes).with(attributes)
         manager.fetch.should == user
       end
-
-      describe 'the oauth token has not changed' do
-        let(:token) { 'abc123' }
-
-        it 'syncs the user' do
-          Travis.expects(:run_service).with(:sync_user, user).never
-          manager.fetch
-        end
-      end
-
-      describe 'the oauth token has changed' do
-        let(:token) { 'xyz890' }
-
-        it 'syncs the user' do
-          Travis.expects(:run_service).with(:sync_user, user)
-          manager.fetch
-        end
-      end
     end
 
     context 'without existing user' do
@@ -93,11 +75,6 @@ describe Travis::Api::App::Endpoint::Authorization::UserManager do
       it 'creates new user' do
         User.expects(:create!).with(attrs).returns(user)
         manager.fetch.should == user
-      end
-
-      it 'syncs the user' do
-        Travis.expects(:run_service).with(:sync_user, user)
-        manager.fetch
       end
     end
   end

--- a/spec/unit/endpoint/authorization_spec.rb
+++ b/spec/unit/endpoint/authorization_spec.rb
@@ -146,5 +146,10 @@ describe Travis::Api::App::Endpoint::Authorization do
       body.should_not include("access_token")
       body.should include("not a Travis user")
     end
+
+    it 'syncs the user' do
+      Travis.expects(:run_service).with(:sync_user, instance_of(User))
+      post('/auth/github', github_token: 'public repos').should be_ok
+    end
   end
 end


### PR DESCRIPTION
Re https://github.com/travis-pro/team-teal/issues/1332

This reverts commit d3154fea75c17f3c602545995fce5b6d05412aed, which reverted 6d2380a1b3eaa170e414615f5ec0a297f329e23f.

Opening this as a new branch so I can re-test things on com staging.

This now always syncs users on sign in.