### PR TITLE
add cache_options hash to config

### DIFF
--- a/lib/travis/config/defaults.rb
+++ b/lib/travis/config/defaults.rb
@@ -50,7 +50,8 @@ module Travis
                              rate_limit: { defaults: { api_builds: 10 }, maximums: { api_builds: 200 } } },
             endpoints:     {},
             oauth2:        {},
-            webhook:       { public_key: nil }
+            webhook:       { public_key: nil },
+            cache_options: {}
 
     default :_access => [:key]
 


### PR DESCRIPTION
The caches specs were failing because they weren't able to assign test cache_options config. The addition of this has in the default config fixes this.
