### PR TITLE
Truncate logs db after test run

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -92,6 +92,14 @@ RSpec.configure do |c|
       endpoint.superclass.direct_subclasses.delete(endpoint)
     end
   end
+
+  c.after :suite do
+    # DatabaseCleaner is not cleaning up the logs database, so this
+    # avoids leaving records lying around between test runs
+    base = ActiveRecord::Base
+    base.establish_connection(Travis.config.logs_database)
+    base.connection.tables.each { |table| base.connection.execute("TRUNCATE #{table}") }
+  end
 end
 
 require 'timecop'


### PR DESCRIPTION
DatabaseCleaner is not cleaning up the logs database, which causes intermittent failures when logs and log_parts rows are left behind.

This avoids that issue by truncating the tables in the logs database after the test suite has run. I tried to get DatabaseCleaner running with two db connections, but it caused issues with nested transactions and I don't want to lose more time on it.