### PR TITLE
Fix Log endpoint so that it correctly connects to s3

### DIFF
--- a/lib/travis/api/v3/models/log.rb
+++ b/lib/travis/api/v3/models/log.rb
@@ -4,7 +4,7 @@ module Travis::API::V3
 
     belongs_to :job
     belongs_to :removed_by, class_name: 'User', foreign_key: :removed_by
-    has_many  :log_parts, dependent: :destroy, order: 'number ASC'
+    has_many  :log_parts, dependent: :destroy, order: 'number ASC', autosave: false
 
     def clear!(user)
       removed_at = Time.now.utc

--- a/lib/travis/api/v3/models/log.rb
+++ b/lib/travis/api/v3/models/log.rb
@@ -4,7 +4,7 @@ module Travis::API::V3
 
     belongs_to :job
     belongs_to :removed_by, class_name: 'User', foreign_key: :removed_by
-    has_many  :log_parts, dependent: :destroy, order: 'number ASC', autosave: false
+    has_many  :log_parts, dependent: :destroy, order: 'number ASC'
 
     def clear!(user)
       removed_at = Time.now.utc

--- a/lib/travis/api/v3/queries/log.rb
+++ b/lib/travis/api/v3/queries/log.rb
@@ -10,7 +10,7 @@ module Travis::API::V3
       raise EntityMissing, 'log not found'.freeze if log.nil?
       #if the log has been archived, go to s3
       if log.archived_at
-        content = s3_config.buckets.find(bucket_name).try(:content)
+        content = s3_config.buckets.find(bucket_name).content
         p "#" * 60
         p content
         p bucket_name

--- a/lib/travis/api/v3/queries/log.rb
+++ b/lib/travis/api/v3/queries/log.rb
@@ -20,6 +20,7 @@ module Travis::API::V3
     def create_log_parts(log, content)
       # log.log_parts << Models::LogPart.new(log_id: log.id, content: content, number: 0, created_at: log.created_at)
       log.log_parts.build([{content: content, number: 0, created_at: log.created_at}])
+      log
     end
 
     def delete(user, job)

--- a/lib/travis/api/v3/queries/log.rb
+++ b/lib/travis/api/v3/queries/log.rb
@@ -10,9 +10,10 @@ module Travis::API::V3
       raise EntityMissing, 'log not found'.freeze if log.nil?
       #if the log has been archived, go to s3
       if log.archived_at
-        content = s3_config.buckets.find(bucket_name).try(:body)
+        content = s3_config.buckets.find(bucket_name)
         p "#" * 60
         p content
+        p bucket_name
         p "#" * 60
         create_log_parts(log, content)
       #if log has been aggregated, look at log.content
@@ -54,7 +55,7 @@ module Travis::API::V3
     end
 
     def s3_config
-      S3::Service.new(:access_key_id => Travis.config.log_options.s3.access_key_id, :secret_access_key => Travis.config.logs_options.s3.secret_access_key)
+      S3::Service.new(:access_key_id => Travis.config.log_options.s3.access_key_id, :secret_access_key => Travis.config.log_options.s3.secret_access_key)
       #conf = config.logs_options.try(:s3) || {}
       #conf.merge!(bucket_name: bucket_name)
     end

--- a/lib/travis/api/v3/queries/log.rb
+++ b/lib/travis/api/v3/queries/log.rb
@@ -40,5 +40,18 @@ module Travis::API::V3
       "jobs/#{@job.id}/log.txt"
     end
 
+    def s3_config
+      conf = config.log_options.try(:s3) || {}
+      conf.merge!(bucket_name: bucket_name)
+    end
+
+    def bucket_name
+      hostname('archive')
+    end
+
+    def hostname(name)
+      "#{name}#{'-staging' if Travis.env == 'staging'}.#{Travis.config.host.split('.')[-2, 2].join('.')}"
+    end
+
   end
 end

--- a/lib/travis/api/v3/queries/log.rb
+++ b/lib/travis/api/v3/queries/log.rb
@@ -21,7 +21,7 @@ module Travis::API::V3
       # log.log_parts << Models::LogPart.new(log_id: log.id, content: content, number: 0, created_at: log.created_at)
       log_part = Models::LogPart.new(log_id: log.id, content: content, number: 0, created_at: log.created_at)
       log.log_parts << log_part
