### PR TITLE
Fix up SSH key permissions

### DIFF
--- a/lib/travis/api/v3/access_control/generic.rb
+++ b/lib/travis/api/v3/access_control/generic.rb
@@ -103,6 +103,10 @@ module Travis::API::V3
       full_access? or public_api?
     end
 
+    def ssl_key_writable?(ssl_key)
+      writable? ssl_key.repository
+    end
+
     def user_visible?(user)
       unrestricted_api?
     end

--- a/lib/travis/api/v3/permissions/repository.rb
+++ b/lib/travis/api/v3/permissions/repository.rb
@@ -34,6 +34,10 @@ module Travis::API::V3
       write?
     end
 
+    def change_key?
+      write?
+    end
+
     def admin?
       access_control.adminable? object
     end

--- a/lib/travis/api/v3/services/ssh_key/create.rb
+++ b/lib/travis/api/v3/services/ssh_key/create.rb
@@ -2,6 +2,7 @@ module Travis::API::V3
   class Services::SshKey::Create < Service
     def run!
       repository = check_login_and_find(:repository)
+      access_control.permissions(repository).change_key!
       ssh_key = query.regenerate(repository)
       result(:ssh_key, ssh_key, status: 201)
     end

--- a/spec/v3/services/owner/find_spec.rb
+++ b/spec/v3/services/owner/find_spec.rb
@@ -68,6 +68,7 @@ describe Travis::API::V3::Services::Owner::Find, set_app: true do
             "create_cron"     => false,
             "change_settings" => false,
             "change_env_vars" => false,
+            "change_key"      => false,
             "admin"           => false
           },
           "id"                => repo.id,
@@ -120,6 +121,7 @@ describe Travis::API::V3::Services::Owner::Find, set_app: true do
             "create_cron"   => false,
             "change_settings" => false,
             "change_env_vars" => false,
+            "change_key"    => false,
             "admin"         => false
           },
           "id"              => repo.id,

--- a/spec/v3/services/repositories/for_current_user_spec.rb
+++ b/spec/v3/services/repositories/for_current_user_spec.rb
@@ -45,7 +45,8 @@ describe Travis::API::V3::Services::Repositories::ForCurrentUser, set_app: true 
           "create_request"   => true,
           "create_cron"      => false,
           "change_settings"  => true,
-          "change_env_vars" => true,
+          "change_env_vars"  => true,
+          "change_key"       => true,
           "admin"            => true
         },
         "id"                 =>  repo.id,

--- a/spec/v3/services/repositories/for_owner_spec.rb
+++ b/spec/v3/services/repositories/for_owner_spec.rb
@@ -47,6 +47,7 @@ describe Travis::API::V3::Services::Repositories::ForOwner, set_app: true do
           "create_cron"      => false,
           "change_settings"  => false,
           "change_env_vars"  => false,
+          "change_key"       => false,
           "admin"            => false
         },
         "id"                 => repo.id,
@@ -127,8 +128,9 @@ describe Travis::API::V3::Services::Repositories::ForOwner, set_app: true do
           "create_request"=> false,
           "create_cron"   => false,
           "change_settings" => false,
-          "change_env_vars"  => false,
-          "admin"            => false
+          "change_env_vars" => false,
+          "change_key"      => false,
+          "admin"           => false
         },
         "id"              => 1,
         "name"            => "minimal",
@@ -161,6 +163,7 @@ describe Travis::API::V3::Services::Repositories::ForOwner, set_app: true do
           "create_cron"   => false,
           "change_settings"  => false,
           "change_env_vars"  => false,
+          "change_key"       => false,
           "admin"            => false
         },
         "id"              => repo2.id,

--- a/spec/v3/services/repository/find_spec.rb
+++ b/spec/v3/services/repository/find_spec.rb
@@ -39,6 +39,7 @@ describe Travis::API::V3::Services::Repository::Find, set_app: true do
         "create_cron"      => false,
         "change_settings"  => false,
         "change_env_vars"  => false,
+        "change_key"       => false,
         "admin"            => false
       },
       "id"                 =>  repo.id,
