### PR TITLE
Add alias identifiers

### DIFF
--- a/lib/travis/api/v3/routes.rb
+++ b/lib/travis/api/v3/routes.rb
@@ -162,7 +162,7 @@ module Travis::API::V3
 
       # This is the key we generate for encryption/decryption etc.
       # In V2 it was found at /repos/:repo_id/key
-      resource :ssl_key do
+      resource :ssl_key, as: :key_pair_generated do
         route '/key_pair/generated'
         get   :find
         post  :create

--- a/lib/travis/api/v3/routes/dsl.rb
+++ b/lib/travis/api/v3/routes/dsl.rb
@@ -18,8 +18,8 @@ module Travis::API::V3
       @prefix ||= ""
     end
 
-    def resource(type, &block)
-      resource = Routes::Resource.new(type)
+    def resource(identifier, **meta_data, &block)
+      resource = Routes::Resource.new(identifier, **meta_data)
       with_resource(resource, &block)
       resources << resource
     end
@@ -47,7 +47,7 @@ module Travis::API::V3
 
     def capture(mapping)
       mapping.each_pair do |key, value|
-        key = "#{current_resource.identifier}.#{key}" if current_resource and not key.to_s.include?(?.)
+        key = "#{current_resource.display_identifier}.#{key}" if current_resource and not key.to_s.include?(?.)
         mustermann_options[:capture][key.to_sym] = value
       end
     end

--- a/lib/travis/api/v3/routes/dsl.rb
+++ b/lib/travis/api/v3/routes/dsl.rb
@@ -18,8 +18,8 @@ module Travis::API::V3
       @prefix ||= ""
     end
 
-    def resource(identifier, **meta_data, &block)
-      resource = Routes::Resource.new(identifier, **meta_data)
+    def resource(identifier, **args, &block)
+      resource = Routes::Resource.new(identifier, **args)
       with_resource(resource, &block)
       resources << resource
     end

--- a/lib/travis/api/v3/routes/resource.rb
+++ b/lib/travis/api/v3/routes/resource.rb
@@ -4,10 +4,11 @@ module Travis::API::V3
   class Routes::Resource
     attr_accessor :identifier, :route, :services, :meta_data
 
-    def initialize(identifier, **meta_data)
-      @identifier = identifier
-      @services   = {}
-      @meta_data  = meta_data
+    def initialize(identifier, as: nil, **meta_data)
+      @identifier         = identifier
+      @display_identifier = as
+      @services           = {}
+      @meta_data          = meta_data
     end
 
     def add_service(request_method, service, sub_route = nil)
@@ -20,7 +21,7 @@ module Travis::API::V3
     end
 
     def display_identifier
-      meta_data.fetch(:as, identifier)
+      @display_identifier || identifier
     end
   end
 end

--- a/lib/travis/api/v3/routes/resource.rb
+++ b/lib/travis/api/v3/routes/resource.rb
@@ -18,5 +18,9 @@ module Travis::API::V3
     def route=(value)
       @route = value ? Mustermann.new(value) : value
     end
+
+    def display_identifier
+      meta_data.fetch(:as, identifier)
+    end
   end
 end

--- a/lib/travis/api/v3/service_index.rb
+++ b/lib/travis/api/v3/service_index.rb
@@ -49,7 +49,7 @@ module Travis::API::V3
           Routes::Resource.new(:template, attributes: [:request_method, :uri_template])
         ]
 
-        all.sort_by(&:identifier)
+        all.sort_by(&:display_identifier)
       end
     end
 
@@ -82,7 +82,7 @@ module Travis::API::V3
     def render_json
       resources = { }
       all_resources.each do |resource|
-        data = resources[resource.identifier] ||= { :@type => :resource, :actions => {} }
+        data = resources[resource.display_identifier] ||= { :@type => :resource, :actions => {} }
         data.merge! resource.meta_data
 
         if renderer = Renderer[resource.identifier, false]
@@ -98,20 +98,20 @@ module Travis::API::V3
           end
         end
 
-        if permissions           = Permissions[resource.identifier, false]
+        if permissions           = Permissions[resource.display_identifier, false]
           data[:permissions]     = permissions.access_rights.keys
         end
 
         resource.services.each do |(request_method, sub_route), service|
-          list    = resources[resource.identifier][:actions][service] ||= []
+          list    = resources[resource.display_identifier][:actions][service] ||= []
           pattern = sub_route ? resource.route + sub_route : resource.route
           factory = Services[resource.identifier][service]
 
           if factory.params and factory.params.include? "sort_by".freeze
-            query = Queries[resource.identifier]
+            query = Queries[resource.display_identifier]
             if query and query.sortable?
-              resources[resource.identifier][:sortable_by]  = query.sort_by.keys - query.experimental_sortable_by
-              resources[resource.identifier][:default_sort] = query.default_sort unless query.default_sort.empty?
+              resources[resource.display_identifier][:sortable_by]  = query.sort_by.keys - query.experimental_sortable_by
+              resources[resource.display_identifier][:default_sort] = query.default_sort unless query.default_sort.empty?
             end
           end
 
@@ -140,7 +140,7 @@ module Travis::API::V3
       all_resources.each do |resource|
         resource.services.each do |(request_method, sub_route), service|
           pattern  = sub_route ? resource.route + sub_route : resource.route
-          relation = "http://schema.travis-ci.com/rel/#{resource.identifier}/#{service}"
+          relation = "http://schema.travis-ci.com/rel/#{resource.display_identifier}/#{service}"
           pattern.to_templates.each do |template|
             relations[relation]           ||= {}
             relations[relation][template] ||= { allow: [], vars: template.scan(/{\+?([^}]+)}/).flatten }

--- a/spec/v3/service_index_spec.rb
+++ b/spec/v3/service_index_spec.rb
@@ -76,6 +76,22 @@ describe Travis::API::V3::ServiceIndex, set_app: true do
           specify { expect(action).to include("@type"=>"template", "request_method"=>"GET", "uri_template"=>"#{path}build/{build.id}{?include}") }
         end
       end
+      
+      describe "key pair (generated) resource" do
+        let(:resource) { resources.fetch("key_pair_generated") }
+        specify { expect(resources)         .to include("key_pair_generated") }
+        specify { expect(resource["@type"]) .to be == "resource"  }
+
+        describe "find action" do
+          let(:action) { resource.fetch("actions").fetch("find") }
+          specify { expect(action).to include("@type"=>"template", "request_method"=>"GET", "uri_template"=>"#{path}repo/{repository.id}/key_pair/generated{?include}") }
+        end
+
+        describe "create action" do
+          let(:action) { resource.fetch("actions").fetch("create") }
+          specify { expect(action).to include("@type"=>"template", "request_method"=>"POST", "uri_template"=>"#{path}repo/{repository.id}/key_pair/generated") }
+        end
+      end
 
       describe "organization resource" do
         let(:resource) { resources.fetch("organization") }


### PR DESCRIPTION
I realised that since the generated key pair resource and all related classes are named `SslKey` after the model/table, the name of the service was shown as `ssl_key` in the service index.

This adds the ability to add a "display identifier" to resources, so that we can rename resources from the API consumer's perspective without renaming our classes/resources in the codebase.

```ruby
resource :ssl_key, as: :key_pair_generated do
  route '/key_pair/generated'
  # ...
end
```

```
{
  "@type": "home",
  "@href": "/v3/",
  ...
  "resources": {
    "key_pair_generated": {
      ...
    }
  }
}
```