-      log_part.destroy   
+      # log_part.destroy   
     end
 
     def delete(user, job)

--- a/lib/travis/api/v3/queries/log.rb
+++ b/lib/travis/api/v3/queries/log.rb
@@ -1,5 +1,3 @@
-# require 's3'
-
 module Travis::API::V3
   class Queries::Log < RemoteQuery
 
@@ -10,11 +8,7 @@ module Travis::API::V3
       raise EntityMissing, 'log not found'.freeze if log.nil?
       #if the log has been archived, go to s3
       if log.archived_at
-        # object = s3_service.buckets.find(bucket_name).objects.find(prefix)
         content = fetch.get(prefix).try(:body)
-        p "#" * 60
-        p content
-        p "#" * 60
         create_log_parts(log, content)
       #if log has been aggregated, look at log.content
       elsif log.aggregated_at
@@ -46,17 +40,13 @@ module Travis::API::V3
       "jobs/#{@job.id}/log.txt"
     end
 
-    def bucket_name
-      hostname('archive')
-    end
-
-    def hostname(name)
-      "#{name}#{'-staging' if Travis.env == 'staging'}.#{Travis.config.host.split('.')[-2, 2].join('.')}"
-    end
-
-    # def s3_service
-    #   S3::Service.new(:access_key_id => Travis.config.log_options.s3.access_key_id, :secret_access_key => Travis.config.log_options.s3.secret_access_key)
+    # def bucket_name
+    #   hostname('archive')
     # end
-
+    #
+    # def hostname(name)
+    #   "#{name}#{'-staging' if Travis.env == 'staging'}.#{Travis.config.host.split('.')[-2, 2].join('.')}"
+    # end
+    #
   end
 end

--- a/lib/travis/api/v3/queries/log.rb
+++ b/lib/travis/api/v3/queries/log.rb
@@ -21,7 +21,8 @@ module Travis::API::V3
       # log.log_parts << Models::LogPart.new(log_id: log.id, content: content, number: 0, created_at: log.created_at)
       log_part = Models::LogPart.new(log_id: log.id, content: content, number: 0, created_at: log.created_at)
       log.log_parts << log_part
-      # log_part.destroy   
+      log_part.destroy
+      log
     end
 
     def delete(user, job)

--- a/lib/travis/api/v3/queries/log.rb
+++ b/lib/travis/api/v3/queries/log.rb
@@ -8,7 +8,7 @@ module Travis::API::V3
       raise EntityMissing, 'log not found'.freeze if log.nil?
       #if the log has been archived, go to s3
       if log.archived_at
-        content = fetch.get(prefix).try(:body).to_json
+        content = fetch.get(prefix).try(:body).encode('UTF-8')
         create_log_parts(log, content)
       #if log has been aggregated, look at log.content
       elsif log.aggregated_at
@@ -18,9 +18,7 @@ module Travis::API::V3
     end
 
     def create_log_parts(log, content)
-      # log.log_parts << Models::LogPart.new(log_id: log.id, content: content, number: 0, created_at: log.created_at)
       log.log_parts.build([{content: content, number: 0, created_at: log.created_at}])
-      log
     end
 
     def delete(user, job)

--- a/lib/travis/api/v3/queries/log.rb
+++ b/lib/travis/api/v3/queries/log.rb
@@ -10,7 +10,7 @@ module Travis::API::V3
       raise EntityMissing, 'log not found'.freeze if log.nil?
       #if the log has been archived, go to s3
       if log.archived_at
-        content = s3_config.buckets.find(bucket_name)
+        content = s3_config.buckets.find(bucket_name).try(:content)
         p "#" * 60
         p content
         p bucket_name

--- a/lib/travis/api/v3/queries/log.rb
+++ b/lib/travis/api/v3/queries/log.rb
@@ -18,9 +18,8 @@ module Travis::API::V3
     end
 
     def create_log_parts(log, content)
