### PR TITLE
Add :branch and :name attributes to caches

### DIFF
--- a/lib/travis/api/v3/renderer/cache.rb
+++ b/lib/travis/api/v3/renderer/cache.rb
@@ -2,5 +2,10 @@ module Travis::API::V3
   class Renderer::Cache < Renderer::ModelRenderer
     representation(:minimal,  :repository_id, :size, :name, :branch, :last_modified)
     representation(:standard, *representations[:minimal], :repo)
+
+    def self.available_attributes
+      [:branch, :name]
+    end
+
   end
 end

--- a/lib/travis/api/v3/renderer/cache.rb
+++ b/lib/travis/api/v3/renderer/cache.rb
@@ -2,10 +2,10 @@ module Travis::API::V3
   class Renderer::Cache < Renderer::ModelRenderer
     representation(:minimal,  :repository_id, :size, :name, :branch, :last_modified)
     representation(:standard, *representations[:minimal], :repo)
-
-    def self.available_attributes
-      [:branch, :name]
-    end
+    # 
+    # def self.available_attributes
+    #   [:branch, :name]
+    # end
 
   end
 end

--- a/lib/travis/api/v3/renderer/cache.rb
+++ b/lib/travis/api/v3/renderer/cache.rb
@@ -2,10 +2,5 @@ module Travis::API::V3
   class Renderer::Cache < Renderer::ModelRenderer
     representation(:minimal,  :repository_id, :size, :name, :branch, :last_modified)
     representation(:standard, *representations[:minimal], :repo)
-    # 
-    # def self.available_attributes
-    #   [:branch, :name]
-    # end
-
   end
 end

--- a/lib/travis/api/v3/renderer/caches.rb
+++ b/lib/travis/api/v3/renderer/caches.rb
@@ -4,7 +4,7 @@ module Travis::API::V3
     collection_key  :caches
 
     def self.available_attributes
-      [:branch, :match]
+      [:branch, :name]
     end
 
   end

--- a/lib/travis/api/v3/renderer/caches.rb
+++ b/lib/travis/api/v3/renderer/caches.rb
@@ -2,5 +2,10 @@ module Travis::API::V3
   class Renderer::Caches < Renderer::CollectionRenderer
     type            :caches
     collection_key  :caches
+
+    def self.available_attributes
+      [:branch, :name]
+    end
+
   end
 end

--- a/lib/travis/api/v3/renderer/caches.rb
+++ b/lib/travis/api/v3/renderer/caches.rb
@@ -4,7 +4,7 @@ module Travis::API::V3
     collection_key  :caches
 
     def self.available_attributes
-      [super*, :branch, :name]
+      [:branch, :name]
     end
 
   end

--- a/lib/travis/api/v3/renderer/caches.rb
+++ b/lib/travis/api/v3/renderer/caches.rb
@@ -4,7 +4,7 @@ module Travis::API::V3
     collection_key  :caches
 
     def self.available_attributes
-      [:branch, :name]
+      [:branch, :match]
     end
 
   end

--- a/lib/travis/api/v3/renderer/caches.rb
+++ b/lib/travis/api/v3/renderer/caches.rb
@@ -4,7 +4,7 @@ module Travis::API::V3
     collection_key  :caches
 
     def self.available_attributes
-      [:branch, :name]
+      [super*, :branch, :name]
     end
 
   end


### PR DESCRIPTION
This is required for the Developer docs.

This branch has been deployed to org staging and the endpoint still returns the payload as before.