### PR TITLE
Remove repository filters that excluded forks of rails/rails repo

### DIFF
--- a/lib/travis/config/defaults.rb
+++ b/lib/travis/config/defaults.rb
@@ -38,7 +38,6 @@ module Travis
             ssl:           {},
             redis:         { url: 'redis://localhost:6379' },
             repository:    { ssl_key: { size: 4096 } },
-            repository_filter: { include: [/^rails\/rails/], exclude: [/\/rails$/] },
             encryption:    Travis.env == 'development' || Travis.env == 'test' ? { key: 'secret' * 10 } : {},
             sync:          { organizations: { repositories_limit: 1000 } },
             states_cache:  { memcached_servers: 'localhost:11211' },


### PR DESCRIPTION
This PR removes repo filter to exclude `rails/rails` forks
- since this was in place when rails repo had our largest build matrix and the system couldn't support it
- this is no longer the case and we plan to introduce a more robust and nuanced fair usage policy, later on

Fixes https://github.com/travis-ci/travis-ci/issues/6907