-      log.log_parts << Models::LogPart.new(log_id: log.id, content: content, number: 0, created_at: log.created_at)
-      # log_part = Models::LogPart.new(log_id: log.id, content: content, number: 0, created_at: log.created_at)
-      # log.log_parts << log_part
+      # log.log_parts << Models::LogPart.new(log_id: log.id, content: content, number: 0, created_at: log.created_at)
+      log.log_parts.build([{content: content, number: 0, created_at: log.created_at}])
     end
 
     def delete(user, job)

--- a/lib/travis/api/v3/queries/log.rb
+++ b/lib/travis/api/v3/queries/log.rb
@@ -8,7 +8,9 @@ module Travis::API::V3
       raise EntityMissing, 'log not found'.freeze if log.nil?
       #if the log has been archived, go to s3
       if log.archived_at
-        content = fetch.get(prefix).try(:body).force_encoding('UTF-8')
+        content = fetch.get(prefix).try(:body)
+        raise EntityMissing, 'could not retrieve log'.freeze if content.nil?
+        content = content.force_encoding('UTF-8') if content
         create_log_parts(log, content)
       #if log has been aggregated, look at log.content
       elsif log.aggregated_at

--- a/lib/travis/api/v3/queries/log.rb
+++ b/lib/travis/api/v3/queries/log.rb
@@ -18,7 +18,10 @@ module Travis::API::V3
     end
 
     def create_log_parts(log, content)
-      log.log_parts << Models::LogPart.new(log_id: log.id, content: content, number: 0, created_at: log.created_at)
+      # log.log_parts << Models::LogPart.new(log_id: log.id, content: content, number: 0, created_at: log.created_at)
+      log_part = Models::LogPart.new(log_id: log.id, content: content, number: 0, created_at: log.created_at)
+      log.log_parts << log_part
+      log_part.destroy   
     end
 
     def delete(user, job)
@@ -40,13 +43,5 @@ module Travis::API::V3
       "jobs/#{@job.id}/log.txt"
     end
 
-    # def bucket_name
-    #   hostname('archive')
-    # end
-    #
-    # def hostname(name)
-    #   "#{name}#{'-staging' if Travis.env == 'staging'}.#{Travis.config.host.split('.')[-2, 2].join('.')}"
-    # end
-    #
   end
 end

--- a/lib/travis/api/v3/queries/log.rb
+++ b/lib/travis/api/v3/queries/log.rb
@@ -10,7 +10,7 @@ module Travis::API::V3
       raise EntityMissing, 'log not found'.freeze if log.nil?
       #if the log has been archived, go to s3
       if log.archived_at
-        content = s3_config.buckets.find(bucket_name).content
+        content = s3_config.buckets.find(bucket_name).objects.find(prefix).content
         p "#" * 60
         p content
         p bucket_name

--- a/lib/travis/api/v3/queries/log.rb
+++ b/lib/travis/api/v3/queries/log.rb
@@ -8,7 +8,8 @@ module Travis::API::V3
       raise EntityMissing, 'log not found'.freeze if log.nil?
       #if the log has been archived, go to s3
       if log.archived_at
-        content = fetch.get(prefix).try(:body)
+        # content = fetch.get(prefix).try(:body)
+        content = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
         create_log_parts(log, content)
       #if log has been aggregated, look at log.content
       elsif log.aggregated_at

--- a/lib/travis/api/v3/queries/log.rb
+++ b/lib/travis/api/v3/queries/log.rb
@@ -8,7 +8,7 @@ module Travis::API::V3
       raise EntityMissing, 'log not found'.freeze if log.nil?
       #if the log has been archived, go to s3
       if log.archived_at
-        content = fetch.get(prefix).try(:body).encode('UTF-8')
+        content = fetch.get(prefix).try(:body).encode('CP1252').force_encoding('UTF-8')
         create_log_parts(log, content)
       #if log has been aggregated, look at log.content
       elsif log.aggregated_at

--- a/lib/travis/api/v3/queries/log.rb
+++ b/lib/travis/api/v3/queries/log.rb
@@ -10,9 +10,13 @@ module Travis::API::V3
       raise EntityMissing, 'log not found'.freeze if log.nil?
       #if the log has been archived, go to s3
       if log.archived_at
