### PR TITLE
Allow to remove order from hooks

### DIFF
--- a/lib/travis/model/user.rb
+++ b/lib/travis/model/user.rb
@@ -79,8 +79,13 @@ class User < Travis::Model
       hooks = hooks.administratable
     end
     hooks = hooks.includes(:permissions).
-              select('repositories.*, permissions.admin as admin, permissions.push as push').
-              order('owner_name, name')
+              select('repositories.*, permissions.admin as admin, permissions.push as push')
+
+    p options
+    if options[:order] != 'none'
+      hooks = hooks.order('owner_name, name')
+    end
+
     # TODO remove owner_name/name once we're on api everywhere
     if options.key?(:id)
       hooks = hooks.where(options.slice(:id))

--- a/spec/lib/services/find_hooks_spec.rb
+++ b/spec/lib/services/find_hooks_spec.rb
@@ -22,6 +22,28 @@ describe Travis::Services::FindHooks do
     hooks.sort_by(&:id).map(&:admin?).should == [true, false]
   end
 
+  it 'does not order the repos with order=none' do
+    first = Factory(:repository, name: 'abc')
+    last = Factory(:repository, name: 'zyx')
+
+    user.permissions.create!(:repository => first, :admin => true)
+    user.permissions.create!(:repository => last,  :admin => true)
+
+    @params = { all: true }
+    service = described_class.new(user, params)
+    hooks = service.run
+    ordered_names = hooks.map(&:name).sort
+    hooks.map(&:name).should == ordered_names
+
+    @params = { all: true, order: 'none' }
+    service = described_class.new(user, params)
+    hooks = service.run
+    ordered_names = hooks.map(&:name).sort
+    hooks.map(&:name).should_not == ordered_names
+  end
+
+
+
   it 'finds repositories where the current user has admin access' do
     @params = {}
     service.run.should include(repo)


### PR DESCRIPTION
Hooks query times out from time to time for big number of repos.
Removing order seems to help a little bit. It isn't the best solution,
but for now it will help at least a little bit to lower the number of
timeouts.