### PR TITLE
Optimise requests to not preload builds

### DIFF
--- a/lib/travis/api/serialize/v2/http/requests.rb
+++ b/lib/travis/api/serialize/v2/http/requests.rb
@@ -41,10 +41,9 @@ module Travis
                   'pull_request_number' => request.pull_request_number,
                   'pull_request_title' => request.pull_request_title,
                   'branch' => request.branch_name,
-                  'tag' => request.tag_name
+                  'tag' => request.tag_name,
+                  'build_id' => request.build_id
                 }
-
-                data['build_id'] = request.builds.first.id if request.builds.present?
 
                 data
               end

--- a/lib/travis/model/request.rb
+++ b/lib/travis/model/request.rb
@@ -26,6 +26,12 @@ class Request < Travis::Model
     def recent(limit = 25)
       order('id DESC').limit(limit)
     end
+
+    def with_build_id
+      select('requests.*, MAX(builds.id) as build_id').
+        joins('left join builds on builds.request_id = requests.id').
+        group('requests.id')
+    end
   end
 
   belongs_to :commit

--- a/lib/travis/services/find_requests.rb
+++ b/lib/travis/services/find_requests.rb
@@ -12,7 +12,7 @@ module Travis
       private
 
         def preload(requests)
-          requests.includes(:commit, :builds)
+          requests.includes(:commit)
         end
 
         def result
@@ -23,7 +23,7 @@ module Travis
             if params[:older_than]
               requests.older_than(params[:older_than])
             else
-              requests.recent(requests_limit)
+              requests.recent(requests_limit).with_build_id
             end
           else
             raise Travis::RepositoryNotFoundError.new(params)

--- a/spec/lib/services/find_requests_spec.rb
+++ b/spec/lib/services/find_requests_spec.rb
@@ -13,6 +13,15 @@ describe Travis::Services::FindRequests do
       service.run.should == [newer_request, request]
     end
 
+    it 'includes the build_id' do
+      Factory.create(:build, request_id: request.id)
+      @params = { :repository_id => repo.id }
+      requests = service.run
+      requests.should == [newer_request, request]
+      requests.first.build_id  = nil
+      requests.second.build_id = request.builds.first.id
+    end
+
     it 'finds requests older than the given id' do
       @params = { :repository_id => repo.id, :older_than => newer_request.id }
       service.run.should == [request]

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -98,7 +98,7 @@ RSpec.configure do |c|
     # avoids leaving records lying around between test runs
     base = ActiveRecord::Base
     base.establish_connection(Travis.config.logs_database.to_h)
-    base.connection.tables.each { |table| base.connection.execute("TRUNCATE #{table}") }
+    base.connection.tables.each { |table| base.connection.execute("TRUNCATE #{table} CASCADE") }
   end
 end
 

--- a/spec/unit/serialize/v2/http/requests_spec.rb
+++ b/spec/unit/serialize/v2/http/requests_spec.rb
@@ -1,13 +1,9 @@
 describe Travis::Api::Serialize::V2::Http::Requests do
   include Travis::Testing::Stubs, Support::Formats
 
-  before do
-    request.stubs(:builds).returns([build])
-  end
-
   let(:data) {
     request = stub_request
-    request.stubs(:builds).returns([build])
+    request.stubs(:build_id).returns(1)
     request.stubs(:tag_name).returns(nil)
     described_class.new([request]).data
   }
@@ -31,7 +27,7 @@ describe Travis::Api::Serialize::V2::Http::Requests do
         'pull_request' => false,
         'pull_request_title' => nil,
         'pull_request_number' => nil,
-        'build_id' => build.id
+        'build_id' => 1
       }
     ]
   end
@@ -56,7 +52,7 @@ describe Travis::Api::Serialize::V2::Http::Requests do
     let(:data) {
       request = stub_request
       request.stubs(:commit).returns(nil)
-      request.stubs(:builds).returns([build])
+      request.stubs(:build_id).returns(1)
       described_class.new([request]).data
     }
 


### PR DESCRIPTION
In order to slightly optimise requests page I would like to not preload
all the build data, but do a LEFT JOIN with builds to just get the id.