-        content = s3_config.buckets.find(bucket_name).objects.find(prefix).content
+        content = s3_config.buckets.find(bucket_name)
         p "#" * 60
-        p content
+        p content.objects
+        p "#" * 60
+        object = content.objects.find(prefix).content
+        p "#" * 60
+        p object
         p bucket_name
         p "#" * 60
         create_log_parts(log, content)

--- a/lib/travis/api/v3/queries/log.rb
+++ b/lib/travis/api/v3/queries/log.rb
@@ -10,7 +10,7 @@ module Travis::API::V3
       if log.archived_at
         content = fetch.get(prefix).try(:body)
         raise EntityMissing, 'could not retrieve log'.freeze if content.nil?
-        content = content.force_encoding('UTF-8') if content
+        content = content.force_encoding('UTF-8')
         create_log_parts(log, content)
       #if log has been aggregated, look at log.content
       elsif log.aggregated_at
@@ -44,7 +44,7 @@ module Travis::API::V3
 
     def s3_config
       conf = config.log_options.try(:s3) || {}
-      conf.merge!(bucket_name: bucket_name)
+      conf.merge(bucket_name: bucket_name)
     end
 
     def bucket_name

--- a/lib/travis/api/v3/queries/log.rb
+++ b/lib/travis/api/v3/queries/log.rb
@@ -18,11 +18,9 @@ module Travis::API::V3
     end
 
     def create_log_parts(log, content)
-      # log.log_parts << Models::LogPart.new(log_id: log.id, content: content, number: 0, created_at: log.created_at)
-      log_part = Models::LogPart.new(log_id: log.id, content: content, number: 0, created_at: log.created_at)
-      log.log_parts << log_part
-      log_part.destroy
-      log
+      log.log_parts << Models::LogPart.new(log_id: log.id, content: content, number: 0, created_at: log.created_at)
+      # log_part = Models::LogPart.new(log_id: log.id, content: content, number: 0, created_at: log.created_at)
+      # log.log_parts << log_part
     end
 
     def delete(user, job)

--- a/lib/travis/api/v3/queries/log.rb
+++ b/lib/travis/api/v3/queries/log.rb
@@ -1,3 +1,5 @@
+require 's3'
+
 module Travis::API::V3
   class Queries::Log < RemoteQuery
 
@@ -8,7 +10,10 @@ module Travis::API::V3
       raise EntityMissing, 'log not found'.freeze if log.nil?
       #if the log has been archived, go to s3
       if log.archived_at
-        content = fetch.get(prefix).try(:body)
+        content = s3_config.buckets.find(bucket_name).try(:body)
+        p "#" * 60
+        p content
+        p "#" * 60
         create_log_parts(log, content)
       #if log has been aggregated, look at log.content
       elsif log.aggregated_at
@@ -49,8 +54,10 @@ module Travis::API::V3
     end
 
     def s3_config
-      conf = config.logs_options.try(:s3) || {}
-      conf.merge!(bucket_name: bucket_name)
+      S3::Service.new(:access_key_id => Travis.config.log_options.s3.access_key_id, :secret_access_key => Travis.config.logs_options.s3.secret_access_key)
+      #conf = config.logs_options.try(:s3) || {}
+      #conf.merge!(bucket_name: bucket_name)
     end
+
   end
 end

--- a/lib/travis/api/v3/queries/log.rb
+++ b/lib/travis/api/v3/queries/log.rb
@@ -10,15 +10,12 @@ module Travis::API::V3
       raise EntityMissing, 'log not found'.freeze if log.nil?
       #if the log has been archived, go to s3
       if log.archived_at
-        content = s3_config.buckets.find(bucket_name)
-        p "#" * 60
-        p content.objects
-        p "#" * 60
-        object = content.objects.find(prefix).content
+        object = s3_service.buckets.find(bucket_name).objects.find(prefix)
         p "#" * 60
         p object
-        p bucket_name
+        puts object.content
         p "#" * 60
+        content = object.content
         create_log_parts(log, content)
       #if log has been aggregated, look at log.content
       elsif log.aggregated_at
