### PR TITLE
pgbouncer: support selectively enabling pgbouncer for more than one dyno

### DIFF
--- a/script/server-pgbouncer
+++ b/script/server-pgbouncer
@@ -1,13 +1,16 @@
 #!/usr/bin/env bash
 # this script enables a pgbouncer wrapper when the
 # $PGBOUNCER_ENABLED variable is set to '1' or 'true'
-# or if $PGBOUNCER_ENABLED_FOR_DYNO matches $DYNO
+# or if the space-delimited list
+# $PGBOUNCER_ENABLED_FOR_DYNOS contains $DYNO
 
 cd "$(dirname "$0")/.."
 
-if [ "$PGBOUNCER_ENABLED_FOR_DYNO" != '' ] && [ "$PGBOUNCER_ENABLED_FOR_DYNO" = "$DYNO" ]; then
-  export PGBOUNCER_ENABLED=true
-fi
+for d in $PGBOUNCER_ENABLED_FOR_DYNOS; do
+  if [ "$d" = "$DYNO" ]; then
+    export PGBOUNCER_ENABLED=true
+  fi
+done
 
 if [ ! -f "bin/start-pgbouncer-stunnel" ]; then
   echo "warning: pgbouncer buildpack not found, setting PGBOUNCER_ENABLED=false"


### PR DESCRIPTION
replaces `PGBOUNCER_ENABLED_FOR_DYNO` env var with `PGBOUNCER_ENABLED_FOR_DYNOS`,
a space-separated list.

this allows us to more selectively roll out to a subset of dynos, as opposed to only a single one. allowing us to add one dyno per day (or so).

the idea is that this will make the rollout slower, more incremental, and safer.