### PR TITLE
add active? method to subscription

### DIFF
--- a/lib/travis/api/v3/models/subscription.rb
+++ b/lib/travis/api/v3/models/subscription.rb
@@ -1,4 +1,9 @@
 module Travis::API::V3
   class Models::Subscription < Model
+
+    def active?
+      cc_token? and valid_to.present? and valid_to >= Time.now.utc
+    end
+
   end
 end

--- a/spec/v3/models/subscription_spec.rb
+++ b/spec/v3/models/subscription_spec.rb
@@ -1,0 +1,14 @@
+describe Travis::API::V3::Models::Subscription do
+  let!(:subscription) { Travis::API::V3::Models::Subscription.create}
+  # Factory.create(:request, event_type: event_type) }
+
+  describe "Subscription inactive" do
+    before { subscription.update_attributes(cc_token: nil, valid_to: Time.now - 100)}
+    example { Travis::API::V3::Models::Subscription.find_by_id(subscription.id).active?.should be false }
+  end
+
+  describe "Subscription active" do
+    before { subscription.update_attributes(cc_token: 'tok_0rlTxxxxxxx', valid_to: Time.now + 100)}
+    example { Travis::API::V3::Models::Subscription.find_by_id(subscription.id).active?.should be true }
+  end
+end

--- a/spec/v3/models/subscription_spec.rb
+++ b/spec/v3/models/subscription_spec.rb
@@ -1,6 +1,5 @@
 describe Travis::API::V3::Models::Subscription do
   let!(:subscription) { Travis::API::V3::Models::Subscription.create}
-  # Factory.create(:request, event_type: event_type) }
 
   describe "Subscription inactive" do
     before { subscription.update_attributes(cc_token: nil, valid_to: Time.now - 100)}


### PR DESCRIPTION
This needs to be added for the `v3/accounts` endpoint to work.

See: https://github.com/travis-pro/team-teal/issues/1627

Tests are passing locally, on travis-ci, and these changes have been deployed to both org & com staging and tested there. The endpoint is now returning the correct payload on .com.

