### PR TITLE
Update travis-core to latest patch level for enterprise-2.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ ruby '2.1.7' if ENV.key?('DYNO')
 
 gem 's3',              github: 'travis-ci/s3'
 
-gem 'travis-core',     github: 'travis-ci/travis-core', branch: 'te-dev'
+gem 'travis-core',     github: 'travis-ci/travis-core', branch: 'enterprise-2.0'
 gem 'travis-support',  github: 'travis-ci/travis-support'
 gem 'travis-amqp',     github: 'travis-ci/travis-amqp'
 gem 'travis-config',   '~> 0.1.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -48,8 +48,8 @@ GIT
 
 GIT
   remote: git://github.com/travis-ci/travis-core.git
-  revision: 2d7714edb82507173514bb9aa762e732626aa732
-  branch: te-dev
+  revision: 41ffe365578331ec5c7b847ac31221f1dc8d3e9f
+  branch: enterprise-2.0
   specs:
     travis-core (0.0.1)
       actionmailer (~> 3.2.19)
@@ -198,7 +198,7 @@ GEM
     httparty (0.11.0)
       multi_json (~> 1.0)
       multi_xml (>= 0.5.2)
-    httpclient (2.8.0)
+    httpclient (2.8.2.4)
     i18n (0.7.0)
     ice_nine (0.11.2)
     jemalloc (1.0.1)


### PR DESCRIPTION
Updating to the latest (now correctly named) enterprise-2.0 version of travis-core which has the fix for sec-incident-20161007 in it.
