### PR TITLE
Restrict access to key pair services to enterprise/private

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -62,7 +62,7 @@ GIT
 
 GIT
   remote: https://github.com/travis-ci/travis-support
-  revision: 2cd02d2a06fdd1e2fc2f129148c168b56f7c190f
+  revision: 70e94a38e87a490cb72bab9da777571014694a82
   specs:
     travis-support (0.0.1)
 

--- a/lib/travis/api/v3.rb
+++ b/lib/travis/api/v3.rb
@@ -41,6 +41,7 @@ module Travis
       LoginRequired       = ClientError        .create('login required', status: 403)
       MethodNotAllowed    = ClientError        .create('method not allowed', status: 405)
       NotImplemented      = ServerError        .create('request not (yet) implemented', status: 501)
+      PaidFeature         = ClientError        .create('this feature is only available on private repositories and for Travis CI Enterprise customers', status: 403)
       RequestLimitReached = ClientError        .create('request limit reached for resource', status: 429)
       UnprocessableEntity = ClientError        .create('request unable to be processed due to semantic errors', status: 422)
       WrongCredentials    = ClientError        .create('access denied',  status: 403)

--- a/lib/travis/api/v3/access_control/generic.rb
+++ b/lib/travis/api/v3/access_control/generic.rb
@@ -46,6 +46,10 @@ module Travis::API::V3
       full_access? || logged_in?
     end
 
+    def enterprise?
+      !!Travis.config.enterprise
+    end
+
     def visible_repositories(list)
       # naïve implementation, replaced with smart implementation in specific subclasses
       return list if full_access?

--- a/lib/travis/api/v3/service.rb
+++ b/lib/travis/api/v3/service.rb
@@ -142,5 +142,9 @@ module Travis::API::V3
     def not_implemented
       raise NotImplemented
     end
+
+    def paid_feature!(repository)
+      raise PaidFeature unless access_control.enterprise? || repository.private?
+    end
   end
 end

--- a/lib/travis/api/v3/services/key_pair/create.rb
+++ b/lib/travis/api/v3/services/key_pair/create.rb
@@ -4,6 +4,7 @@ module Travis::API::V3
 
     def run!
       repository = check_login_and_find(:repository)  
+      paid_feature!(repository)
       access_control.permissions(repository).create_key_pair!
       key_pair = query.create(repository)
       result(:key_pair, key_pair, status: 201)

--- a/lib/travis/api/v3/services/key_pair/delete.rb
+++ b/lib/travis/api/v3/services/key_pair/delete.rb
@@ -4,6 +4,7 @@ module Travis::API::V3
 
     def run!
       repository = check_login_and_find(:repository)
+      paid_feature!(repository)
       key_pair = find(:key_pair, repository)
       access_control.permissions(key_pair).write!
       query.delete(repository) and deleted

--- a/lib/travis/api/v3/services/key_pair/find.rb
+++ b/lib/travis/api/v3/services/key_pair/find.rb
@@ -2,6 +2,7 @@ module Travis::API::V3
   class Services::KeyPair::Find < Service
     def run!
       repository = check_login_and_find(:repository)
+      paid_feature!(repository)
       query.find(repository)
     end
   end

--- a/lib/travis/api/v3/services/key_pair/update.rb
+++ b/lib/travis/api/v3/services/key_pair/update.rb
@@ -4,6 +4,7 @@ module Travis::API::V3
 
     def run!
       repository = check_login_and_find(:repository)
+      paid_feature!(repository)
       key_pair = find(:key_pair, repository)
       access_control.permissions(key_pair).write!
       key_pair = query.update(key_pair)

--- a/spec/support/shared_examples.rb
+++ b/spec/support/shared_examples.rb
@@ -9,6 +9,17 @@ RSpec.shared_examples 'not authenticated' do
   end
 end
 
+RSpec.shared_examples 'paid feature error' do
+  example { expect(last_response.status).to eq 403 }
+  example do
+    expect(JSON.parse(last_response.body)).to eq(
+      '@type' => 'error',
+      'error_message' => 'this feature is only available on private repositories and for Travis CI Enterprise customers',
+      'error_type' => 'paid_feature'
+    )
+  end
+end
+
 RSpec.shared_examples 'insufficient access to repo' do |permission|
   example { expect(last_response.status).to eq(403) }
   example do

--- a/spec/v3/services/key_pair/create_spec.rb
+++ b/spec/v3/services/key_pair/create_spec.rb
@@ -4,116 +4,143 @@ require 'openssl'
 describe Travis::API::V3::Services::KeyPair::Create, set_app: true do
   let(:repo) { Travis::API::V3::Models::Repository.where(owner_name: 'svenfuchs', name: 'minimal').first_or_create }
   let(:token) { Travis::Api::App::AccessToken.create(user: repo.owner, app_id: 1) }
