### PR TITLE
Use uniform param names in settings endpoints

### DIFF
--- a/lib/travis/api/v3/queries/user_setting.rb
+++ b/lib/travis/api/v3/queries/user_setting.rb
@@ -1,13 +1,24 @@
 module Travis::API::V3
   class Queries::UserSetting < Query
     params :name, :value, prefix: :setting
+    params :name, :value, prefix: :user_setting
 
     def find(repository)
-      repository.user_settings.read(name)
+      repository.user_settings.read(_name)
     end
 
     def update(repository)
-      repository.user_settings.update(name, value)
+      repository.user_settings.update(_name, _value)
+    end
+
+    private
+
+    def _name
+      user_setting_params.key?('name') ? user_setting_params['name'] : setting_params['name']
+    end
+
+    def _value
+      user_setting_params.key?('value') ? user_setting_params['value'] : setting_params['value']
     end
   end
 end

--- a/lib/travis/api/v3/renderer/user_setting.rb
+++ b/lib/travis/api/v3/renderer/user_setting.rb
@@ -5,7 +5,7 @@ module Travis::API::V3
     def href
       Renderer.href(:user_setting,
         :"repository.id" => model.repository_id,
-        :"setting.name" => name,
+        :"user_setting.name" => name,
         :"script_name" => script_name
       )
     end

--- a/lib/travis/api/v3/routes.rb
+++ b/lib/travis/api/v3/routes.rb
@@ -124,7 +124,7 @@ module Travis::API::V3
       end
 
       resource :user_setting do
-        route '/setting/{setting.name}'
+        route '/setting/{user_setting.name}'
         get  :find
         patch :update
       end

--- a/lib/travis/api/v3/services/user_setting/update.rb
+++ b/lib/travis/api/v3/services/user_setting/update.rb
@@ -1,6 +1,7 @@
 module Travis::API::V3
   class Services::UserSetting::Update < Service
     params :value, prefix: :setting
+    params :value, prefix: :user_setting
 
     def run!
       repository = check_login_and_find(:repository)

--- a/spec/v3/services/user_setting/update_spec.rb
+++ b/spec/v3/services/user_setting/update_spec.rb
@@ -5,11 +5,13 @@ describe Travis::API::V3::Services::UserSetting::Update, set_app: true do
   let(:other_token) { Travis::Api::App::AccessToken.create(user: other_user, app_id: 2) }
   let(:auth_headers) { { 'HTTP_AUTHORIZATION' => "token #{token}" } }
   let(:json_headers) { { 'CONTENT_TYPE' => 'application/json' } }
-  let(:params) { JSON.dump('setting.value' => false) }
+
+  let(:old_params) { JSON.dump('setting.value' => false) }
+  let(:new_params) { JSON.dump('user_setting.value' => false) }
 
   describe 'not authenticated' do
     before do
-      patch("/v3/repo/#{repo.id}/setting/build_pushes", params, json_headers)
+      patch("/v3/repo/#{repo.id}/setting/build_pushes", new_params, json_headers)
     end
 
     example { expect(last_response.status).to eq(403) }
@@ -24,7 +26,7 @@ describe Travis::API::V3::Services::UserSetting::Update, set_app: true do
 
   describe 'authenticated, missing repo' do
     before do
-      patch('/v3/repo/9999999999/setting/build_pushes', params, json_headers.merge(auth_headers))
+      patch('/v3/repo/9999999999/setting/build_pushes', new_params, json_headers.merge(auth_headers))
     end
 
     example { expect(last_response.status).to eq(404) }
@@ -38,13 +40,7 @@ describe Travis::API::V3::Services::UserSetting::Update, set_app: true do
     end
   end
 
-  describe 'authenticated, existing repo' do
-    before do
-      repo.update_attribute(:settings, JSON.dump('env_vars' => ['something']))
-      Travis::API::V3::Models::Permission.create(repository: repo, user: repo.owner, push: true)
-      patch("/v3/repo/#{repo.id}/setting/build_pushes", params, json_headers.merge(auth_headers))
-    end
-
+  shared_examples 'successful patch' do
     example { expect(last_response.status).to eq(200) }
     example do
       expect(JSON.load(body)).to eq(
@@ -63,9 +59,27 @@ describe Travis::API::V3::Services::UserSetting::Update, set_app: true do
     end
   end
 
+  describe 'authenticated, existing repo, old params' do
+    before do
+      repo.update_attribute(:settings, JSON.dump('env_vars' => ['something']))
+      Travis::API::V3::Models::Permission.create(repository: repo, user: repo.owner, push: true)
+      patch("/v3/repo/#{repo.id}/setting/build_pushes", old_params, json_headers.merge(auth_headers))
+    end
+    include_examples 'successful patch'
+  end
+
+  describe 'authenticated, existing repo, new params' do
+    before do
+      repo.update_attribute(:settings, JSON.dump('env_vars' => ['something']))
+      Travis::API::V3::Models::Permission.create(repository: repo, user: repo.owner, push: true)
+      patch("/v3/repo/#{repo.id}/setting/build_pushes", new_params, json_headers.merge(auth_headers))
+    end
+    include_examples 'successful patch'
+  end
+
   describe 'authenticated, existing repo, user does not have correct permissions' do
     before do
-      patch("/v3/repo/#{repo.id}/setting/build_pushes", params, json_headers.merge('HTTP_AUTHORIZATION' => "token #{other_token}"))
+      patch("/v3/repo/#{repo.id}/setting/build_pushes", new_params, json_headers.merge('HTTP_AUTHORIZATION' => "token #{other_token}"))
     end
 
     example { expect(last_response.status).to eq(403) }


### PR DESCRIPTION
It came to my attention when writing the docs for these endpoints
that trying to accomodate the previous `setting.something` params
is not worth the hassle now that the resource is named `user_setting`.

This switches to `user_setting.something` but still allows
`setting.something` so that we can deploy this without breaking
travis-web.