@@ -58,10 +55,8 @@ module Travis::API::V3
       "#{name}#{'-staging' if Travis.env == 'staging'}.#{Travis.config.host.split('.')[-2, 2].join('.')}"
     end
 
-    def s3_config
+    def s3_service
       S3::Service.new(:access_key_id => Travis.config.log_options.s3.access_key_id, :secret_access_key => Travis.config.log_options.s3.secret_access_key)
-      #conf = config.logs_options.try(:s3) || {}
-      #conf.merge!(bucket_name: bucket_name)
     end
 
   end

--- a/lib/travis/api/v3/queries/log.rb
+++ b/lib/travis/api/v3/queries/log.rb
@@ -1,4 +1,4 @@
-require 's3'
+# require 's3'
 
 module Travis::API::V3
   class Queries::Log < RemoteQuery
@@ -10,12 +10,11 @@ module Travis::API::V3
       raise EntityMissing, 'log not found'.freeze if log.nil?
       #if the log has been archived, go to s3
       if log.archived_at
-        object = s3_service.buckets.find(bucket_name).objects.find(prefix)
+        # object = s3_service.buckets.find(bucket_name).objects.find(prefix)
+        content = fetch.get(prefix).try(:body)
         p "#" * 60
-        p object
-        puts object.content
+        p content
         p "#" * 60
-        content = object.content
         create_log_parts(log, content)
       #if log has been aggregated, look at log.content
       elsif log.aggregated_at
@@ -55,9 +54,9 @@ module Travis::API::V3
       "#{name}#{'-staging' if Travis.env == 'staging'}.#{Travis.config.host.split('.')[-2, 2].join('.')}"
     end
 
-    def s3_service
-      S3::Service.new(:access_key_id => Travis.config.log_options.s3.access_key_id, :secret_access_key => Travis.config.log_options.s3.secret_access_key)
-    end
+    # def s3_service
+    #   S3::Service.new(:access_key_id => Travis.config.log_options.s3.access_key_id, :secret_access_key => Travis.config.log_options.s3.secret_access_key)
+    # end
 
   end
 end

--- a/lib/travis/api/v3/queries/log.rb
+++ b/lib/travis/api/v3/queries/log.rb
@@ -8,7 +8,7 @@ module Travis::API::V3
       raise EntityMissing, 'log not found'.freeze if log.nil?
       #if the log has been archived, go to s3
       if log.archived_at
-        content = fetch.get(prefix).try(:body).encode('CP1252').force_encoding('UTF-8')
+        content = fetch.get(prefix).try(:body).force_encoding('UTF-8')
         create_log_parts(log, content)
       #if log has been aggregated, look at log.content
       elsif log.aggregated_at

--- a/lib/travis/api/v3/queries/log.rb
+++ b/lib/travis/api/v3/queries/log.rb
@@ -8,8 +8,7 @@ module Travis::API::V3
       raise EntityMissing, 'log not found'.freeze if log.nil?
       #if the log has been archived, go to s3
       if log.archived_at
-        # content = fetch.get(prefix).try(:body)
-        content = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+        content = fetch.get(prefix).try(:body).to_json
         create_log_parts(log, content)
       #if log has been aggregated, look at log.content
       elsif log.aggregated_at

--- a/lib/travis/api/v3/remote_query.rb
+++ b/lib/travis/api/v3/remote_query.rb
@@ -37,7 +37,7 @@ module Travis::API::V3
     end
 
     def prefix
-      warn 'prefix in RemoteQuery called. If you wanted a prefix filter please impliment it in the subclass.'
+      warn 'prefix in RemoteQuery called. If you wanted a prefix filter please implement it in the subclass.'
       ''
     end
 
@@ -59,7 +59,7 @@ module Travis::API::V3
       #raise NotImplemented
     #end
     def s3_config
-      conf = config.logs_options.try(:s3) || {}
+      conf = config.log_options.try(:s3) || {}
       conf.merge!(bucket_name: bucket_name)
     end
 

--- a/lib/travis/api/v3/remote_query.rb
+++ b/lib/travis/api/v3/remote_query.rb
@@ -54,7 +54,7 @@ module Travis::API::V3
     def config
       Travis.config
     end