-  let(:other_user) { FactoryGirl.create(:user) }
-  let(:other_token) { Travis::Api::App::AccessToken.create(user: other_user, app_id: 2) }
   let(:auth_headers) { { 'HTTP_AUTHORIZATION' => "token #{token}" } }
   let(:json_headers) { { 'CONTENT_TYPE' => 'application/json' } }
 
-  describe 'not authenticated' do
-    before { post("/v3/repo/#{repo.id}/key_pair") }
-    include_examples 'not authenticated'
+  shared_examples 'paid' do
+    describe 'not authenticated' do
+      before { post("/v3/repo/#{repo.id}/key_pair") }
+      include_examples 'not authenticated'
+    end
+
+    context 'authenticated' do
+      describe 'missing repo' do
+        before { post('/v3/repo/999999999/key_pair', {}, auth_headers) }
+        include_examples 'missing repo'
+      end
+
+      context 'existing repo' do
+        describe 'wrong permissions' do
+          before do
+            Travis::API::V3::Models::Permission.create(repository: repo, user: repo.owner, pull: true)
+            post("/v3/repo/#{repo.id}/key_pair", {}, { 'HTTP_AUTHORIZATION' => "token #{token}" })
+          end
+          include_examples 'insufficient access to repo', 'create_key_pair'
+        end
+
+        context 'correct permissions' do
+          before { Travis::API::V3::Models::Permission.create(repository: repo, user: repo.owner, pull: true,  push: true) }
+
+          describe 'key pair already exists' do
+            let(:key) { OpenSSL::PKey::RSA.generate(2048) }
+            let(:params) do
+              {
+                'key_pair.description' => 'foo',
+                'key_pair.value' => key.to_pem
+              }
+            end
+
+            before do
+              repo.update_attribute(:settings, JSON.generate(ssh_key: { description: 'foo', value: Travis::Settings::EncryptedValue.new(key.to_pem) }))
+              post("/v3/repo/#{repo.id}/key_pair", JSON.generate(params), auth_headers.merge(json_headers))
+            end
+
+            example { expect(last_response.status).to eq 409 }
+            example do
+              expect(JSON.parse(last_response.body)).to eq(
+                '@type' => 'error',
+                'error_message' => 'resource already exists',
+                'error_type' => 'duplicate_resource'
+              )
+            end
+          end
+
+          describe 'wrong params' do
+            let(:params) do
+              {
+                'key_pair.description' => 'hello'
+              }
+            end
+            before { post("/v3/repo/#{repo.id}/key_pair", JSON.generate(params), auth_headers.merge(json_headers)) }
+            include_examples 'wrong params'
+          end
+
+          describe 'value is not valid private key' do
+            let(:params) do
+              {
+                'key_pair.value' => 'not a proper private key'
+              }
+            end
+
+            before { post("/v3/repo/#{repo.id}/key_pair", JSON.generate(params), auth_headers.merge(json_headers)) }
+
+            example { expect(last_response.status).to eq 422 }
+            example do
+              expect(JSON.parse(last_response.body)).to eq(
+                '@type' => 'error',
+                'error_message' => 'request unable to be processed due to semantic errors',
+                'error_type' => 'unprocessable_entity'
+              )
+            end
+          end
+
+          describe 'creates key pair' do
+            let(:key) { OpenSSL::PKey::RSA.generate(2048) }
+            let(:fingerprint) { Travis::API::V3::Models::Fingerprint.calculate(key.to_pem) }
+            let(:params) do
+              {
+                'key_pair.value' => key.to_pem,
+                'key_pair.description' => 'foo key pair'
+              }
+            end
+
+            before do
+              post("/v3/repo/#{repo.id}/key_pair", JSON.generate(params), auth_headers.merge(json_headers))
+            end
+
+            example { expect(last_response.status).to eq 201 }
+            example do
+              expect(JSON.parse(last_response.body)).to eq(
+                '@href' => "/v3/repo/#{repo.id}/key_pair",
+                '@representation' => 'standard',
+                '@permissions' => { 'read' => true, 'write' => true },
+                '@type' => 'key_pair',
+                'description' => 'foo key pair',
+                'fingerprint' =>  fingerprint,
+                'public_key' => key.public_key.to_s
+              )
+            end
+            example 'persists changes' do
+              expect(repo.reload.settings['ssh_key']['description']).to eq 'foo key pair'
+            end
+            example 'persists repository id' do
+              expect(repo.reload.settings['ssh_key']['repository_id']).to eq repo.id
+            end
+          end
+        end
+      end
+    end
   end
 
-  context 'authenticated' do
-    describe 'missing repo' do
-      before { post('/v3/repo/999999999/key_pair', {}, auth_headers) }
-      include_examples 'missing repo'
+  context 'enterprise' do
+    around(:each) do |example|
+      Travis.config.enterprise = true
+      example.run
+      Travis.config.enterprise = nil
     end
 
