### PR TITLE
Run customerio in background

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,4 +1,4 @@
 web: ./script/server
 console: bundle exec je ./script/console
-sidekiq: bundle exec je sidekiq -c 4 -r ./lib/travis/sidekiq.rb -q build_cancellations, -q build_restarts, -q job_cancellations, -q job_restarts
+sidekiq: bundle exec je sidekiq -c 4 -r ./lib/travis/sidekiq.rb -q customerio
 cron: bin/cron

--- a/lib/travis/api/app/endpoint/authorization.rb
+++ b/lib/travis/api/app/endpoint/authorization.rb
@@ -1,10 +1,10 @@
 require 'addressable/uri'
 require 'faraday'
 require 'securerandom'
-require 'customerio'
 require 'travis/api/app'
 require 'travis/github/education'
 require 'travis/github/oauth'
+require 'travis/customerio'
 
 class Travis::Api::App
   class Endpoint
@@ -138,27 +138,6 @@ class Travis::Api::App
           end
         end
 
-        def update_customerio(user)
-          return unless Travis.config.customerio.site_id
-
-          # send event to customer.io
-          payload = {
-            :id => user.id,
-            :name => user.name,
-            :login => user.login,
-            :email => primary_email_for_user(user.github_oauth_token),
-            :created_at => user.created_at.to_i,
-            :github_id => user.github_id,
-            :education => user.education,
-            :first_logged_in_at => user.first_logged_in_at.to_i,
-            :travis_domain => Travis.config.client_domain
-          }
-
-          customerio.identify(payload)
-        rescue StandardError => e
-          Travis.logger.error "Could not update Customer.io for User: #{user.id}:#{user.login} with message:#{e.message}"
-        end
-
         def serialize_user(user)
           rendered = Travis::Api::Serialize.data(user, version: :v2)
           rendered['user'].merge('token' => user.tokens.first.try(:token).to_s)
@@ -189,7 +168,7 @@ class Travis::Api::App
             token                  = generate_token(user: user, app_id: 0)
             payload                = params[:state].split(":::", 2)[1]
             update_first_login(user)
-            update_customerio(user)
+            Travis::Customerio.update(user)
             yield serialize_user(user), token, payload
           else
             values[:state]         = create_state
@@ -362,14 +341,6 @@ class Travis::Api::App
           @allowed_https_targets ||= Travis.config.auth.target_origin.to_s.split(',')
         end
 
-        def primary_email_for_user(oauth_token)
-          # check for the users primary email address (we don't store this info)
-          GH.with(token: oauth_token, client_id: nil) { GH['user/emails'] }.select { |e| e['primary'] }.first['email']
-        end
-
-        def customerio
-          Customerio::Client.new(Travis.config.customerio.site_id, Travis.config.customerio.api_key, :json => true)
-        end
     end
   end
 end

--- a/lib/travis/customerio.rb
+++ b/lib/travis/customerio.rb
@@ -1,0 +1,49 @@
+require 'customerio'
+
+module Travis
+  class Customerio
+    include Sidekiq::Worker
+
+    sidekiq_options queue: 'customerio'
+
+    def self.update(user)
+      return unless Travis.config.customerio.site_id
+
+      perform_async(user.id)
+    end
+
+    def perform(user_id)
+      return unless Travis.config.customerio.site_id
+
+      user = User.find(user_id)
+
+      # send event to customer.io
+      payload = {
+        :id => user.id,
+        :name => user.name,
+        :login => user.login,
+        :email => primary_email_for_user(user),
+        :created_at => user.created_at.to_i,
+        :github_id => user.github_id,
+        :education => user.education,
+        :first_logged_in_at => user.first_logged_in_at.to_i,
+        :travis_domain => Travis.config.client_domain
+      }
+
+      client.identify(payload)
+    rescue StandardError => e
+      Travis.logger.error "Could not update Customer.io for User: #{user.id}:#{user.login} with message:#{e.message}"
+    end
+
+    private
+    def client
+      @client ||= ::Customerio::Client.new(Travis.config.customerio.site_id, Travis.config.customerio.api_key, :json => true)
+    end
+
+    def primary_email_for_user(user)
+      oauth_token = user.github_oauth_token
+      # check for the users primary email address (we don't store this info)
+      GH.with(token: oauth_token, client_id: nil) { GH['user/emails'] }.select { |e| e['primary'] }.first['email']
+    end
+  end
+end

--- a/lib/travis/sidekiq.rb
+++ b/lib/travis/sidekiq.rb
@@ -2,6 +2,7 @@
 require 'sidekiq'
 require 'travis'
 require 'travis/support/amqp'
+require 'travis/customerio'
 
 pool_size = ENV['SIDEKIQ_DB_POOL_SIZE'] || 5
 Travis.config.database[:pool] = pool_size.to_i


### PR DESCRIPTION
From commit message:

```
At the moment we need to wait for a customerio's response in order to
log a user in. I think that this might be causing problems for some
users. I'm not 100% certain that this is customerio's problem, but I
think that we should be running it in the background anyway. It's not
crucial for signing in, so we shouldn't be making a handshake call
longer than it needs to be.

I chose to run customerio in a separate thread. This is because I think
that putting it in sidekiq would be an overkill. There are only 2
downsides to using threads that I can imagine:

1. When the server is restarted the request might not reach customerio.
I don't think it's enough of a problem in reality. When an app is
deployed on Heroku it will wait till the old instance stops handling
requests and only then it will kill the old instance. This should
usually give enough time for requests to customerio to succeed.
2. If we get a lot of requests to a handshake endpoint that would end up
in one instance, we will potentially fire a lot of threads. I don't
think that's a huge problem, either, as we usually run at least a few
Heroku dynos and we have API anti-ddos protection, which should prevent
it.

In case second caveat is ever a problem we could also easily change this
code to always run only one thread and queue requests.
```