### PR TITLE
Load key pair properly

### DIFF
--- a/lib/travis/api/v3/models/repository.rb
+++ b/lib/travis/api/v3/models/repository.rb
@@ -86,7 +86,7 @@ module Travis::API::V3
 
     def key_pair
       return unless settings['ssh_key']
-      Models::KeyPair.new(settings['ssh_key']).tap do |kp|
+      Models::KeyPair.load(settings['ssh_key']).tap do |kp|
         kp.sync(self, :settings)
       end
     end

--- a/lib/travis/api/v3/models/ssl_key.rb
+++ b/lib/travis/api/v3/models/ssl_key.rb
@@ -22,7 +22,7 @@ module Travis::API::V3
     end
 
     def fingerprint_source
-      public_key
+      private_key
     end
 
     def encoded_public_key

--- a/spec/v3/models/fingerprint_spec.rb
+++ b/spec/v3/models/fingerprint_spec.rb
@@ -1,0 +1,43 @@
+describe Travis::API::V3::Models::Fingerprint do
+  let(:klass_without_implementation) do
+    Class.new do
+      include Travis::API::V3::Models::Fingerprint
+    end
+  end
+  let(:klass_with_nil_source) do
+    Class.new do
+      include Travis::API::V3::Models::Fingerprint
+      def fingerprint_source
+        nil
+      end
+    end
+  end
+  let(:klass_with_source) do
+    Class.new do
+      include Travis::API::V3::Models::Fingerprint
+      def fingerprint_source
+        OpenSSL::PKey::RSA.new(TEST_PRIVATE_KEY).to_pem
+      end
+    end
+  end
+
+  it 'must define fingerprint source' do
+    instance = klass_without_implementation.new
+    expect { instance.fingerprint }.to raise_error(NotImplementedError)
+  end
+
+  it 'returns nil when source is nil' do
+    instance = klass_with_nil_source.new
+    expect(instance.fingerprint).to be_nil
+  end
+
+  it 'returns fingerprint when source is a private key' do
+    instance = klass_with_source.new
+    expect(instance.fingerprint).to eq described_class.calculate(instance.fingerprint_source)
+  end
+
+  it 'calculates fingerprint from private key' do
+    key = OpenSSL::PKey::RSA.new(TEST_PRIVATE_KEY)
+    expect(described_class.calculate(key.to_pem)).to eq "57:78:65:c2:c9:c8:c9:f7:dd:2b:35:39:40:27:d2:40"
+  end
+end

--- a/spec/v3/services/key_pair/create_spec.rb
+++ b/spec/v3/services/key_pair/create_spec.rb
@@ -30,7 +30,7 @@ describe Travis::API::V3::Services::KeyPair::Create, set_app: true do
         before { Travis::API::V3::Models::Permission.create(repository: repo, user: repo.owner, push: true) }
 
         describe 'key pair already exists' do
-          let(:key) { OpenSSL::PKey::RSA.generate(4096) }
+          let(:key) { OpenSSL::PKey::RSA.generate(2048) }
           let(:params) do
             {
               'key_pair.description' => 'foo',
@@ -83,7 +83,7 @@ describe Travis::API::V3::Services::KeyPair::Create, set_app: true do
         end
 
         describe 'creates key pair' do
-          let(:key) { OpenSSL::PKey::RSA.generate(4096) }
+          let(:key) { OpenSSL::PKey::RSA.generate(2048) }
           let(:fingerprint) { Travis::API::V3::Models::Fingerprint.calculate(key.to_pem) }
           let(:params) do
             {

--- a/spec/v3/services/key_pair/find_spec.rb
+++ b/spec/v3/services/key_pair/find_spec.rb
@@ -5,7 +5,7 @@ describe Travis::API::V3::Services::KeyPair::Find, set_app: true do
   let(:repo) { Travis::API::V3::Models::Repository.where(owner_name: 'svenfuchs', name: 'minimal').first_or_create }
   let(:token) { Travis::Api::App::AccessToken.create(user: repo.owner, app_id: 1) }
   let(:key) { OpenSSL::PKey::RSA.generate(4096) }
-  let(:key_pair) { { description: 'foo key pair', value: key.to_pem, repository_id: repo.id } }
+  let(:key_pair) { { description: 'foo key pair', value: Travis::Settings::EncryptedValue.new(key.to_pem), repository_id: repo.id } }
   let(:auth_headers) { { 'HTTP_AUTHORIZATION' => "token #{token}" } }
 
   describe 'not authenticated' do

--- a/spec/v3/services/key_pair/update_spec.rb
+++ b/spec/v3/services/key_pair/update_spec.rb
@@ -26,7 +26,7 @@ describe Travis::API::V3::Services::KeyPair::Update, set_app: true do
       end
 
       context 'correct user' do
-        let(:key) { OpenSSL::PKey::RSA.generate(4096) }
+        let(:key) { OpenSSL::PKey::RSA.generate(2048) }
 
         before { Travis::API::V3::Models::Permission.create(repository: repo, user: repo.owner, push: true) }
 
@@ -52,7 +52,7 @@ describe Travis::API::V3::Services::KeyPair::Update, set_app: true do
           end
 
           before do
-            repo.update_attribute(:settings, JSON.generate(ssh_key: { description: 'foo', value: key.to_pem, repository_id: repo.id }))
+            repo.update_attribute(:settings, JSON.generate(ssh_key: { description: 'foo', value: Travis::Settings::EncryptedValue.new(key.to_pem), repository_id: repo.id }))
             patch("/v3/repo/#{repo.id}/key_pair", JSON.generate(params), auth_headers.merge(json_headers))
           end
 
@@ -86,7 +86,7 @@ describe Travis::API::V3::Services::KeyPair::Update, set_app: true do
           end
 
           before do
-            repo.update_attribute(:settings, JSON.generate(ssh_key: { description: 'foo', value: key.to_pem, repository_id: repo.id }))
+            repo.update_attribute(:settings, JSON.generate(ssh_key: { description: 'foo', value: Travis::Settings::EncryptedValue.new(key.to_pem), repository_id: repo.id }))
             patch("/v3/repo/#{repo.id}/key_pair", JSON.generate(params), auth_headers.merge(json_headers))
           end
 
@@ -101,7 +101,7 @@ describe Travis::API::V3::Services::KeyPair::Update, set_app: true do
         end
 
         describe 'updates key pair' do
-          let(:new_key) { OpenSSL::PKey::RSA.generate(4096) }
+          let(:new_key) { OpenSSL::PKey::RSA.generate(2048) }
           let(:params) do
             {
               'key_pair.description' => 'new description',
@@ -110,7 +110,7 @@ describe Travis::API::V3::Services::KeyPair::Update, set_app: true do
           end
 
           before do
-            repo.update_attribute(:settings, JSON.generate(ssh_key: { description: 'foo', value: key.to_pem, repository_id: repo.id }))
+            repo.update_attribute(:settings, JSON.generate(ssh_key: { description: 'foo', value: Travis::Settings::EncryptedValue.new(key.to_pem), repository_id: repo.id }))
             patch("/v3/repo/#{repo.id}/key_pair", JSON.generate(params), auth_headers.merge(json_headers))
           end
 


### PR DESCRIPTION
Models which inherit from `Travis::Settings::Model` must use `#load` for instantiation, if they contain non-primitive attributes like `EncryptedValue`.

This PR also corrects the fingerprint calculation, which should always use the PEM as its source.

The key length has changed to bring the tests in line with V2, and also to speed up generation.