-    context 'existing repo' do
-      describe 'wrong user' do
-        before { post("/v3/repo/#{repo.id}/key_pair", {}, { 'HTTP_AUTHORIZATION' => "token #{other_token}" }) }
-        include_examples 'insufficient access to repo', 'create_key_pair'
-      end
+    include_examples 'paid'
+  end
 
-      context 'correct user' do
-        before { Travis::API::V3::Models::Permission.create(repository: repo, user: repo.owner, push: true) }
+  context 'private repo' do
+    before { repo.update_attributes(private: true) }
 
-        describe 'key pair already exists' do
-          let(:key) { OpenSSL::PKey::RSA.generate(2048) }
-          let(:params) do
-            {
-              'key_pair.description' => 'foo',
-              'key_pair.value' => key.to_pem
-            }
-          end
+    include_examples 'paid'
+  end
 
-          before do
-            repo.update_attribute(:settings, JSON.generate(ssh_key: { description: 'foo', value: Travis::Settings::EncryptedValue.new(key.to_pem) }))
-            post("/v3/repo/#{repo.id}/key_pair", JSON.generate(params), auth_headers.merge(json_headers))
-          end
+  context 'non-paid' do
+    before { post("/v3/repo/#{repo.id}/key_pair", {}, auth_headers.merge(json_headers)) }
 
-          example { expect(last_response.status).to eq 409 }
-          example do
-            expect(JSON.parse(last_response.body)).to eq(
-              '@type' => 'error',
-              'error_message' => 'resource already exists',
-              'error_type' => 'duplicate_resource'
-            )
-          end
-        end
-
-        describe 'wrong params' do
-          let(:params) do
-            {
-              'key_pair.description' => 'hello'
-            }
-          end
-          before { post("/v3/repo/#{repo.id}/key_pair", JSON.generate(params), auth_headers.merge(json_headers)) }
-          include_examples 'wrong params'
-        end
-
-        describe 'value is not valid private key' do
-          let(:params) do
-            {
-              'key_pair.value' => 'not a proper private key'
-            }
-          end
-
-          before { post("/v3/repo/#{repo.id}/key_pair", JSON.generate(params), auth_headers.merge(json_headers)) }
-
-          example { expect(last_response.status).to eq 422 }
-          example do
-            expect(JSON.parse(last_response.body)).to eq(
-              '@type' => 'error',
-              'error_message' => 'request unable to be processed due to semantic errors',
-              'error_type' => 'unprocessable_entity'
-            )
-          end
-        end
-
-        describe 'creates key pair' do
-          let(:key) { OpenSSL::PKey::RSA.generate(2048) }
-          let(:fingerprint) { Travis::API::V3::Models::Fingerprint.calculate(key.to_pem) }
-          let(:params) do
-            {
-              'key_pair.value' => key.to_pem,
-              'key_pair.description' => 'foo key pair'
-            }
-          end
-
-          before { post("/v3/repo/#{repo.id}/key_pair", JSON.generate(params), auth_headers.merge(json_headers)) }
-
-          example { expect(last_response.status).to eq 201 }
-          example do
-            expect(JSON.parse(last_response.body)).to eq(
-              '@href' => "/v3/repo/#{repo.id}/key_pair",
-              '@representation' => 'standard',
-              '@permissions' => { 'read' => true, 'write' => true },
-              '@type' => 'key_pair',
-              'description' => 'foo key pair',
-              'fingerprint' =>  fingerprint,
-              'public_key' => key.public_key.to_s
-            )
-          end
-          example 'persists changes' do
-            expect(repo.reload.settings['ssh_key']['description']).to eq 'foo key pair'
-          end
-          example 'persists repository id' do
-            expect(repo.reload.settings['ssh_key']['repository_id']).to eq repo.id
-          end
-        end
-      end
-    end
+    include_examples 'paid feature error'
   end
 end

--- a/spec/v3/services/key_pair/delete_spec.rb
+++ b/spec/v3/services/key_pair/delete_spec.rb
@@ -4,83 +4,105 @@ require 'openssl'
 describe Travis::API::V3::Services::KeyPair::Delete, set_app: true do
   let(:repo) { Travis::API::V3::Models::Repository.where(owner_name: 'svenfuchs', name: 'minimal').first_or_create }
   let(:token) { Travis::Api::App::AccessToken.create(user: repo.owner, app_id: 1) }
-  let(:other_user) { FactoryGirl.create(:user) }
-  let(:other_token) { Travis::Api::App::AccessToken.create(user: other_user, app_id: 2) }
   let(:auth_headers) { { 'HTTP_AUTHORIZATION' => "token #{token}" } }
   let(:key) { OpenSSL::PKey::RSA.generate(4096) }
   let(:key_pair) { { description: 'foo key pair', value: Travis::Settings::EncryptedValue.new(key.to_pem), repository_id: repo.id } }
 
