### PR TITLE
Ensure repo id is always set as additional attribute

### DIFF
--- a/lib/travis/api/v3/models/key_pair.rb
+++ b/lib/travis/api/v3/models/key_pair.rb
@@ -21,7 +21,7 @@ module Travis::API::V3
     end
 
     def to_h
-      { 'ssh_key' => attributes.slice(:description, :value).stringify_keys }
+      { 'ssh_key' => attributes.slice(:description, :value, :repository_id).stringify_keys }
     end
 
     def valid_pem?

--- a/lib/travis/api/v3/models/repository.rb
+++ b/lib/travis/api/v3/models/repository.rb
@@ -86,7 +86,7 @@ module Travis::API::V3
 
     def key_pair
       return unless settings['ssh_key']
-      Models::KeyPair.load(settings['ssh_key']).tap do |kp|
+      Models::KeyPair.load(settings['ssh_key'], repository_id: id).tap do |kp|
         kp.sync(self, :settings)
       end
     end

--- a/spec/v3/services/env_vars/create_spec.rb
+++ b/spec/v3/services/env_vars/create_spec.rb
@@ -66,6 +66,9 @@ describe Travis::API::V3::Services::EnvVars::Create, set_app: true do
       example 'persists changes' do
         expect(repo.reload.settings['env_vars'].first['name']).to eq 'FOO'
       end
+      example 'persists repository id' do
+        expect(repo.reload.settings['env_vars'].first['repository_id']).to eq repo.id
+      end
     end
 
     describe 'public' do

--- a/spec/v3/services/key_pair/create_spec.rb
+++ b/spec/v3/services/key_pair/create_spec.rb
@@ -108,6 +108,9 @@ describe Travis::API::V3::Services::KeyPair::Create, set_app: true do
           example 'persists changes' do
             expect(repo.reload.settings['ssh_key']['description']).to eq 'foo key pair'
           end
+          example 'persists repository id' do
+            expect(repo.reload.settings['ssh_key']['repository_id']).to eq repo.id
+          end
         end
       end
     end


### PR DESCRIPTION
We found an error where updating a key pair via PATCH resulted
in a rendering error. This was traced to the repo id on the key
pair being nil, because the create service was not setting it.

This also adds tests to cover that case, for key pairs and
env vars.