### PR TITLE
Add allowed_params to POST & PATCH actions in service index

### DIFF
--- a/lib/travis/api/v3/queries/env_vars.rb
+++ b/lib/travis/api/v3/queries/env_vars.rb
@@ -1,6 +1,6 @@
 module Travis::API::V3
   class Queries::EnvVars < Query
-    params :id, :name, :value, :public, prefix: :env_var
+    params :name, :value, :public, prefix: :env_var
 
     def find(repository)
       repository.env_vars    

--- a/lib/travis/api/v3/routes.rb
+++ b/lib/travis/api/v3/routes.rb
@@ -138,12 +138,12 @@ module Travis::API::V3
 
       resource :user_settings do
         route '/settings'
-        get   :find
+        get   :for_repository
       end
 
       resource :user_setting do
         route '/setting/{user_setting.name}'
-        get  :find
+        get   :find
         patch :update
       end
 

--- a/lib/travis/api/v3/service.rb
+++ b/lib/travis/api/v3/service.rb
@@ -24,6 +24,10 @@ module Travis::API::V3
       @params
     end
 
+    def self.accepted_params
+      self.params.select { |p| p =~ /#{result_type}\./.freeze }
+    end
+
     def self.paginate(**options)
       params("limit".freeze, "offset".freeze)
       params("sort_by".freeze) if query_factory.sortable?

--- a/lib/travis/api/v3/service_index.rb
+++ b/lib/travis/api/v3/service_index.rb
@@ -119,7 +119,13 @@ module Travis::API::V3
             params    = factory.params if request_method == 'GET'.freeze
             params  &&= params.reject { |p| p.start_with? ?@.freeze }
             template += "{?#{params.sort.join(?,)}}" if params and params.any?
-            list << { :@type => :template, :request_method => request_method, :uri_template => prefix + template }
+            action    = {
+              :@type => :template,
+              :request_method => request_method,
+              :uri_template => prefix + template
+            }
+            action[:accepted_params] = factory.accepted_params if ['POST'.freeze, 'PATCH'.freeze].include? request_method
+            list << action
           end
 
         end

--- a/lib/travis/api/v3/services/env_var/update.rb
+++ b/lib/travis/api/v3/services/env_var/update.rb
@@ -1,7 +1,6 @@
 module Travis::API::V3
   class Services::EnvVar::Update < Service
-    params :id, prefix: :repository
-    params :id, :name, :value, :public, prefix: :env_var
+    params :name, :value, :public, prefix: :env_var
 
     def run!
       repository = check_login_and_find(:repository)

--- a/lib/travis/api/v3/services/env_vars/create.rb
+++ b/lib/travis/api/v3/services/env_vars/create.rb
@@ -1,7 +1,7 @@
 module Travis::API::V3
   class Services::EnvVars::Create < Service
-    params :id, prefix: :repository
-    params :id, :name, :value, :public, prefix: :env_var
+    params :name, :value, :public, prefix: :env_var
+    result_type :env_var
 
     def run!
       repository = check_login_and_find(:repository)

--- a/lib/travis/api/v3/services/user_settings/for_repository.rb
+++ b/lib/travis/api/v3/services/user_settings/for_repository.rb
@@ -1,5 +1,5 @@
 module Travis::API::V3
-  class Services::UserSettings::Find < Service
+  class Services::UserSettings::ForRepository < Service
     def run!
       repo = check_login_and_find(:repository)
       query.find(repo)

--- a/spec/v3/service_index_spec.rb
+++ b/spec/v3/service_index_spec.rb
@@ -19,7 +19,14 @@ describe Travis::API::V3::ServiceIndex, set_app: true do
 
         describe "create action" do
           let(:action) { resource.fetch("actions").fetch("create") }
-          specify { expect(action).to include("@type"=>"template", "request_method"=>"POST", "uri_template"=>"#{path}repo/{repository.id}/requests") }
+          specify do
+            expect(action).to include(
+              "@type"=>"template",
+              "request_method"=>"POST",
+              "uri_template"=>"#{path}repo/{repository.id}/requests",
+              "accepted_params" => ["request.config", "request.message", "request.branch", "request.token"]
+            )
+          end
         end
       end
 
@@ -46,12 +53,26 @@ describe Travis::API::V3::ServiceIndex, set_app: true do
 
         describe "activate action" do
           let(:action) { resource.fetch("actions").fetch("activate") }
-          specify { expect(action).to include("@type"=>"template", "request_method"=>"POST", "uri_template"=>"#{path}repo/{repository.id}/activate") }
+          specify do
+            expect(action).to include(
+              "@type"=>"template",
+              "request_method"=>"POST",
+              "uri_template"=>"#{path}repo/{repository.id}/activate",
+              "accepted_params" => []
+            )
+          end
         end
 
         describe "deactivate action" do
           let(:action) { resource.fetch("actions").fetch("deactivate") }
-          specify { expect(action).to include("@type"=>"template", "request_method"=>"POST", "uri_template"=>"#{path}repo/{repository.id}/deactivate") }
+          specify do
+            expect(action).to include(
+              "@type"=>"template",
+              "request_method"=>"POST",
+              "uri_template"=>"#{path}repo/{repository.id}/deactivate",
+              "accepted_params" => []
+            )
+          end
         end
       end
 
@@ -66,6 +87,86 @@ describe Travis::API::V3::ServiceIndex, set_app: true do
         end
       end
 
+      describe "env_vars resource" do
+        let(:resource) { resources.fetch("env_vars") }
+        specify { expect(resources)         .to include("env_vars") }
+        specify { expect(resource["@type"]) .to be == "resource"  }
+
+        describe "for_repository action" do
+          let(:action) { resource.fetch("actions").fetch("for_repository") }
+          specify { expect(action).to include("@type"=>"template", "request_method"=>"GET", "uri_template"=>"#{path}repo/{repository.id}/env_vars{?include}") }
+        end
+
+        describe "create action" do
+          let(:action) { resource.fetch("actions").fetch("create") }
+          specify do
+            expect(action).to include(
+              "@type"=>"template",
+              "request_method"=>"POST",
+              "uri_template"=>"#{path}repo/{repository.id}/env_vars",
+              "accepted_params" => ["env_var.name", "env_var.value", "env_var.public"]
+            )
+          end
+        end
+      end
+
+      describe "env_var resource" do
+        let(:resource) { resources.fetch("env_var") }
+        specify { expect(resources)         .to include("env_var") }
+        specify { expect(resource["@type"]) .to be == "resource"  }
+
+        describe "update action" do
+          let(:action) { resource.fetch("actions").fetch("update") }
+          specify do
+            expect(action).to include(
+              "@type"=>"template",
+              "request_method"=>"PATCH",
+              "uri_template"=>"#{path}repo/{repository.id}/env_var/{env_var.id}",
+              "accepted_params" => ["env_var.name", "env_var.value", "env_var.public"]
+            )
+          end
+        end
+
+        describe "delete action" do
+          let(:action) { resource.fetch("actions").fetch("delete") }
+          specify { expect(action).to include("@type"=>"template", "request_method"=>"DELETE", "uri_template"=>"#{path}repo/{repository.id}/env_var/{env_var.id}") }
+        end
+      end
+
+      describe "user_settings resource" do
+        let(:resource) { resources.fetch("user_settings") }
+        specify { expect(resources)         .to include("user_settings") }
+        specify { expect(resource["@type"]) .to be == "resource"  }
+
+        describe "find action" do
+          let(:action) { resource.fetch("actions").fetch("for_repository") }
+          specify { expect(action).to include("@type"=>"template", "request_method"=>"GET", "uri_template"=>"#{path}repo/{repository.id}/settings{?include}") }
+        end
+      end
+
+      describe "user_setting resource" do
+        let(:resource) { resources.fetch("user_setting") }
+        specify { expect(resources)         .to include("user_setting") }
+        specify { expect(resource["@type"]) .to be == "resource"  }
+
+        describe "find action" do
+          let(:action) { resource.fetch("actions").fetch("find") }
+          specify { expect(action).to include("@type"=>"template", "request_method"=>"GET", "uri_template"=>"#{path}repo/{repository.id}/setting/{user_setting.name}{?include}") }
+        end
+
+        describe "update action" do
+          let(:action) { resource.fetch("actions").fetch("update") }
+          specify do
+            expect(action).to include(
+              "@type"=>"template",
+              "request_method"=>"PATCH",
+              "uri_template"=>"#{path}repo/{repository.id}/setting/{user_setting.name}",
+              "accepted_params" => ["user_setting.value"]
+            )
+          end
+        end
+      end
+
       describe "build resource" do
         let(:resource) { resources.fetch("build") }
         specify { expect(resources)         .to include("build") }
@@ -74,6 +175,29 @@ describe Travis::API::V3::ServiceIndex, set_app: true do
         describe "find action" do
           let(:action) { resource.fetch("actions").fetch("find") }
           specify { expect(action).to include("@type"=>"template", "request_method"=>"GET", "uri_template"=>"#{path}build/{build.id}{?include}") }
+        end
+      end
+      
+      describe "key pair resource" do
+        let(:resource) { resources.fetch("key_pair") }
+        specify { expect(resources)         .to include("key_pair") }
+        specify { expect(resource["@type"]) .to be == "resource"  }
+
+        describe "find action" do
+          let(:action) { resource.fetch("actions").fetch("find") }
+          specify { expect(action).to include("@type"=>"template", "request_method"=>"GET", "uri_template"=>"#{path}repo/{repository.id}/key_pair{?include}") }
+        end
+
+        describe "create action" do
+          let(:action) { resource.fetch("actions").fetch("create") }
+          specify do
+            expect(action).to include(
+              "@type"=>"template",
+              "request_method"=>"POST",
+              "uri_template"=>"#{path}repo/{repository.id}/key_pair",
+              "accepted_params" => ["key_pair.description", "key_pair.value"]
+            )
+          end
         end
       end
       
@@ -89,7 +213,14 @@ describe Travis::API::V3::ServiceIndex, set_app: true do
 
         describe "create action" do
           let(:action) { resource.fetch("actions").fetch("create") }
-          specify { expect(action).to include("@type"=>"template", "request_method"=>"POST", "uri_template"=>"#{path}repo/{repository.id}/key_pair/generated") }
+          specify do
+            expect(action).to include(
+              "@type"=>"template",
+              "request_method"=>"POST",
+              "uri_template"=>"#{path}repo/{repository.id}/key_pair/generated",
+              "accepted_params" => []
+            )
+          end
         end
       end
 

--- a/spec/v3/services/user_settings/for_repository_spec.rb
+++ b/spec/v3/services/user_settings/for_repository_spec.rb
@@ -1,4 +1,4 @@
-describe Travis::API::V3::Services::UserSettings::Find, set_app: true do
+describe Travis::API::V3::Services::UserSettings::ForRepository, set_app: true do
   let(:repo)  { Travis::API::V3::Models::Repository.where(owner_name: 'svenfuchs', name: 'minimal').first_or_create }
   let(:token) { Travis::Api::App::AccessToken.create(user: repo.owner, app_id: 1) }
   let(:auth_headers) { { 'HTTP_AUTHORIZATION' => "token #{token}" } }


### PR DESCRIPTION
```
{
 "@type"=>"template",
 "request_method"=>"POST",
 "uri_template"=>"/repo/{repository.slug}/requests",
 "accepted_params"=> ["request.config", "request.message", "request.branch", "request.token"]
}
```

This is to:
  * Allow better discoverability of our POST/PATCH services
  * Add params automatically to the developer app (v3 docs)

This commit also changes the name of the `env_var` `Find` service to
`ForRepository`, which is in line with the other services.