### PR TITLE
update active? to remove cc_token check

### DIFF
--- a/lib/travis/api/v3/models/subscription.rb
+++ b/lib/travis/api/v3/models/subscription.rb
@@ -2,7 +2,7 @@ module Travis::API::V3
   class Models::Subscription < Model
 
     def active?
-      valid_to.present? and valid_to + 1.day >= Time.now
+      valid_to.present? and valid_to >= Time.now
     end
 
   end

--- a/lib/travis/api/v3/models/subscription.rb
+++ b/lib/travis/api/v3/models/subscription.rb
@@ -2,7 +2,7 @@ module Travis::API::V3
   class Models::Subscription < Model
 
     def active?
-      cc_token? and valid_to.present? and valid_to >= Time.now.utc
+      valid_to.present? and valid_to + 1.day >= Time.now
     end
 
   end

--- a/spec/v3/models/subscription_spec.rb
+++ b/spec/v3/models/subscription_spec.rb
@@ -2,12 +2,12 @@ describe Travis::API::V3::Models::Subscription do
   let!(:subscription) { Travis::API::V3::Models::Subscription.create}
 
   describe "Subscription inactive" do
-    before { subscription.update_attributes(cc_token: nil, valid_to: Time.now - 100)}
+    before { subscription.update_attributes(valid_to: Time.now - 1.day)}
     example { Travis::API::V3::Models::Subscription.find_by_id(subscription.id).active?.should be false }
   end
 
   describe "Subscription active" do
-    before { subscription.update_attributes(cc_token: 'tok_0rlTxxxxxxx', valid_to: Time.now + 100)}
+    before { subscription.update_attributes(valid_to: Time.now + 1.day)}
     example { Travis::API::V3::Models::Subscription.find_by_id(subscription.id).active?.should be true }
   end
 end


### PR DESCRIPTION
This updates the recently added `active?` method on Subscription, removing the `cc_token` check, as some subscriptions are created manually and have no cc_token. It also conforms to the way Gatekeeper check for an active subscription, using `+ 1.day` and `- 1.day` on the timestamp.

Test are passing locally, on travis-ci, and have been deployed to com-staging (where the original problem with the `v3/accounts` endpoint appeared) and tested there.