### PR TITLE
pgbouncer: support enabling for a single dyno via env

### DIFF
--- a/script/server-pgbouncer
+++ b/script/server-pgbouncer
@@ -4,6 +4,10 @@
 
 cd "$(dirname "$0")/.."
 
+if [ "$PGBOUNCER_ENABLE_FOR_DYNO" != '' ] && [ "$PGBOUNCER_ENABLE_FOR_DYNO" = "$DYNO" ]; then
+  export PGBOUNCER_ENABLED=true
+fi
+
 if [ ! -f "bin/start-pgbouncer-stunnel" ]; then
   echo "warning: pgbouncer buildpack not found, setting PGBOUNCER_ENABLED=false"
   export PGBOUNCER_ENABLED=false


### PR DESCRIPTION
In order to be able to perform a safe rollout of pgbouncer (https://github.com/travis-pro/dev/issues/9) on production, this patch allows enabling it selectively on a single dyno, by setting (for example) `PGBOUNCER_ENABLE_FOR_DYNO=web.5`.