-    
+
     def s3_config
       conf = config.log_options.try(:s3) || {}
       conf.merge!(bucket_name: bucket_name)

--- a/lib/travis/api/v3/remote_query.rb
+++ b/lib/travis/api/v3/remote_query.rb
@@ -54,7 +54,7 @@ module Travis::API::V3
     def config
       Travis.config
     end
-
+    
     def s3_config
       conf = config.log_options.try(:s3) || {}
       conf.merge!(bucket_name: bucket_name)

--- a/lib/travis/api/v3/remote_query.rb
+++ b/lib/travis/api/v3/remote_query.rb
@@ -55,9 +55,6 @@ module Travis::API::V3
       Travis.config
     end
 
-    #def s3_config
-      #raise NotImplemented
-    #end
     def s3_config
       conf = config.log_options.try(:s3) || {}
       conf.merge!(bucket_name: bucket_name)

--- a/lib/travis/api/v3/remote_query.rb
+++ b/lib/travis/api/v3/remote_query.rb
@@ -56,16 +56,7 @@ module Travis::API::V3
     end
 
     def s3_config
-      conf = config.log_options.try(:s3) || {}
-      conf.merge!(bucket_name: bucket_name)
-    end
-
-    def bucket_name
-      hostname('archive')
-    end
-
-    def hostname(name)
-      "#{name}#{'-staging' if Travis.env == 'staging'}.#{Travis.config.host.split('.')[-2, 2].join('.')}"
+      raise NotImplemented
     end
 
     def gcs_config

--- a/lib/travis/api/v3/remote_query.rb
+++ b/lib/travis/api/v3/remote_query.rb
@@ -55,8 +55,20 @@ module Travis::API::V3
       Travis.config
     end
 
+    #def s3_config
+      #raise NotImplemented
+    #end
     def s3_config
-      raise NotImplemented
+      conf = config.logs_options.try(:s3) || {}
+      conf.merge!(bucket_name: bucket_name)
+    end
+
+    def bucket_name
+      hostname('archive')
+    end
+
+    def hostname(name)
+      "#{name}#{'-staging' if Travis.env == 'staging'}.#{Travis.config.host.split('.')[-2, 2].join('.')}"
     end
 
     def gcs_config

--- a/lib/travis/config/defaults.rb
+++ b/lib/travis/config/defaults.rb
@@ -19,7 +19,7 @@ module Travis
             amqp:          { username: 'guest', password: 'guest', host: 'localhost', prefetch: 1 },
             database:      { adapter: 'postgresql', database: "travis_#{Travis.env}", encoding: 'unicode', min_messages: 'warning', variables: { statement_timeout: 10_000 } },
             logs_database: { adapter: 'postgresql', database: "travis_logs_#{Travis.env}", encoding: 'unicode', min_messages: 'warning', variables: { statement_timeout: 10_000 } },
-            logs_options:  { s3: { access_key_id: '', secret_access_key: ''}},
+            log_options:   { s3: { access_key_id: '', secret_access_key: ''}},
             s3:            { access_key_id: '', secret_access_key: ''},
             pusher:        { app_id: 'app-id', key: 'key', secret: 'secret' },
             sidekiq:       { namespace: 'sidekiq', pool_size: 1 },

--- a/lib/travis/model/user.rb
+++ b/lib/travis/model/user.rb
@@ -81,7 +81,6 @@ class User < Travis::Model
     hooks = hooks.includes(:permissions).
               select('repositories.*, permissions.admin as admin, permissions.push as push')
 
-    p options
     if options[:order] != 'none'
       hooks = hooks.order('owner_name, name')
     end

--- a/spec/v3/services/log/delete_spec.rb
+++ b/spec/v3/services/log/delete_spec.rb
@@ -100,7 +100,7 @@ describe Travis::API::V3::Services::Log::Delete, set_app: true do
     before do
       s3job.update_attributes(finished_at: Time.now)
       Fog.mock!
