### PR TITLE
add cron prefix to cron params

### DIFF
--- a/lib/travis/api/v3/queries/cron.rb
+++ b/lib/travis/api/v3/queries/cron.rb
@@ -1,7 +1,8 @@
 module Travis::API::V3
   class Queries::Cron < Query
     params :id
-
+    params :interval, :dont_run_if_recent_build_exists
+    params :interval, :dont_run_if_recent_build_exists, prefix: :cron
     sortable_by :id
 
     def find
@@ -13,9 +14,21 @@ module Travis::API::V3
       branch.cron
     end
 
-    def create(branch, interval, dont_run_if_recent_build_exists)
+    def create(branch)
       branch.cron.destroy unless branch.cron.nil?
-      Models::Cron.create(branch: branch, interval: interval, dont_run_if_recent_build_exists: dont_run_if_recent_build_exists)
+      Models::Cron.create(branch: branch, interval: _interval, dont_run_if_recent_build_exists: _dont_run_if_recent_build_exists)
     end
+
+    private
+
+    def _interval
+      cron_params.key?('interval') ? cron_params['interval'] : params['interval']
+    end
+
+    def _dont_run_if_recent_build_exists
+      value = cron_params['dont_run_if_recent_build_exists'] || params['dont_run_if_recent_build_exists']
+      value || false
+    end
+
   end
 end

--- a/lib/travis/api/v3/services/cron/create.rb
+++ b/lib/travis/api/v3/services/cron/create.rb
@@ -2,16 +2,17 @@ module Travis::API::V3
   class Services::Cron::Create < Service
     result_type :cron
     params :interval, :dont_run_if_recent_build_exists
+    params :interval, :dont_run_if_recent_build_exists, prefix: :cron
+
 
     def run!
       repository = check_login_and_find(:repository)
       raise NotFound unless branch = find(:branch, repository)
       raise Error.new('Crons can only be set up for branches existing on GitHub!', status: 422) unless branch.exists_on_github
-      raise Error.new('Invalid value for interval. Interval must be "daily", "weekly" or "monthly"!', status: 422) unless ["daily", "weekly", "monthly"].include?(params["interval"])
+      raise Error.new('Invalid value for interval. Interval must be "daily", "weekly" or "monthly"!', status: 422) unless ["daily", "weekly", "monthly"].include?(params["interval"] || params["cron.interval"])
       access_control.permissions(repository).create_cron!
       access_control.permissions(branch.cron).delete! if branch.cron
-      result query.create(branch, params["interval"], params["dont_run_if_recent_build_exists"] ? params["dont_run_if_recent_build_exists"] : false)
+      result query.create(branch)
     end
-
   end
 end


### PR DESCRIPTION
This change conforms to previous conventions re namespacing of params on other endpoints, and reflects info in the developer documentation https://developer.travis-ci.org/resource/cron#create