-  describe 'not authenticated' do
-    before { delete("/v3/repo/#{repo.id}/key_pair") }
-    include_examples 'not authenticated'
-  end
-
-  context 'authenticated' do
-    describe 'missing repo' do
-      before { delete('/v3/repo/999999999/key_pair', {}, auth_headers) }
-      include_examples 'missing repo'
+  shared_examples 'paid' do
+    describe 'not authenticated' do
+      before { delete("/v3/repo/#{repo.id}/key_pair") }
+      include_examples 'not authenticated'
     end
 
-    context 'existing repo' do
-      describe 'authenticated user with wrong permissions' do
-        before do
-          Travis::API::V3::Models::Permission.create(repository: repo, user: other_user, pull: true)
-          repo.update_attributes(settings: JSON.generate(ssh_key: key_pair, foo: 'bar'))
-          delete("/v3/repo/#{repo.id}/key_pair", {}, { 'HTTP_AUTHORIZATION' => "token #{other_token}" })
-        end
-
-        example { expect(last_response.status).to eq 403 }
-        example do
-          expect(JSON.parse(last_response.body)).to eq(
-            '@type' => 'error',
-            'error_message' => 'operation requires write access to key_pair',
-            'error_type' => 'insufficient_access',
-            'permission' => 'write',
-            'key_pair' => {
-              '@type' => 'key_pair',
-              '@href' => "/v3/repo/#{repo.id}/key_pair",
-              '@representation' => 'minimal',
-              'description' => repo.key_pair.description,
-              'public_key' => repo.key_pair.public_key,
-              'fingerprint' => repo.key_pair.fingerprint
-            },
-            'resource_type' => 'key_pair'
-          )
-        end
+    context 'authenticated' do
+      describe 'missing repo' do
+        before { delete('/v3/repo/999999999/key_pair', {}, auth_headers) }
+        include_examples 'missing repo'
       end
 
-      context 'authenticated user with correct permissions' do
-        before { Travis::API::V3::Models::Permission.create(repository: repo, user: repo.owner, push: true) }
+      context 'existing repo' do
+        describe 'authenticated user with wrong permissions' do
+          before do
+            Travis::API::V3::Models::Permission.create(repository: repo, user: repo.owner, pull: true)
+            repo.update_attributes(settings: JSON.generate(ssh_key: key_pair, foo: 'bar'))
+            delete("/v3/repo/#{repo.id}/key_pair", {}, { 'HTTP_AUTHORIZATION' => "token #{token}" })
+          end
 
-        describe 'existing repo, no key pair' do
-          before { delete("/v3/repo/#{repo.id}/key_pair", {}, auth_headers) }
-
-          example { expect(last_response.status).to eq 404 }
+          example { expect(last_response.status).to eq 403 }
           example do
             expect(JSON.parse(last_response.body)).to eq(
               '@type' => 'error',
-              'error_message' => 'key_pair not found (or insufficient access)',
-              'error_type' => 'not_found',
+              'error_message' => 'operation requires write access to key_pair',
+              'error_type' => 'insufficient_access',
+              'permission' => 'write',
+              'key_pair' => {
+                '@type' => 'key_pair',
+                '@href' => "/v3/repo/#{repo.id}/key_pair",
+                '@representation' => 'minimal',
+                'description' => repo.key_pair.description,
+                'public_key' => repo.key_pair.public_key,
+                'fingerprint' => repo.key_pair.fingerprint
+              },
               'resource_type' => 'key_pair'
             )
           end
         end
 
-        describe 'existing repo, deletes key pair' do
-          before do
-            repo.update_attributes(settings: JSON.generate(ssh_key: key_pair, foo: 'bar'))
-            delete("/v3/repo/#{repo.id}/key_pair", {}, auth_headers)
+        context 'authenticated user with correct permissions' do
+          before { Travis::API::V3::Models::Permission.create(repository: repo, user: repo.owner, pull: true, push: true) }
+
+          describe 'existing repo, no key pair' do
+            before { delete("/v3/repo/#{repo.id}/key_pair", {}, auth_headers) }
+
+            example { expect(last_response.status).to eq 404 }
+            example do
+              expect(JSON.parse(last_response.body)).to eq(
+                '@type' => 'error',
+                'error_message' => 'key_pair not found (or insufficient access)',
+                'error_type' => 'not_found',
+                'resource_type' => 'key_pair'
+              )
+            end
           end
 