@@ -121,6 +122,7 @@ describe Travis::API::V3::Services::Repository::Find, set_app: true do
         "create_cron"      => false,
         "change_settings"  => false,
         "change_env_vars"  => false,
+        "change_key"       => false,
         "admin"            => false
       },
       "id"                 =>  repo.id,
@@ -188,6 +190,7 @@ describe Travis::API::V3::Services::Repository::Find, set_app: true do
         "create_cron"      => false,
         "change_settings"  => true,
         "change_env_vars"  => true,
+        "change_key"       => true,
         "admin"            => false
       },
       "id"                 =>  repo.id,
@@ -255,6 +258,7 @@ describe Travis::API::V3::Services::Repository::Find, set_app: true do
         "create_cron"      => false,
         "change_settings"  => true,
         "change_env_vars"  => true,
+        "change_key"       => true,
         "admin"            => true
       },
       "id"                 =>  repo.id,

--- a/spec/v3/services/ssh_key/create_spec.rb
+++ b/spec/v3/services/ssh_key/create_spec.rb
@@ -7,6 +7,8 @@ describe Travis::API::V3::Services::SshKey::Create, set_app: true do
     end
   end
   let(:token) { Travis::Api::App::AccessToken.create(user: repo.owner, app_id: 1) }
+  let(:other_user) { FactoryGirl.create(:user) }
+  let(:other_token) { Travis::Api::App::AccessToken.create(user: other_user, app_id: 2) }
   let(:auth_headers) { { 'HTTP_AUTHORIZATION' => "token #{token}" } }
 
   describe 'not authenticated' do
@@ -14,34 +16,65 @@ describe Travis::API::V3::Services::SshKey::Create, set_app: true do
     include_examples 'not authenticated'
   end
 
-  describe 'authenticated, missing repo' do
-    before { post("/v3/repo/999999999/ssh_key", {}, auth_headers) }
-    include_examples 'missing repo'
+  context 'authenticated as wrong user' do
+    describe 'not allowed' do
+      before { post("/v3/repo/#{repo.id}/ssh_key", {}, 'HTTP_AUTHORIZATION' => "token #{other_token}") }
+
+      example { expect(last_response.status).to eq(403) }
+      example do
+        expect(JSON.load(body)).to eq(
+          '@type' => 'error',
+          'error_type' => 'insufficient_access',
+          'error_message' => 'operation requires change_key access to repository',
+          'permission' => 'change_key',
+          'resource_type' => 'repository',
+          'repository' => {
+            '@type' => 'repository',
+            '@href' => "/v3/repo/#{repo.id}",
+            '@representation' => 'minimal',
+            'id' => repo.id,
+            'name' => 'minimal',
+            'slug' => 'svenfuchs/minimal'
+          }
+        )
+      end
+    end
   end
 
-  describe 'authenticated, existing repo, creates key when none exists' do
-    before do
-      repo.key.destroy
-      post("/v3/repo/#{repo.id}/ssh_key", {}, auth_headers)
+  context 'authenticated' do
+    describe 'missing repo' do
+      before { post("/v3/repo/999999999/ssh_key", {}, auth_headers) }
+      include_examples 'missing repo'
     end
 
-    example { expect(last_response.status).to eq 201 }
-    example do
-      expect(JSON.parse(last_response.body)).to include *%w{@type @href @representation id public_key fingerprint}
+    describe 'existing repo, creates key when none exists' do
+      before do
+        Travis::API::V3::Models::Permission.create(repository: repo, user: repo.owner, push: true)
+        repo.key.destroy
+        post("/v3/repo/#{repo.id}/ssh_key", {}, auth_headers)
+      end
+
+      example { expect(last_response.status).to eq 201 }
+      example do
+        expect(JSON.parse(last_response.body)).to include *%w{@type @href @representation id public_key fingerprint}
+      end
     end
-  end
 
-  describe 'authenticated, existing repo, regenerates key when one exists' do
-    let!(:key) { repo.key }
+    describe 'existing repo, regenerates key when one exists' do
+      let!(:key) { repo.key }
 
