### PR TITLE
introduce separate LogsModel for v3 so that all v3 models inherit the same behaviour

### DIFF
--- a/lib/travis/api/v3/logs_model.rb
+++ b/lib/travis/api/v3/logs_model.rb
@@ -1,0 +1,14 @@
+module Travis::API::V3
+  # copy-pasted from Travis::API::V3::Model
+  # in order to be able to change the inheritance to
+  # Travis::LogsModel, so that postgres connections
+  # can be shared between api v2 and v3
+  class LogsModel < Travis::LogsModel
+    include Extensions::BelongsTo
+    self.abstract_class = true
+
+    def self.===(other)
+      super or (self == Model and other.class.parent == Models)
+    end
+  end
+end

--- a/lib/travis/api/v3/models/log.rb
+++ b/lib/travis/api/v3/models/log.rb
@@ -1,5 +1,5 @@
 module Travis::API::V3
-  class Models::Log < Travis::LogsModel
+  class Models::Log < LogsModel
     belongs_to :job
     belongs_to :removed_by, class_name: 'User', foreign_key: :removed_by
     has_many  :log_parts, dependent: :destroy, order: 'number ASC'

--- a/lib/travis/api/v3/models/log_part.rb
+++ b/lib/travis/api/v3/models/log_part.rb
@@ -1,5 +1,5 @@
 module Travis::API::V3
-  class Models::LogPart < Travis::LogsModel
+  class Models::LogPart < LogsModel
     belongs_to :log
   end
 end


### PR DESCRIPTION
@drogus raised a concern about the v3 Log and LogPart models inheriting
from Travis::LogsModel instead of Travis::API::V3::Model, as the shared
v3 base class has some extra behaviour that is now missing.

since we cannot inherit from both the v3 model as well as the v2
LogsModel, this patch addresses the problem by copy-pasting the v3
model, and inheriting from the v2 LogsModel.

any changes to Travis::API::V3::Model will need to be applied to
Travis::API::V3::LogsModel as well. at least until api v2 and v3
are split into separate repos.

this is a temporary(tm)* fix.

*probably forever <3

refs https://github.com/travis-ci/travis-api/pull/445, https://github.com/travis-pro/team-teal/issues/1775