### PR TITLE
Log GitHub's response when token is missing

### DIFF
--- a/lib/travis/api/app/endpoint/authorization.rb
+++ b/lib/travis/api/app/endpoint/authorization.rb
@@ -298,7 +298,7 @@ class Travis::Api::App
           token_info = parameters.assoc("access_token")
 
           unless token_info
-            log_with_request_id("[handshake] Could not fetch token, github's response: status=#{response.status}")
+            log_with_request_id("[handshake] Could not fetch token, github's response: status=#{response.status}, body=#{parameters.inspect} headers=#{response.headers.inspect}")
             halt 401, 'could not resolve github token'
           end
           token_info.last


### PR DESCRIPTION
For some users we get a response that has a 200 status, but there's no
token. This commit adds logging of the response's body and headers in
order to get more information about the situation. This should be safe
as it will only output the body when token can't be found.