-          example { expect(last_response.status).to eq 204 }
-          example do
-            expect(last_response.body).to be_empty
-          end
-          example 'persists changes' do
-            expect(repo.reload.settings).to eq("foo"=>"bar")
+          describe 'existing repo, deletes key pair' do
+            before do
+              repo.update_attributes(settings: JSON.generate(ssh_key: key_pair, foo: 'bar'))
+              delete("/v3/repo/#{repo.id}/key_pair", {}, auth_headers)
+            end
+
+            example { expect(last_response.status).to eq 204 }
+            example do
+              expect(last_response.body).to be_empty
+            end
+            example 'persists changes' do
+              expect(repo.reload.settings).to eq("foo"=>"bar")
+            end
           end
         end
       end
     end
+  end
+
+  context 'enterprise' do
+    around(:each) do |example|
+      Travis.config.enterprise = true
+      example.run
+      Travis.config.enterprise = nil
+    end
+
+    include_examples 'paid'
+  end
+
+  context 'private repo' do
+    before { repo.update_attributes(private: true) }
+
+    include_examples 'paid'
+  end
+
+  context 'non-paid' do
+    before { delete("/v3/repo/#{repo.id}/key_pair", {}, auth_headers) }
+
+    include_examples 'paid feature error'
   end
 end

--- a/spec/v3/services/key_pair/find_spec.rb
+++ b/spec/v3/services/key_pair/find_spec.rb
@@ -8,49 +8,79 @@ describe Travis::API::V3::Services::KeyPair::Find, set_app: true do
   let(:key_pair) { { description: 'foo key pair', value: Travis::Settings::EncryptedValue.new(key.to_pem), repository_id: repo.id } }
   let(:auth_headers) { { 'HTTP_AUTHORIZATION' => "token #{token}" } }
 
-  describe 'not authenticated' do
-    before { get("/v3/repo/#{repo.id}/key_pair") }
-    include_examples 'not authenticated'
+  shared_examples 'paid' do
+    describe 'not authenticated' do
+      before { get("/v3/repo/#{repo.id}/key_pair") }
+      include_examples 'not authenticated'
+    end
+
+    context 'authenticated' do
+      describe 'missing repo' do
+        before { get('/v3/repo/999999999/key_pair', {}, auth_headers) }
+        include_examples 'missing repo'
+      end
+
+      describe 'existing repo, no key pair' do
+        before do
+          Travis::API::V3::Models::Permission.create(repository: repo, user: repo.owner, pull: true)
+          get("/v3/repo/#{repo.id}/key_pair", {}, auth_headers)
+        end
+
+        example { expect(last_response.status).to eq 404 }
+        example do
+          expect(JSON.parse(last_response.body)).to eq(
+            '@type' => 'error',
+            'error_message' => 'key_pair not found (or insufficient access)',
+            'error_type' => 'not_found',
+            'resource_type' => 'key_pair'
+          )
+        end
+      end
+
+      describe 'existing repo, existing key pair' do
+        before do
+          Travis::API::V3::Models::Permission.create(repository: repo, user: repo.owner, pull: true)
+          repo.update_attributes(settings: JSON.generate(ssh_key: key_pair))
+          get("/v3/repo/#{repo.id}/key_pair", {}, auth_headers)
+        end
+
+        example { expect(last_response.status).to eq 200 }
+        example do
+          expect(JSON.parse(last_response.body)).to eq(
+            '@type' => 'key_pair',
+            '@href' => "/v3/repo/#{repo.id}/key_pair",
+            '@representation' => 'standard',
+            '@permissions' => { 'read' => true, 'write' => false },
+            'description' => 'foo key pair',
+            'fingerprint' => Travis::API::V3::Models::Fingerprint.calculate(key.to_pem),
+            'public_key' => key.public_key.to_s
+          )
+        end
+      end
+    end
   end
 
-  context 'authenticated' do
-    describe 'missing repo' do
-      before { get('/v3/repo/999999999/key_pair', {}, auth_headers) }
-      include_examples 'missing repo'
+  context 'enterprise' do
+    around(:each) do |example|
+      Travis.config.enterprise = true
+      example.run
+      Travis.config.enterprise = nil
     end
 
-    describe 'existing repo, no key pair' do
+    include_examples 'paid'
+  end
+
+  context 'private repo' do
+    before { repo.update_attributes(private: true) }
+
+    include_examples 'paid'
+  end
+
+  context 'non-paid' do
+    describe 'feature not available' do
       before { get("/v3/repo/#{repo.id}/key_pair", {}, auth_headers) }
 