-    before { post("/v3/repo/#{repo.id}/ssh_key", {}, auth_headers) }
+      before do
+        Travis::API::V3::Models::Permission.create(repository: repo, user: repo.owner, push: true)
+        post("/v3/repo/#{repo.id}/ssh_key", {}, auth_headers)
+      end
 
-    example { expect(last_response.status).to eq 201 }
-    example do
-      result = JSON.parse(last_response.body)
-      expect(result).to include *%w{@type @href @representation id public_key fingerprint}
-      expect(result['id']).to eq key.id
-      expect(result['fingerprint']).not_to eq(key.fingerprint)
+      example { expect(last_response.status).to eq 201 }
+      example do
+        result = JSON.parse(last_response.body)
+        expect(result).to include *%w{@type @href @representation id public_key fingerprint}
+        expect(result['id']).to eq key.id
+        expect(result['fingerprint']).not_to eq(key.fingerprint)
+      end
     end
   end
 end

--- a/spec/v3/services/ssh_key/find_spec.rb
+++ b/spec/v3/services/ssh_key/find_spec.rb
@@ -14,40 +14,42 @@ describe Travis::API::V3::Services::SshKey::Find, set_app: true do
     include_examples 'not authenticated'
   end
 
-  describe 'authenticated, missing repo' do
-    before { get("/v3/repo/999999999/ssh_key", {}, auth_headers) }
-    include_examples 'missing repo'
-  end
-
-  describe 'authenticated, existing repo, no key' do
-    before do
-      repo.key.destroy
-      get("/v3/repo/#{repo.id}/ssh_key", {}, auth_headers)
+  context 'authenticated' do
+    describe 'missing repo' do
+      before { get("/v3/repo/999999999/ssh_key", {}, auth_headers) }
+      include_examples 'missing repo'
     end
 
-    example { expect(last_response.status).to eq 404 }
-    example do
-      expect(JSON.parse(last_response.body)).to eq(
-        '@type' => 'error',
-        'error_message' => 'ssh_key not found (or insufficient access)',
-        'error_type' => 'not_found',
-        'resource_type' => 'ssh_key'
-      )
-    end
-  end
+    describe 'existing repo, no key' do
+      before do
+        repo.key.destroy
+        get("/v3/repo/#{repo.id}/ssh_key", {}, auth_headers)
+      end
 
-  describe 'authenticated, existing repo, existing key' do
-    before { get("/v3/repo/#{repo.id}/ssh_key", {}, auth_headers) }
-    example { expect(last_response.status).to eq 200 }
-    example do
-      expect(JSON.parse(last_response.body)).to eq(
-        '@type' => 'ssh_key',
-        '@href' => "/v3/repo/#{repo.id}/ssh_key",
-        '@representation' => 'standard',
-        'id' => repo.key.id,
-        'public_key' => repo.key.public_key,
-        'fingerprint' => repo.key.fingerprint
-      )
+      example { expect(last_response.status).to eq 404 }
+      example do
+        expect(JSON.parse(last_response.body)).to eq(
+          '@type' => 'error',
+          'error_message' => 'ssh_key not found (or insufficient access)',
+          'error_type' => 'not_found',
+          'resource_type' => 'ssh_key'
+        )
+      end
+    end
+
+    describe 'existing repo, existing key' do
+      before { get("/v3/repo/#{repo.id}/ssh_key", {}, auth_headers) }
+      example { expect(last_response.status).to eq 200 }
+      example do
+        expect(JSON.parse(last_response.body)).to eq(
+          '@type' => 'ssh_key',
+          '@href' => "/v3/repo/#{repo.id}/ssh_key",
+          '@representation' => 'standard',
+          'id' => repo.key.id,
+          'public_key' => repo.key.public_key,
+          'fingerprint' => repo.key.fingerprint
+        )
+      end
     end
   end
 end


### PR DESCRIPTION
Requires that users have the correct permissions to regenerate
the key for a repo.

Additional to https://github.com/travis-ci/travis-api/pull/357