### PR TITLE
Stop settings update from clobbering existing settings hash

### DIFF
--- a/lib/travis/api/v3/models/json_slice.rb
+++ b/lib/travis/api/v3/models/json_slice.rb
@@ -34,14 +34,11 @@ module Travis::API::V3
       Hash[map { |x| [x.name, x.value] }]
     end
 
-    def to_json
-      to_h.to_json
-    end
-
     def parent_attr(parent, attr)
       @parent, @attr = parent, attr
       @sync = -> do
-        @parent.send(:"#{@attr}=", to_json)
+        previous = @parent.send(:"#{@attr}")
+        @parent.send(:"#{@attr}=", previous.merge(to_h).to_json)
         @parent.save!
       end
     end

--- a/lib/travis/api/v3/models/repository.rb
+++ b/lib/travis/api/v3/models/repository.rb
@@ -66,19 +66,19 @@ module Travis::API::V3
     end
 
     def settings
-      @settings ||= JSON.load(super || '{}'.freeze)
+      JSON.load(super || '{}'.freeze)
     end
 
     def user_settings
-      @user_settings ||= Models::UserSettings.new(settings).tap { |us| us.parent_attr(self, :settings) }
+      Models::UserSettings.new(settings).tap { |us| us.parent_attr(self, :settings) }
     end
 
     def admin_settings
-      @admin_settings ||= Models::AdminSettings.new(settings).tap { |as| as.parent_attr(self, :settings) }
+      Models::AdminSettings.new(settings).tap { |as| as.parent_attr(self, :settings) }
     end
 
     def env_vars
-      @env_vars ||= Models::EnvVars.new.tap do |vars|
+      Models::EnvVars.new.tap do |vars|
         vars.load(settings.fetch('env_vars', []), repository_id: self.id)
       end
     end

--- a/spec/v3/services/user_setting/update_spec.rb
+++ b/spec/v3/services/user_setting/update_spec.rb
@@ -40,6 +40,7 @@ describe Travis::API::V3::Services::UserSetting::Update, set_app: true do
 
   describe 'authenticated, existing repo' do
     before do
+      repo.update_attribute(:settings, JSON.dump('env_vars' => ['something']))
       Travis::API::V3::Models::Permission.create(repository: repo, user: repo.owner, push: true)
       patch("/v3/repo/#{repo.id}/setting/build_pushes", params, json_headers.merge(auth_headers))
     end
@@ -56,6 +57,9 @@ describe Travis::API::V3::Services::UserSetting::Update, set_app: true do
     end
     example 'value is persisted' do
       expect(repo.reload.user_settings.build_pushes).to eq false
+    end
+    example 'does not clobber other things in the settings hash' do
+      expect(repo.reload.settings['env_vars']).to eq(['something'])
     end
   end
 


### PR DESCRIPTION
This was an issue that @backspace found when working on travis-web.

Since we store lots of other things in the settings column besides
user settings, the attr has to be merged.

Also removes some ivar caching that didn't win us much in production
but made debugging hard.