-      example { expect(last_response.status).to eq 404 }
-      example do
-        expect(JSON.parse(last_response.body)).to eq(
-          '@type' => 'error',
-          'error_message' => 'key_pair not found (or insufficient access)',
-          'error_type' => 'not_found',
-          'resource_type' => 'key_pair'
-        )
-      end
-    end
-
-    describe 'existing repo, existing key pair' do
-      before do
-        repo.update_attributes(settings: JSON.generate(ssh_key: key_pair))
-        get("/v3/repo/#{repo.id}/key_pair", {}, auth_headers)
-      end
-
-      example { expect(last_response.status).to eq 200 }
-      example do
-        expect(JSON.parse(last_response.body)).to eq(
-          '@type' => 'key_pair',
-          '@href' => "/v3/repo/#{repo.id}/key_pair",
-          '@representation' => 'standard',
-          '@permissions' => { 'read' => true, 'write' => false },
-          'description' => 'foo key pair',
-          'fingerprint' => Travis::API::V3::Models::Fingerprint.calculate(key.to_pem),
-          'public_key' => key.public_key.to_s
-        )
-      end
+      include_examples 'paid feature error'
     end
   end
 end

--- a/spec/v3/services/key_pair/update_spec.rb
+++ b/spec/v3/services/key_pair/update_spec.rb
@@ -3,165 +3,181 @@ require 'spec_helper'
 describe Travis::API::V3::Services::KeyPair::Update, set_app: true do
   let(:repo) { Travis::API::V3::Models::Repository.where(owner_name: 'svenfuchs', name: 'minimal').first_or_create }
   let(:token) { Travis::Api::App::AccessToken.create(user: repo.owner, app_id: 1) }
-  let(:other_user) { FactoryGirl.create(:user) }
-  let(:other_token) { Travis::Api::App::AccessToken.create(user: other_user, app_id: 2) }
   let(:auth_headers) { { 'HTTP_AUTHORIZATION' => "token #{token}" } }
   let(:json_headers) { { 'CONTENT_TYPE' => 'application/json' } }
 
-  describe 'not authenticated' do
-    before { patch("/v3/repo/#{repo.id}/key_pair") }
-    include_examples 'not authenticated'
+  shared_examples 'paid' do
+    describe 'not authenticated' do
+      before { patch("/v3/repo/#{repo.id}/key_pair") }
+      include_examples 'not authenticated'
+    end
+
+    context 'authenticated' do
+      describe 'missing repo' do
+        before { patch('/v3/repo/999999999/key_pair', {}, auth_headers) }
+        include_examples 'missing repo'
+      end
+
+      context 'existing repo' do
+        describe 'correct user, wrong permissions' do
+          let(:key) { OpenSSL::PKey::RSA.generate(2048) }
+
+          before do
+            Travis::API::V3::Models::Permission.create(repository: repo, user: repo.owner, pull: true)
+            repo.update_attribute(:settings, JSON.generate(ssh_key: { description: 'foo', value: Travis::Settings::EncryptedValue.new(key.to_pem), repository_id: repo.id }))
+            patch("/v3/repo/#{repo.id}/key_pair", JSON.generate({}), auth_headers.merge(json_headers))
+          end
+
+          example { expect(last_response.status).to eq 403 }
+          example do
+            expect(JSON.parse(last_response.body)).to eq(
+              '@type' => 'error',
+              'error_type' => 'insufficient_access',
+              'error_message' => 'operation requires write access to key_pair',
+              'permission' => 'write',
+              'resource_type' => 'key_pair',
+              'key_pair' => {
+                '@href' => "/v3/repo/#{repo.id}/key_pair",
+                '@representation' => 'minimal',
+                '@type' => 'key_pair',
+                'description' => 'foo',
+                'fingerprint' => Travis::API::V3::Models::Fingerprint.calculate(key.to_pem),
+                'public_key' => key.public_key.to_s
+              }
+            )
+          end
+        end
+
+        context 'correct user, correct permissions' do
+          let(:key) { OpenSSL::PKey::RSA.generate(2048) }
+
+          before { Travis::API::V3::Models::Permission.create(repository: repo, user: repo.owner, pull: true, push: true) }
+
+          describe 'missing key pair' do
+            before { patch("/v3/repo/#{repo.id}/key_pair", {}, auth_headers.merge(json_headers)) }
+
+            example { expect(last_response.status).to eq 404 }
+            example do
+              expect(JSON.parse(last_response.body)).to eq(
+                '@type' => 'error',
+                'error_message' => 'key_pair not found (or insufficient access)',
+                'error_type' => 'not_found',
+                'resource_type' => 'key_pair'
+              )
+            end
+          end
+
+          describe 'wrong params have no effect but return warning' do
+            let(:params) do
+              {
+                'key_pair.xyz' => 'this does nothing'
+              }
+            end
+
+            before do
+              repo.update_attribute(:settings, JSON.generate(ssh_key: { description: 'foo', value: Travis::Settings::EncryptedValue.new(key.to_pem), repository_id: repo.id }))
+              patch("/v3/repo/#{repo.id}/key_pair", JSON.generate(params), auth_headers.merge(json_headers))
+            end
+
+            example { expect(last_response.status).to eq 200 }
+            example do
+              expect(JSON.parse(last_response.body)).to eq(
+                '@href' => "/v3/repo/#{repo.id}/key_pair",
+                '@representation' => 'standard',
+                '@type' => 'key_pair',
+                '@permissions' => { 'read' => true, 'write' => true },
+                '@warnings' => [
+                  {
+                    '@type' => 'warning',
+                    'message' => 'query parameter key_pair.xyz not safelisted, ignored',
+                    'warning_type' => 'ignored_parameter',
+                    'parameter' => 'key_pair.xyz'
+                  }
+                ],
+                'description' => 'foo',
+                'fingerprint' => Travis::API::V3::Models::Fingerprint.calculate(key.to_pem),
+                'public_key' => key.public_key.to_s
+              )
+            end
+          end
+
+          describe 'invalid private key' do
+            let(:params) do
+              {
+                'key_pair.description' => 'new description',
+                'key_pair.value' => 'not a real key'
+              }
+            end
+
+            before do
+              repo.update_attribute(:settings, JSON.generate(ssh_key: { description: 'foo', value: Travis::Settings::EncryptedValue.new(key.to_pem), repository_id: repo.id }))
+              patch("/v3/repo/#{repo.id}/key_pair", JSON.generate(params), auth_headers.merge(json_headers))
+            end
+
+            example { expect(last_response.status).to eq 422 }
+            example do
+              expect(JSON.parse(last_response.body)).to eq(
+                '@type' => 'error',
+                'error_message' => 'request unable to be processed due to semantic errors',
+                'error_type' => 'unprocessable_entity'
+              )
+            end
+          end
+
+          describe 'updates key pair' do
+            let(:new_key) { OpenSSL::PKey::RSA.generate(2048) }
+            let(:params) do
+              {
+                'key_pair.description' => 'new description',
+                'key_pair.value' => new_key.to_pem
+              }
+            end
+
+            before do
+              repo.update_attribute(:settings, JSON.generate(ssh_key: { description: 'foo', value: Travis::Settings::EncryptedValue.new(key.to_pem), repository_id: repo.id }))
+              patch("/v3/repo/#{repo.id}/key_pair", JSON.generate(params), auth_headers.merge(json_headers))
+            end
+
+            example { expect(last_response.status).to eq 200 }
+            example do
+              expect(JSON.parse(last_response.body)).to eq(
+                '@href' => "/v3/repo/#{repo.id}/key_pair",
+                '@representation' => 'standard',
+                '@type' => 'key_pair',
+                '@permissions' => { 'read' => true, 'write' => true },
+                'description' => 'new description',
+                'fingerprint' => Travis::API::V3::Models::Fingerprint.calculate(new_key.to_pem),
+                'public_key' => new_key.public_key.to_s
+              )
+            end
+            example 'persists changes' do
+              expect(repo.reload.settings['ssh_key']['description']).to eq 'new description'
+            end
+          end
+        end
+      end
+    end
   end
 
