### PR TITLE
Remove safelist of travis-lite.com in API

### DIFF
--- a/lib/travis/api/app/endpoint/authorization.rb
+++ b/lib/travis/api/app/endpoint/authorization.rb
@@ -383,8 +383,6 @@ class Travis::Api::App
             uri.scheme == 'https'
           elsif uri.host =~ /\A(.+\.)?travis-ci\.(com|org)\Z/
             uri.scheme == 'https'
-          elsif uri.host =~ /\A(.+\.)?travis-lite\.com\Z/
-            uri.scheme == 'https'
           elsif uri.host == 'localhost' or uri.host == '127.0.0.1'
             uri.port > 1023
           end


### PR DESCRIPTION
travis-lite no longer appears to be in use or operational, remove it before the domain expires.