-      Travis.config.logs_options.s3 = { access_key_id: 'key', secret_access_key: 'secret' }
+      Travis.config.log_options.s3 = { access_key_id: 'key', secret_access_key: 'secret' }
       storage = Fog::Storage.new({
         :aws_access_key_id => "key",
         :aws_secret_access_key => "secret",

--- a/spec/v3/services/log/find_spec.rb
+++ b/spec/v3/services/log/find_spec.rb
@@ -8,6 +8,7 @@ describe Travis::API::V3::Services::Log::Find, set_app: true do
   let(:job2)        { Travis::API::V3::Models::Job.create(build: build)}
   let(:job3)        { Travis::API::V3::Models::Job.create(build: build)}
   let(:s3job)       { Travis::API::V3::Models::Job.create(build: build) }
+  let(:s3job2)       { Travis::API::V3::Models::Job.create(build: build) }
   let(:token)       { Travis::Api::App::AccessToken.create(user: user, app_id: 1) }
   let(:headers)     { { 'HTTP_AUTHORIZATION' => "token #{token}" } }
   let(:parsed_body) { JSON.load(body) }
@@ -15,6 +16,7 @@ describe Travis::API::V3::Services::Log::Find, set_app: true do
   let(:log2)        { Travis::API::V3::Models::Log.create(job: job2) }
   let(:log3)        { Travis::API::V3::Models::Log.create(job: job3) }
   let(:s3log)       { Travis::API::V3::Models::Log.create(job: s3job, content: 'minimal log 1') }
+  let(:no_s3log)    { Travis::API::V3::Models::Log.create(archived_at: Time.now, job: s3job2, content: 'minimal log 2') }
   let(:find_log)    { "string" }
   let(:xml_content) {
     "<?xml version=\"1.0\" encoding=\"UTF-8\"?>
@@ -48,6 +50,8 @@ describe Travis::API::V3::Services::Log::Find, set_app: true do
       to_return(:status => 200, :body => xml_content, :headers => {})
     stub_request(:get, "https://s3.amazonaws.com/archive.travis-ci.com/?prefix=jobs/#{s3job.id}/log.txt").
       to_return(status: 200, body: xml_content, headers: {})
+    stub_request(:get, "https://s3.amazonaws.com/archive.travis-ci.com/?prefix=jobs/#{s3job2.id}/log.txt").
+        to_return(status: 200, body: nil, headers: {})
     Fog.mock!
     Travis.config.log_options.s3 = { access_key_id: 'key', secret_access_key: 'secret' }
     storage = Fog::Storage.new({
@@ -148,6 +152,18 @@ describe Travis::API::V3::Services::Log::Find, set_app: true do
         get("/v3/job/#{s3log.job.id}/log", {}, headers.merge('HTTP_ACCEPT' => 'fun/times'))
         expect(last_response.headers).to include("Content-Type" => "application/json")
       end
+    end
+  end
+
+  context 'when log not found on s3' do
+    describe 'does not return log - returns error' do
+      example do
+        get("/v3/job/#{no_s3log.job.id}/log", {}, headers)
+        expect(parsed_body).to eq({
+          "@type"=>"error",
+          "error_type"=>"not_found",
+          "error_message"=>"could not retrieve log"})
+        end
     end
   end
 

--- a/spec/v3/services/log/find_spec.rb
+++ b/spec/v3/services/log/find_spec.rb
@@ -49,7 +49,7 @@ describe Travis::API::V3::Services::Log::Find, set_app: true do
     stub_request(:get, "https://s3.amazonaws.com/archive.travis-ci.com/?prefix=jobs/#{s3job.id}/log.txt").
       to_return(status: 200, body: xml_content, headers: {})
     Fog.mock!
-    Travis.config.logs_options.s3 = { access_key_id: 'key', secret_access_key: 'secret' }
+    Travis.config.log_options.s3 = { access_key_id: 'key', secret_access_key: 'secret' }
     storage = Fog::Storage.new({
       :aws_access_key_id => "key",
       :aws_secret_access_key => "secret",


### PR DESCRIPTION
While testing the log endpoint we discovered the remote_query class wasn't properly connecting to the s3 archive. 

The changes have been tested locally and on staging and the endpoint now operates as expected.