-  context 'authenticated' do
-    describe 'missing repo' do
-      before { patch('/v3/repo/999999999/key_pair', {}, auth_headers) }
-      include_examples 'missing repo'
+  context 'enterprise' do
+    around(:each) do |example|
+      Travis.config.enterprise = true
+      example.run
+      Travis.config.enterprise = nil
     end
 
-    context 'existing repo' do
-      describe 'wrong user' do
-        before { patch("/v3/repo/#{repo.id}/key_pair", {}, { 'HTTP_AUTHORIZATION' => "token #{other_token}" }) }
-        include_examples 'missing key_pair'
-      end
+    include_examples 'paid'
+  end
 
+  context 'private repo' do
+    before { repo.update_attributes(private: true) }
 
-      describe 'correct user, wrong permissions' do
-        let(:key) { OpenSSL::PKey::RSA.generate(2048) }
+    include_examples 'paid'
+  end
 
-        before do
-          Travis::API::V3::Models::Permission.create(repository: repo, user: repo.owner, pull: true)
-          repo.update_attribute(:settings, JSON.generate(ssh_key: { description: 'foo', value: Travis::Settings::EncryptedValue.new(key.to_pem), repository_id: repo.id }))
-          patch("/v3/repo/#{repo.id}/key_pair", JSON.generate({}), auth_headers.merge(json_headers))
-        end
+  context 'non-paid' do
+    before { patch("/v3/repo/#{repo.id}/key_pair", {}, auth_headers.merge(json_headers)) }
 
