### PR TITLE
share postgres connection pool between all logs models

### DIFF
--- a/lib/travis/api/v3/models/log.rb
+++ b/lib/travis/api/v3/models/log.rb
@@ -1,7 +1,5 @@
 module Travis::API::V3
-  class Models::Log < Model
-    establish_connection(Travis.config.logs_database.to_h)
-
+  class Models::Log < Travis::LogsModel
     belongs_to :job
     belongs_to :removed_by, class_name: 'User', foreign_key: :removed_by
     has_many  :log_parts, dependent: :destroy, order: 'number ASC'

--- a/lib/travis/api/v3/models/log_part.rb
+++ b/lib/travis/api/v3/models/log_part.rb
@@ -1,6 +1,5 @@
 module Travis::API::V3
-  class Models::LogPart < Model
-    establish_connection(Travis.config.logs_database.to_h)
+  class Models::LogPart < Travis::LogsModel
     belongs_to :log
   end
 end


### PR DESCRIPTION
it looks like the status quo may be creating 3 separate pools, leading to 3x50 pg connections instead of the allocated 50.

refs https://github.com/travis-pro/team-teal/issues/1775.