### PR TITLE
Skip cron build if last build doesn't have finished_at

### DIFF
--- a/lib/travis/api/v3/models/cron.rb
+++ b/lib/travis/api/v3/models/cron.rb
@@ -27,7 +27,7 @@ module Travis::API::V3
     end
 
     def needs_new_build?
-      always_run? || (last_non_cron_build_time < (24.hour.ago))
+      always_run? || !last_non_cron_build_time || last_non_cron_build_time < 24.hour.ago
     end
 
     def skip_and_schedule_next_build
@@ -81,7 +81,8 @@ module Travis::API::V3
     end
 
     def last_non_cron_build_time
-      Build.find_by_id(branch.last_build_id).finished_at.to_datetime.utc
+      last_build = Build.find_by_id(branch.last_build_id)
+      last_build.finished_at.to_datetime.utc if last_build
     end
   end
 end

--- a/lib/travis/testing/factories.rb
+++ b/lib/travis/testing/factories.rb
@@ -137,9 +137,21 @@ FactoryGirl.define do
     repository_id { Factory(:repository).id }
   end
 
+  factory :v3_build, class: Travis::API::V3::Models::Build do
+    owner { User.first || Factory(:user) }
+    repository { Repository.first || Factory(:repository) }
+    association :request
+    association :commit
+    started_at { Time.now.utc }
+    finished_at { Time.now.utc }
+    number 1
+    state :passed
+  end
+
   factory :cron, class: Travis::API::V3::Models::Cron do
     branch { Factory(:branch) }
     interval "daily"
+    dont_run_if_recent_build_exists false
   end
 end
 

--- a/spec/v3/models/cron_spec.rb
+++ b/spec/v3/models/cron_spec.rb
@@ -111,6 +111,23 @@ describe Travis::API::V3::Models::Cron do
     end
   end
 
+  context "when always_run? is false" do
+    context "when no build has existed before running a cron build" do
+      let(:cron) { Factory(:cron, branch_id: Factory(:branch).id, dont_run_if_recent_build_exists: true) }
+      it "needs_new_build? returns true" do
+        cron.needs_new_build?.should be_truthy
+      end
+    end
+
+    context "when there was a build in the last 24h" do
+      let(:cron) { Factory(:cron, branch_id: Factory(:branch, last_build: Factory(:v3_build)).id, dont_run_if_recent_build_exists: true) }
+
+      it "needs_new_build? returns false" do
+        cron.needs_new_build?.should be_falsey
+      end
+    end
+  end
+
   context "when repo ownership is transferred" do
     it "enqueues a cron for the repo with the new owner" do
       subject.branch.repository.update_attribute(:owner, Factory(:user, name: "Yoda", login: "yoda", email: "yoda@yoda.com"))


### PR DESCRIPTION
Fixes sentry error : https://sentry.io/travis-ci/com-api-production/issues/189288118/events/4670632850/