-        example { expect(last_response.status).to eq 403 }
-        example do
-          expect(JSON.parse(last_response.body)).to eq(
-            '@type' => 'error',
-            'error_type' => 'insufficient_access',
-            'error_message' => 'operation requires write access to key_pair',
-            'permission' => 'write',
-            'resource_type' => 'key_pair',
-            'key_pair' => {
-              '@href' => "/v3/repo/#{repo.id}/key_pair",
-              '@representation' => 'minimal',
-              '@type' => 'key_pair',
-              'description' => 'foo',
-              'fingerprint' => Travis::API::V3::Models::Fingerprint.calculate(key.to_pem),
-              'public_key' => key.public_key.to_s
-            }
-          )
-        end
-      end
-
-      context 'correct user, correct permissions' do
-        let(:key) { OpenSSL::PKey::RSA.generate(2048) }
-
-        before { Travis::API::V3::Models::Permission.create(repository: repo, user: repo.owner, push: true) }
-
-        describe 'missing key pair' do
-          before { patch("/v3/repo/#{repo.id}/key_pair", {}, auth_headers.merge(json_headers)) }
-
-          example { expect(last_response.status).to eq 404 }
-          example do
-            expect(JSON.parse(last_response.body)).to eq(
-              '@type' => 'error',
-              'error_message' => 'key_pair not found (or insufficient access)',
-              'error_type' => 'not_found',
-              'resource_type' => 'key_pair'
-            )
-          end
-        end
-
-        describe 'wrong params have no effect but return warning' do
-          let(:params) do
-            {
-              'key_pair.xyz' => 'this does nothing'
-            }
-          end
-
-          before do
-            repo.update_attribute(:settings, JSON.generate(ssh_key: { description: 'foo', value: Travis::Settings::EncryptedValue.new(key.to_pem), repository_id: repo.id }))
-            patch("/v3/repo/#{repo.id}/key_pair", JSON.generate(params), auth_headers.merge(json_headers))
-          end
-
-          example { expect(last_response.status).to eq 200 }
-          example do
-            expect(JSON.parse(last_response.body)).to eq(
-              '@href' => "/v3/repo/#{repo.id}/key_pair",
-              '@representation' => 'standard',
-              '@type' => 'key_pair',
-              '@permissions' => { 'read' => true, 'write' => true },
-              '@warnings' => [
-                {
-                  '@type' => 'warning',
-                  'message' => 'query parameter key_pair.xyz not safelisted, ignored',
-                  'warning_type' => 'ignored_parameter',
-                  'parameter' => 'key_pair.xyz'
-                }
-              ],
-              'description' => 'foo',
-              'fingerprint' => Travis::API::V3::Models::Fingerprint.calculate(key.to_pem),
-              'public_key' => key.public_key.to_s
-            )
-          end
-        end
-
-        describe 'invalid private key' do
-          let(:params) do
-            {
-              'key_pair.description' => 'new description',
-              'key_pair.value' => 'not a real key'
-            }
-          end
-
-          before do
-            repo.update_attribute(:settings, JSON.generate(ssh_key: { description: 'foo', value: Travis::Settings::EncryptedValue.new(key.to_pem), repository_id: repo.id }))
-            patch("/v3/repo/#{repo.id}/key_pair", JSON.generate(params), auth_headers.merge(json_headers))
-          end
-
-          example { expect(last_response.status).to eq 422 }
-          example do
-            expect(JSON.parse(last_response.body)).to eq(
-              '@type' => 'error',
-              'error_message' => 'request unable to be processed due to semantic errors',
-              'error_type' => 'unprocessable_entity'
-            )
-          end
-        end
-
-        describe 'updates key pair' do
-          let(:new_key) { OpenSSL::PKey::RSA.generate(2048) }
-          let(:params) do
-            {
-              'key_pair.description' => 'new description',
-              'key_pair.value' => new_key.to_pem
-            }
-          end
-
-          before do
-            repo.update_attribute(:settings, JSON.generate(ssh_key: { description: 'foo', value: Travis::Settings::EncryptedValue.new(key.to_pem), repository_id: repo.id }))
-            patch("/v3/repo/#{repo.id}/key_pair", JSON.generate(params), auth_headers.merge(json_headers))
-          end
-
-          example { expect(last_response.status).to eq 200 }
-          example do
-            expect(JSON.parse(last_response.body)).to eq(
-              '@href' => "/v3/repo/#{repo.id}/key_pair",
-              '@representation' => 'standard',
-              '@type' => 'key_pair',
-              '@permissions' => { 'read' => true, 'write' => true },
-              'description' => 'new description',
-              'fingerprint' => Travis::API::V3::Models::Fingerprint.calculate(new_key.to_pem),
-              'public_key' => new_key.public_key.to_s
-            )
-          end
-          example 'persists changes' do
-            expect(repo.reload.settings['ssh_key']['description']).to eq 'new description'
-          end
-        end
-      end
-    end
+    include_examples 'paid feature error'
   end
 end


### PR DESCRIPTION
This mirrors V2 api behaviour but in the single codebase.

The `PaidFeature` error is raised when a key pair action is
attempted, unless the repo is private or the api is running
on enterprise.

This is following advice re: enterprise and The Merge in
https://github.com/travis-ci/travis-api/pull/418.