### PR TITLE
Ensure RemoteLog serializes more like direct database Log

### DIFF
--- a/lib/travis/api/app.rb
+++ b/lib/travis/api/app.rb
@@ -27,6 +27,7 @@ require 'metriks/librato_metrics_reporter'
 require 'travis/support/log_subscriber/active_record_metrics'
 require 'fileutils'
 require 'securerandom'
+require 'fog/aws'
 
 module Travis::Api
 end
@@ -194,6 +195,12 @@ module Travis::Api
 
         if use_monitoring? && !console?
           setup_monitoring
+        end
+
+        if defined?(Fog) && defined?(Fog::Logger)
+          %i(warning deprecation debug).each do |channel|
+            Fog::Logger[channel] = nil
+          end
         end
       end
 

--- a/lib/travis/api/app.rb
+++ b/lib/travis/api/app.rb
@@ -181,8 +181,6 @@ module Travis::Api
       end
 
       def self.setup_travis
-        # HACK: explicitly set logging to debug
-        Travis.logger.level = Logger::DEBUG
         Travis::Async.enabled = true
         Travis::Amqp.setup(Travis.config.amqp.to_h)
 

--- a/lib/travis/api/app.rb
+++ b/lib/travis/api/app.rb
@@ -181,6 +181,8 @@ module Travis::Api
       end
 
       def self.setup_travis
+        # HACK: explicitly set logging to debug
+        Travis.logger.level = Logger::DEBUG
         Travis::Async.enabled = true
         Travis::Amqp.setup(Travis.config.amqp.to_h)
 

--- a/lib/travis/api/app/endpoint/builds.rb
+++ b/lib/travis/api/app/endpoint/builds.rb
@@ -9,13 +9,12 @@ class Travis::Api::App
         prefer_follower do
           name = params[:branches] ? :find_branches : :find_builds
           params['ids'] = params['ids'].split(',') if params['ids'].respond_to?(:split)
-          params[:include_log_id] ||= include_log_id?
-          respond_with service(name, params)
+          respond_with service(name, params), include_log_id: include_log_id?
         end
       end
 
       get '/:id' do
-        respond_with service(:find_build, params.merge(include_log_id: include_log_id?))
+        respond_with service(:find_build, params), include_log_id: include_log_id?
       end
 
       post '/:id/cancel' do

--- a/lib/travis/api/app/endpoint/builds.rb
+++ b/lib/travis/api/app/endpoint/builds.rb
@@ -68,6 +68,8 @@ class Travis::Api::App
     end
 
     private def include_log_id?
+      # HACK: short-circuit always on
+      return true
       params[:include_log_id] = !Travis.config.logs_api.enabled? if params[:include_log_id].nil?
       params[:include_log_id] || request.user_agent.to_s.start_with?('Travis')
     end

--- a/lib/travis/api/app/endpoint/builds.rb
+++ b/lib/travis/api/app/endpoint/builds.rb
@@ -9,12 +9,12 @@ class Travis::Api::App
         prefer_follower do
           name = params[:branches] ? :find_branches : :find_builds
           params['ids'] = params['ids'].split(',') if params['ids'].respond_to?(:split)
-          respond_with service(name, params)
+          respond_with service(name, params), include_log_id: include_log_id?
         end
       end
 
       get '/:id' do
-        respond_with service(:find_build, params)
+        respond_with service(:find_build, params), include_log_id: include_log_id?
       end
 
       post '/:id/cancel' do
@@ -65,6 +65,11 @@ class Travis::Api::App
 
         respond_with(result: result, flash: service.messages)
       end
+    end
+
+    private def include_log_id?
+      params[:include_log_id] = !Travis.config.logs_api.enabled? if params[:include_log_id].nil?
+      params[:include_log_id] || request.user_agent.to_s.start_with?('Travis')
     end
   end
 end

--- a/lib/travis/api/app/endpoint/builds.rb
+++ b/lib/travis/api/app/endpoint/builds.rb
@@ -9,7 +9,8 @@ class Travis::Api::App
         prefer_follower do
           name = params[:branches] ? :find_branches : :find_builds
           params['ids'] = params['ids'].split(',') if params['ids'].respond_to?(:split)
-          respond_with service(name, params.merge(include_log_id: include_log_id?))
+          params[:include_log_id] ||= include_log_id?
+          respond_with service(name, params)
         end
       end
 
@@ -68,8 +69,9 @@ class Travis::Api::App
     end
 
     private def include_log_id?
-      params[:include_log_id] = !Travis.config.logs_api.enabled? if params[:include_log_id].nil?
-      params[:include_log_id] || request.user_agent.to_s.start_with?('Travis')
+      params[:include_log_id] ||
+        !Travis.config.logs_api.enabled? ||
+        request.user_agent.to_s.start_with?('Travis')
     end
   end
 end

--- a/lib/travis/api/app/endpoint/builds.rb
+++ b/lib/travis/api/app/endpoint/builds.rb
@@ -9,12 +9,12 @@ class Travis::Api::App
         prefer_follower do
           name = params[:branches] ? :find_branches : :find_builds
           params['ids'] = params['ids'].split(',') if params['ids'].respond_to?(:split)
-          respond_with service(name, params), include_log_id: include_log_id?
+          respond_with service(name, params.merge(include_log_id: include_log_id?))
         end
       end
 
       get '/:id' do
-        respond_with service(:find_build, params), include_log_id: include_log_id?
+        respond_with service(:find_build, params.merge(include_log_id: include_log_id?))
       end
 
       post '/:id/cancel' do
@@ -68,8 +68,6 @@ class Travis::Api::App
     end
 
     private def include_log_id?
-      # HACK: short-circuit always on
-      return true
       params[:include_log_id] = !Travis.config.logs_api.enabled? if params[:include_log_id].nil?
       params[:include_log_id] || request.user_agent.to_s.start_with?('Travis')
     end

--- a/lib/travis/api/app/endpoint/jobs.rb
+++ b/lib/travis/api/app/endpoint/jobs.rb
@@ -9,15 +9,14 @@ class Travis::Api::App
 
       get '/' do
         prefer_follower do
-          params[:include_log_id] ||= include_log_id?
-          respond_with service(:find_jobs, params)
+          respond_with service(:find_jobs, params), include_log_id: include_log_id?
         end
       end
 
       get '/:id' do
-        job = service(:find_job, params.merge(include_log_id: include_log_id?)).run
+        job = service(:find_job, params).run
         if job && job.repository
-          respond_with job
+          respond_with job, include_log_id: include_log_id?
         else
           json = { error: { message: "The job(#{params[:id]}) couldn't be found" } }
           status 404

--- a/lib/travis/api/app/endpoint/jobs.rb
+++ b/lib/travis/api/app/endpoint/jobs.rb
@@ -142,6 +142,8 @@ class Travis::Api::App
       end
 
       private def include_log_id?
+        # HACK: short-circuit always on
+        return true
         params[:include_log_id] = !Travis.config.logs_api.enabled? if params[:include_log_id].nil?
         params[:include_log_id] || request.user_agent.to_s.start_with?('Travis')
       end

--- a/lib/travis/api/app/endpoint/jobs.rb
+++ b/lib/travis/api/app/endpoint/jobs.rb
@@ -9,14 +9,14 @@ class Travis::Api::App
 
       get '/' do
         prefer_follower do
-          respond_with service(:find_jobs, params), include_log_id: include_log_id?
+          respond_with service(:find_jobs, params.merge(include_log_id: include_log_id?))
         end
       end
 
       get '/:id' do
-        job = service(:find_job, params).run
+        job = service(:find_job, params.merge(include_log_id: include_log_id?)).run
         if job && job.repository
-          respond_with job, include_log_id: include_log_id?
+          respond_with job
         else
           json = { error: { message: "The job(#{params[:id]}) couldn't be found" } }
           status 404
@@ -142,8 +142,6 @@ class Travis::Api::App
       end
 
       private def include_log_id?
-        # HACK: short-circuit always on
-        return true
         params[:include_log_id] = !Travis.config.logs_api.enabled? if params[:include_log_id].nil?
         params[:include_log_id] || request.user_agent.to_s.start_with?('Travis')
       end

--- a/lib/travis/api/app/endpoint/jobs.rb
+++ b/lib/travis/api/app/endpoint/jobs.rb
@@ -9,7 +9,8 @@ class Travis::Api::App
 
       get '/' do
         prefer_follower do
-          respond_with service(:find_jobs, params.merge(include_log_id: include_log_id?))
+          params[:include_log_id] ||= include_log_id?
+          respond_with service(:find_jobs, params)
         end
       end
 
@@ -142,8 +143,9 @@ class Travis::Api::App
       end
 
       private def include_log_id?
-        params[:include_log_id] = !Travis.config.logs_api.enabled? if params[:include_log_id].nil?
-        params[:include_log_id] || request.user_agent.to_s.start_with?('Travis')
+        params[:include_log_id] ||
+          !Travis.config.logs_api.enabled? ||
+          request.user_agent.to_s.start_with?('Travis')
       end
     end
   end

--- a/lib/travis/api/app/endpoint/jobs.rb
+++ b/lib/travis/api/app/endpoint/jobs.rb
@@ -9,14 +9,14 @@ class Travis::Api::App
 
       get '/' do
         prefer_follower do
-          respond_with service(:find_jobs, params)
+          respond_with service(:find_jobs, params), include_log_id: include_log_id?
         end
       end
 
       get '/:id' do
         job = service(:find_job, params).run
         if job && job.repository
-          respond_with job
+          respond_with job, include_log_id: include_log_id?
         else
           json = { error: { message: "The job(#{params[:id]}) couldn't be found" } }
           status 404
@@ -139,6 +139,11 @@ class Travis::Api::App
 
       def hostname(name)
         "#{name}#{'-staging' if Travis.env == 'staging'}.#{Travis.config.host.split('.')[-2, 2].join('.')}"
+      end
+
+      private def include_log_id?
+        params[:include_log_id] = !Travis.config.logs_api.enabled? if params[:include_log_id].nil?
+        params[:include_log_id] || request.user_agent.to_s.start_with?('Travis')
       end
     end
   end

--- a/lib/travis/api/app/helpers/respond_with.rb
+++ b/lib/travis/api/app/helpers/respond_with.rb
@@ -22,6 +22,7 @@ class Travis::Api::App
           result = prettify_result? ? JSON.pretty_generate(result) : result.to_json
         end
 
+        response.headers['Travis-Response-Options'] = JSON.dump(options)
         halt result || 404
       end
 

--- a/lib/travis/api/app/helpers/respond_with.rb
+++ b/lib/travis/api/app/helpers/respond_with.rb
@@ -22,7 +22,6 @@ class Travis::Api::App
           result = prettify_result? ? JSON.pretty_generate(result) : result.to_json
         end
 
-        response.headers['Travis-Response-Options'] = JSON.dump(options)
         halt result || 404
       end
 

--- a/lib/travis/api/app/responders/json.rb
+++ b/lib/travis/api/app/responders/json.rb
@@ -39,7 +39,11 @@ class Travis::Api::App
             p[:root] = options[:root] if options[:root]
             p[:root] = options[:type] if options[:type] && !p[:root]
             builder_instance = builder.new(resource, p)
-            builder_instance.options = options if builder_instance.respond_to?(:options=)
+
+            if builder_instance.respond_to?(:serialization_options=)
+              builder_instance.serialization_options = options
+            end
+
             builder_instance.data
           else
             basic_type_resource

--- a/lib/travis/api/app/responders/json.rb
+++ b/lib/travis/api/app/responders/json.rb
@@ -38,7 +38,9 @@ class Travis::Api::App
             p = params
             p[:root] = options[:root] if options[:root]
             p[:root] = options[:type] if options[:type] && !p[:root]
-            builder.new(resource, p).data
+            builder_instance = builder.new(resource, p)
+            builder_instance.options = options if builder_instance.respond_to?(:options=)
+            builder_instance.data
           else
             basic_type_resource
           end

--- a/lib/travis/api/serialize/v0/pusher/job.rb
+++ b/lib/travis/api/serialize/v0/pusher/job.rb
@@ -31,7 +31,6 @@ module Travis
               def job_data(job)
                 {
                   'id' => job.id,
-                  'log_id' => job.log_id,
                   'repository_id' => job.repository_id,
                   'repository_slug' => job.repository.slug,
                   'repository_private' => job.repository.private,
@@ -44,7 +43,9 @@ module Travis
                   'queue' => job.queue,
                   'allow_failure' => job.allow_failure,
                   'annotation_ids' => job.annotation_ids
-                }
+                }.tap do |ret|
+                  ret['log_id'] = job.log_id if options[:include_log_id]
+                end
               end
 
               def commit_data(commit)

--- a/lib/travis/api/serialize/v0/pusher/job.rb
+++ b/lib/travis/api/serialize/v0/pusher/job.rb
@@ -14,12 +14,12 @@ module Travis
             include Formats
 
             attr_reader :job, :params
-            attr_accessor :options
+            attr_accessor :serialization_options
 
             def initialize(job, params = {})
               @job = job
               @params = params
-              @options = {}
+              @serialization_options = {}
             end
 
             def data
@@ -66,7 +66,7 @@ module Travis
               end
 
               def include_log_id?
-                !!options[:include_log_id]
+                !!serialization_options[:include_log_id]
               end
           end
         end

--- a/lib/travis/api/serialize/v0/pusher/job.rb
+++ b/lib/travis/api/serialize/v0/pusher/job.rb
@@ -44,7 +44,7 @@ module Travis
                   'allow_failure' => job.allow_failure,
                   'annotation_ids' => job.annotation_ids
                 }.tap do |ret|
-                  ret['log_id'] = job.log_id if options[:include_log_id]
+                  ret['log_id'] = job.log_id unless options[:include_log_id].nil?
                 end
               end
 

--- a/lib/travis/api/serialize/v0/pusher/job.rb
+++ b/lib/travis/api/serialize/v0/pusher/job.rb
@@ -13,11 +13,13 @@ module Travis
           class Job
             include Formats
 
-            attr_reader :job, :options
+            attr_reader :job, :params
+            attr_accessor :options
 
-            def initialize(job, options = {})
+            def initialize(job, params = {})
               @job = job
-              @options = options
+              @params = params
+              @options = {}
             end
 
             def data
@@ -44,7 +46,7 @@ module Travis
                   'allow_failure' => job.allow_failure,
                   'annotation_ids' => job.annotation_ids
                 }.tap do |ret|
-                  ret['log_id'] = job.log_id unless options[:include_log_id].nil?
+                  ret['log_id'] = job.log_id if include_log_id?
                 end
               end
 
@@ -61,6 +63,10 @@ module Travis
                   'committer_email' => commit.committer_email,
                   'compare_url' => commit.compare_url,
                 }
+              end
+
+              def include_log_id?
+                !!options[:include_log_id]
               end
           end
         end

--- a/lib/travis/api/serialize/v2/http/build.rb
+++ b/lib/travis/api/serialize/v2/http/build.rb
@@ -80,7 +80,7 @@ module Travis
                   'tags' => job.tags,
                   'annotation_ids' => job.annotation_ids,
                 }.tap do |ret|
-                  ret['log_id'] = job.log_id if options[:include_log_id]
+                  ret['log_id'] = job.log_id unless options[:include_log_id].nil?
                 end
               end
 

--- a/lib/travis/api/serialize/v2/http/build.rb
+++ b/lib/travis/api/serialize/v2/http/build.rb
@@ -20,7 +20,7 @@ module Travis
             def data
               Travis.logger.debug("#{self.class.name} params=#{params.inspect} serialization_options=#{serialization_options.inspect}")
               {
-                'build'  => build_data
+                'build'  => build_data,
                 'commit' => commit_data,
                 'jobs'   => jobs_data,
                 'annotations' => annotations_data

--- a/lib/travis/api/serialize/v2/http/build.rb
+++ b/lib/travis/api/serialize/v2/http/build.rb
@@ -23,7 +23,6 @@ module Travis
                 'commit' => commit_data(build.commit, build.repository),
                 'jobs'   => options[:include_jobs] ? build.matrix.map { |job| job_data(job) } : [],
                 'annotations' => options[:include_jobs] ? Annotations.new(annotations(build), @options).data["annotations"] : [],
-                'options' => options
               }
             end
 

--- a/lib/travis/api/serialize/v2/http/build.rb
+++ b/lib/travis/api/serialize/v2/http/build.rb
@@ -23,6 +23,7 @@ module Travis
                 'commit' => commit_data(build.commit, build.repository),
                 'jobs'   => options[:include_jobs] ? build.matrix.map { |job| job_data(job) } : [],
                 'annotations' => options[:include_jobs] ? Annotations.new(annotations(build), @options).data["annotations"] : [],
+                'options' => options
               }
             end
 

--- a/lib/travis/api/serialize/v2/http/build.rb
+++ b/lib/travis/api/serialize/v2/http/build.rb
@@ -66,7 +66,6 @@ module Travis
               def job_data(job)
                 {
                   'id' => job.id,
-                  'log_id' => job.log_id,
                   'repository_id' => job.repository_id,
                   'build_id' => job.source_id,
                   'commit_id' => job.commit_id,
@@ -79,7 +78,9 @@ module Travis
                   'allow_failure' => job.allow_failure,
                   'tags' => job.tags,
                   'annotation_ids' => job.annotation_ids,
-                }
+                }.tap do |ret|
+                  ret['log_id'] = job.log_id if options[:include_log_id]
+                end
               end
 
               def branch_is_default(commit, repository)

--- a/lib/travis/api/serialize/v2/http/build.rb
+++ b/lib/travis/api/serialize/v2/http/build.rb
@@ -8,16 +8,17 @@ module Travis
           class Build
             include Formats
 
-            attr_reader :build, :options
+            attr_reader :build, :params
+            attr_accessor :options
 
-            def initialize(build, options = {})
-              options[:include_jobs] = true unless options.key?(:include_jobs)
-
+            def initialize(build, params = {})
               @build = build
-              @options = options
+              @params = params
+              @options = {}
             end
 
             def data
+              Travis.logger.debug("#{self.class.name} params=#{params.inspect} options=#{options.inspect}")
               {
                 'build'  => build_data(build),
                 'commit' => commit_data(build.commit, build.repository),
@@ -79,7 +80,7 @@ module Travis
                   'tags' => job.tags,
                   'annotation_ids' => job.annotation_ids,
                 }.tap do |ret|
-                  ret['log_id'] = job.log_id unless options[:include_log_id].nil?
+                  ret['log_id'] = job.log_id if include_log_id?
                 end
               end
 
@@ -89,6 +90,10 @@ module Travis
 
               def annotations(build)
                 build.matrix.map(&:annotations).flatten
+              end
+
+              def include_log_id?
+                !!options[:include_log_id]
               end
           end
         end

--- a/lib/travis/api/serialize/v2/http/build.rb
+++ b/lib/travis/api/serialize/v2/http/build.rb
@@ -18,7 +18,6 @@ module Travis
             end
 
             def data
-              Travis.logger.debug("#{self.class.name} params=#{params.inspect} serialization_options=#{serialization_options.inspect}")
               {
                 'build'  => build_data,
                 'commit' => commit_data,

--- a/lib/travis/api/serialize/v2/http/job.rb
+++ b/lib/travis/api/serialize/v2/http/job.rb
@@ -43,7 +43,7 @@ module Travis
                   'tags' => job.tags,
                   'annotation_ids' => job.annotation_ids,
                 }.tap do |ret|
-                  ret['log_id'] = job.log_id if options[:include_log_id]
+                  ret['log_id'] = job.log_id unless options[:include_log_id].nil?
                 end
               end
 

--- a/lib/travis/api/serialize/v2/http/job.rb
+++ b/lib/travis/api/serialize/v2/http/job.rb
@@ -28,7 +28,6 @@ module Travis
               def job_data(job)
                 {
                   'id' => job.id,
-                  'log_id' => job.log_id,
                   'repository_id' => job.repository_id,
                   'repository_slug' => job.repository.slug,
                   'build_id' => job.source_id,
@@ -42,7 +41,9 @@ module Travis
                   'allow_failure' => job.allow_failure,
                   'tags' => job.tags,
                   'annotation_ids' => job.annotation_ids,
-                }
+                }.tap do |ret|
+                  ret['log_id'] = job.log_id if options[:include_log_id]
+                end
               end
 
               def commit_data(commit, repository)

--- a/lib/travis/api/serialize/v2/http/job.rb
+++ b/lib/travis/api/serialize/v2/http/job.rb
@@ -9,26 +9,26 @@ module Travis
             include Formats
 
             attr_reader :job, :params
-            attr_accessor :options
+            attr_accessor :serialization_options
 
             def initialize(job, params = {})
               @job = job
               @params = params
-              @options = {}
+              @serialization_options = {}
             end
 
             def data
-              Travis.logger.debug("#{self.class.name} params=#{params.inspect} options=#{options.inspect}")
+              Travis.logger.debug("#{self.class.name} params=#{params.inspect} serialization_options=#{serialization_options.inspect}")
               {
-                'job' => job_data(job),
-                'commit' => commit_data(job.commit, job.repository),
-                'annotations' => Annotations.new(job.annotations, @options).data["annotations"]
+                'job' => job_data,
+                'commit' => commit_data,
+                'annotations' => annotations_data
               }
             end
 
             private
 
-              def job_data(job)
+              def job_data
                 {
                   'id' => job.id,
                   'repository_id' => job.repository_id,
@@ -49,7 +49,7 @@ module Travis
                 end
               end
 
-              def commit_data(commit, repository)
+              def commit_data
                 {
                   'id' => commit.id,
                   'sha' => commit.commit,
@@ -65,12 +65,24 @@ module Travis
                 }
               end
 
+              def annotations_data
+                Annotations.new(job.annotations, params).data["annotations"]
+              end
+
               def branch_is_default(commit, repository)
                 repository.default_branch == commit.branch
               end
 
+              def commit
+                job.commit
+              end
+
+              def repository
+                job.repository
+              end
+
               def include_log_id?
-                !!options[:include_log_id]
+                !!serialization_options[:include_log_id]
               end
           end
         end

--- a/lib/travis/api/serialize/v2/http/job.rb
+++ b/lib/travis/api/serialize/v2/http/job.rb
@@ -20,6 +20,7 @@ module Travis
                 'job' => job_data(job),
                 'commit' => commit_data(job.commit, job.repository),
                 'annotations' => Annotations.new(job.annotations, @options).data["annotations"],
+                '__options' => options
               }
             end
 

--- a/lib/travis/api/serialize/v2/http/job.rb
+++ b/lib/travis/api/serialize/v2/http/job.rb
@@ -18,7 +18,6 @@ module Travis
             end
 
             def data
-              Travis.logger.debug("#{self.class.name} params=#{params.inspect} serialization_options=#{serialization_options.inspect}")
               {
                 'job' => job_data,
                 'commit' => commit_data,

--- a/lib/travis/api/serialize/v2/http/job.rb
+++ b/lib/travis/api/serialize/v2/http/job.rb
@@ -20,7 +20,7 @@ module Travis
                 'job' => job_data(job),
                 'commit' => commit_data(job.commit, job.repository),
                 'annotations' => Annotations.new(job.annotations, @options).data["annotations"],
-                '__options' => options
+                'options' => options
               }
             end
 

--- a/lib/travis/api/serialize/v2/http/job.rb
+++ b/lib/travis/api/serialize/v2/http/job.rb
@@ -19,8 +19,7 @@ module Travis
               {
                 'job' => job_data(job),
                 'commit' => commit_data(job.commit, job.repository),
-                'annotations' => Annotations.new(job.annotations, @options).data["annotations"],
-                'options' => options
+                'annotations' => Annotations.new(job.annotations, @options).data["annotations"]
               }
             end
 

--- a/lib/travis/api/serialize/v2/http/job.rb
+++ b/lib/travis/api/serialize/v2/http/job.rb
@@ -11,7 +11,7 @@ module Travis
             attr_reader :job, :options
 
             def initialize(job, options = {})
-              $stdout.puts "---> #{self.class.name}.new(job, #{options.inspect})"
+              Travis.logger.debug("#{self.class.name}.new options=#{options.inspect}")
               @job = job
               @options = options
             end

--- a/lib/travis/api/serialize/v2/http/job.rb
+++ b/lib/travis/api/serialize/v2/http/job.rb
@@ -8,15 +8,17 @@ module Travis
           class Job
             include Formats
 
-            attr_reader :job, :options
+            attr_reader :job, :params
+            attr_accessor :options
 
-            def initialize(job, options = {})
-              Travis.logger.debug("#{self.class.name}.new options=#{options.inspect}")
+            def initialize(job, params = {})
               @job = job
-              @options = options
+              @params = params
+              @options = {}
             end
 
             def data
+              Travis.logger.debug("#{self.class.name} params=#{params.inspect} options=#{options.inspect}")
               {
                 'job' => job_data(job),
                 'commit' => commit_data(job.commit, job.repository),
@@ -43,7 +45,7 @@ module Travis
                   'tags' => job.tags,
                   'annotation_ids' => job.annotation_ids,
                 }.tap do |ret|
-                  ret['log_id'] = job.log_id unless options[:include_log_id].nil?
+                  ret['log_id'] = job.log_id if include_log_id?
                 end
               end
 
@@ -65,6 +67,10 @@ module Travis
 
               def branch_is_default(commit, repository)
                 repository.default_branch == commit.branch
+              end
+
+              def include_log_id?
+                !!options[:include_log_id]
               end
           end
         end

--- a/lib/travis/api/serialize/v2/http/job.rb
+++ b/lib/travis/api/serialize/v2/http/job.rb
@@ -11,6 +11,7 @@ module Travis
             attr_reader :job, :options
 
             def initialize(job, options = {})
+              $stdout.puts "---> #{self.class.name}.new(job, #{options.inspect})"
               @job = job
               @options = options
             end

--- a/lib/travis/api/serialize/v2/http/jobs.rb
+++ b/lib/travis/api/serialize/v2/http/jobs.rb
@@ -27,7 +27,6 @@ module Travis
               def job_data(job)
                 {
                   'id' => job.id,
-                  'log_id' => job.log_id,
                   'repository_id' => job.repository_id,
                   'repository_slug' => job.repository.slug,
                   'build_id' => job.source_id,
@@ -40,7 +39,9 @@ module Travis
                   'queue' => job.queue,
                   'allow_failure' => job.allow_failure,
                   'tags' => job.tags
-                }
+                }.tap do |ret|
+                  ret['log_id'] = job.log_id if options[:include_log_id]
+                end
               end
 
               def commit_data(commit)

--- a/lib/travis/api/serialize/v2/http/jobs.rb
+++ b/lib/travis/api/serialize/v2/http/jobs.rb
@@ -8,15 +8,17 @@ module Travis
           class Jobs
             include Formats
 
-            attr_reader :jobs, :options
+            attr_reader :jobs, :params
+            attr_accessor :options
 
-            def initialize(jobs, options = {})
-              Travis.logger.debug("#{self.class.name}.new options=#{options.inspect}")
+            def initialize(jobs, params = {})
               @jobs = jobs
-              @options = options
+              @params = params
+              @options = {}
             end
 
             def data
+              Travis.logger.debug("#{self.class.name} params=#{params.inspect} options=#{options.inspect}")
               {
                 'jobs' => jobs.map { |job| job_data(job) },
                 'commits' => jobs.map { |job| commit_data(job.commit) }
@@ -41,7 +43,7 @@ module Travis
                   'allow_failure' => job.allow_failure,
                   'tags' => job.tags
                 }.tap do |ret|
-                  ret['log_id'] = job.log_id unless options[:include_log_id].nil?
+                  ret['log_id'] = job.log_id if include_log_id?
                 end
               end
 
@@ -58,6 +60,10 @@ module Travis
                   'committer_email' => commit.committer_email,
                   'compare_url' => commit.compare_url,
                 }
+              end
+
+              def include_log_id?
+                !!options[:include_log_id]
               end
           end
         end

--- a/lib/travis/api/serialize/v2/http/jobs.rb
+++ b/lib/travis/api/serialize/v2/http/jobs.rb
@@ -11,7 +11,7 @@ module Travis
             attr_reader :jobs, :options
 
             def initialize(jobs, options = {})
-              $stdout.puts "---> #{self.class.name}.new(jobs, #{options.inspect})"
+              Travis.logger.debug("#{self.class.name}.new options=#{options.inspect}")
               @jobs = jobs
               @options = options
             end

--- a/lib/travis/api/serialize/v2/http/jobs.rb
+++ b/lib/travis/api/serialize/v2/http/jobs.rb
@@ -19,7 +19,7 @@ module Travis
               {
                 'jobs' => jobs.map { |job| job_data(job) },
                 'commits' => jobs.map { |job| commit_data(job.commit) },
-                '__options' => options
+                'options' => options
               }
             end
 

--- a/lib/travis/api/serialize/v2/http/jobs.rb
+++ b/lib/travis/api/serialize/v2/http/jobs.rb
@@ -18,7 +18,6 @@ module Travis
             end
 
             def data
-              Travis.logger.debug("#{self.class.name} params=#{params.inspect} serialization_options=#{serialization_options.inspect}")
               {
                 'jobs' => jobs.map { |job| job_data(job) },
                 'commits' => jobs.map { |job| commit_data(job.commit) }

--- a/lib/travis/api/serialize/v2/http/jobs.rb
+++ b/lib/travis/api/serialize/v2/http/jobs.rb
@@ -41,7 +41,7 @@ module Travis
                   'allow_failure' => job.allow_failure,
                   'tags' => job.tags
                 }.tap do |ret|
-                  ret['log_id'] = job.log_id if options[:include_log_id]
+                  ret['log_id'] = job.log_id unless options[:include_log_id].nil?
                 end
               end
 

--- a/lib/travis/api/serialize/v2/http/jobs.rb
+++ b/lib/travis/api/serialize/v2/http/jobs.rb
@@ -11,6 +11,7 @@ module Travis
             attr_reader :jobs, :options
 
             def initialize(jobs, options = {})
+              $stdout.puts "---> #{self.class.name}.new(jobs, #{options.inspect})"
               @jobs = jobs
               @options = options
             end

--- a/lib/travis/api/serialize/v2/http/jobs.rb
+++ b/lib/travis/api/serialize/v2/http/jobs.rb
@@ -18,7 +18,8 @@ module Travis
             def data
               {
                 'jobs' => jobs.map { |job| job_data(job) },
-                'commits' => jobs.map { |job| commit_data(job.commit) }
+                'commits' => jobs.map { |job| commit_data(job.commit) },
+                '__options' => options
               }
             end
 

--- a/lib/travis/api/serialize/v2/http/jobs.rb
+++ b/lib/travis/api/serialize/v2/http/jobs.rb
@@ -9,16 +9,16 @@ module Travis
             include Formats
 
             attr_reader :jobs, :params
-            attr_accessor :options
+            attr_accessor :serialization_options
 
             def initialize(jobs, params = {})
               @jobs = jobs
               @params = params
-              @options = {}
+              @serialization_options = {}
             end
 
             def data
-              Travis.logger.debug("#{self.class.name} params=#{params.inspect} options=#{options.inspect}")
+              Travis.logger.debug("#{self.class.name} params=#{params.inspect} serialization_options=#{serialization_options.inspect}")
               {
                 'jobs' => jobs.map { |job| job_data(job) },
                 'commits' => jobs.map { |job| commit_data(job.commit) }
@@ -63,7 +63,7 @@ module Travis
               end
 
               def include_log_id?
-                !!options[:include_log_id]
+                !!serialization_options[:include_log_id]
               end
           end
         end

--- a/lib/travis/api/serialize/v2/http/jobs.rb
+++ b/lib/travis/api/serialize/v2/http/jobs.rb
@@ -18,8 +18,7 @@ module Travis
             def data
               {
                 'jobs' => jobs.map { |job| job_data(job) },
-                'commits' => jobs.map { |job| commit_data(job.commit) },
-                'options' => options
+                'commits' => jobs.map { |job| commit_data(job.commit) }
               }
             end
 

--- a/lib/travis/api/serialize/v2/http/remote_log.rb
+++ b/lib/travis/api/serialize/v2/http/remote_log.rb
@@ -13,8 +13,14 @@ module Travis
             end
 
             def data
-              log.as_json(chunked: !!serialization_options[:chunked])
+              log.as_json(chunked: chunked?)
             end
+
+            private
+
+              def chunked?
+                !!params.fetch(:chunked, serialization_options[:chunked])
+              end
           end
         end
       end

--- a/lib/travis/api/serialize/v2/http/remote_log.rb
+++ b/lib/travis/api/serialize/v2/http/remote_log.rb
@@ -4,14 +4,15 @@ module Travis
       module V2
         module Http
           class RemoteLog
-            attr_reader :log
+            attr_reader :log, :options
 
             def initialize(log, options = {})
               @log = log
+              @options = options
             end
 
             def data
-              log.as_json
+              log.as_json(chunked: !!options[:chunked])
             end
           end
         end

--- a/lib/travis/api/serialize/v2/http/remote_log.rb
+++ b/lib/travis/api/serialize/v2/http/remote_log.rb
@@ -13,13 +13,23 @@ module Travis
             end
 
             def data
-              log.as_json(chunked: chunked?)
+              log.as_json(
+                chunked: chunked?,
+                after: params[:after],
+                part_numbers: part_numbers
+              )
             end
 
             private
 
               def chunked?
                 !!params.fetch(:chunked, serialization_options[:chunked])
+              end
+
+              def part_numbers
+                @part_numbers ||= params[:part_numbers].to_s
+                                                       .split(',')
+                                                       .map(&:to_i)
               end
           end
         end

--- a/lib/travis/api/serialize/v2/http/remote_log.rb
+++ b/lib/travis/api/serialize/v2/http/remote_log.rb
@@ -4,15 +4,16 @@ module Travis
       module V2
         module Http
           class RemoteLog
-            attr_reader :log, :options
+            attr_reader :log, :params
+            attr_accessor :serialization_options
 
-            def initialize(log, options = {})
+            def initialize(log, params = {})
               @log = log
-              @options = options
+              @params = params
             end
 
             def data
-              log.as_json(chunked: !!options[:chunked])
+              log.as_json(chunked: !!serialization_options[:chunked])
             end
           end
         end

--- a/lib/travis/api/v3/models/log.rb
+++ b/lib/travis/api/v3/models/log.rb
@@ -17,5 +17,9 @@ module Travis::API::V3
       log_parts.destroy_all
       log_parts.create(content: message, number: 1, final: true)
     end
+
+    def archived?
+      archived_at && archive_verified?
+    end
   end
 end

--- a/lib/travis/api/v3/queries/log.rb
+++ b/lib/travis/api/v3/queries/log.rb
@@ -7,7 +7,7 @@ module Travis::API::V3
       log = logs_model.find_by_job_id(@job.id)
       raise EntityMissing, 'log not found'.freeze if log.nil?
       #if the log has been archived, go to s3
-      if log.archived_at
+      if log.archived?
         content = fetch.first
         raise EntityMissing, 'could not retrieve log'.freeze if content.nil?
         body = content.body.force_encoding('UTF-8') unless content.body.nil?

--- a/lib/travis/remote_log.rb
+++ b/lib/travis/remote_log.rb
@@ -10,7 +10,7 @@ module Travis
       extend Forwardable
 
       def_delegators :client, :find_by_job_id, :find_by_id,
-        :find_id_by_job_id, :write_content_for_job_id
+        :find_id_by_job_id, :find_parts_by_job_id, :write_content_for_job_id
 
       def_delegators :archive_client, :fetch_archived_url
 
@@ -65,12 +65,28 @@ module Travis
       @removed_by ||= User.find(removed_by_id)
     end
 
-    def parts
-      # The content field is always pre-aggregated.
-      []
+    def removed?
+      !removed_by_id.nil?
+    end
+
+    def parts(after: nil, part_numbers: [])
+      return solo_part if removed? || aggregated?
+      self.class.find_parts_by_job_id(
+        job_id, after: after, part_numbers: part_numbers
+      )
     end
 
     alias log_parts parts
+
+    private def solo_part
+      [
+        {
+          'number' => 1,
+          'content' => content,
+          'final' => true
+        }
+      ]
+    end
 
     def aggregated?
       !!aggregated_at
@@ -84,11 +100,15 @@ module Travis
       @archived_url ||= self.class.fetch_archived_url(job_id, expires: expires)
     end
 
-    def to_json(chunked: false)
-      as_json(chunked: chunked).to_json
+    def to_json(chunked: false, after: nil, part_numbers: [])
+      as_json(
+        chunked: chunked,
+        after: after,
+        part_numbers: part_numbers
+      ).to_json
     end
 
-    def as_json(chunked: false)
+    def as_json(chunked: false, after: nil, part_numbers: [])
       ret = {
         'id' => id,
         'job_id' => job_id,
@@ -101,13 +121,10 @@ module Travis
       end
 
       if chunked
-        ret['parts'] = [
-          {
-            'number' => 1,
-            'content' => content,
-            'final' => true
-          }
-        ]
+        ret['parts'] = parts(
+          after: after,
+          part_numbers: part_numbers
+        ).map(&:as_json)
       else
         ret['body'] = content
       end
@@ -163,6 +180,23 @@ module Travis
         end
         return nil unless resp.success?
         JSON.parse(resp.body).fetch('id')
+      end
+
+      def find_parts_by_job_id(job_id, after: nil, part_numbers: [])
+        resp = conn.get do |req|
+          req.url "/log-parts/#{job_id}"
+          req.params['after'] = after unless after.nil?
+          unless part_numbers.empty?
+            req.params['part_numbers'] = part_numbers.map(&:to_s).join(',')
+          end
+        end
+        unless resp.success?
+          raise Error, "failed to fetch log-parts job_id=#{job_id}"
+        end
+
+        JSON.parse(resp.body).fetch('log_parts').map do |part|
+          Travis::RemoteLogPart.new(part)
+        end
       end
 
       def write_content_for_job_id(job_id, content: '', removed_by: nil)
@@ -226,6 +260,19 @@ module Travis
         return nil if candidates.empty?
         candidates.first
       end
+    end
+  end
+
+  class RemoteLogPart
+    include Virtus.model(nullify_blank: true)
+
+    attribute :content, String
+    attribute :final, Boolean
+    attribute :id, Integer
+    attribute :number, Integer
+
+    def as_json
+      attributes.dup
     end
   end
 end

--- a/spec/integration/v2/jobs_spec.rb
+++ b/spec/integration/v2/jobs_spec.rb
@@ -13,7 +13,12 @@ describe 'Jobs', set_app: true do
 
   it '/jobs/:id' do
     response = get "/jobs/#{job.id}", {}, headers
-    response.should deliver_json_for(job, version: 'v2')
+    response.status.should == 200
+    expected = Travis::Api::Serialize.data(job, version: 'v2')
+    expected.delete('log_id')
+    parsed = MultiJson.decode(response.body)
+    parsed['job'].delete('log_id')
+    parsed.should == expected
   end
 
   context 'GET /jobs/:job_id/log.txt', logs_api_enabled: false do

--- a/spec/lib/travis/remote_log_spec.rb
+++ b/spec/lib/travis/remote_log_spec.rb
@@ -134,14 +134,6 @@ describe Travis::RemoteLog do
     from_json.fetch('body').should == attrs[:content]
   end
 
-  it 'can fake chunked serialization via #to_json' do
-    from_json = JSON.parse(subject.to_json(chunked: true)).fetch('log')
-    from_json.fetch('id').should == attrs[:id]
-    from_json.fetch('job_id').should == attrs[:job_id]
-    from_json.fetch('type').should == 'Log'
-    from_json.fetch('parts').first.fetch('content').should == attrs[:content]
-  end
-
   it 'can serialize removed logs via #to_json' do
     user_id = 8
     user = mock('user')

--- a/spec/lib/travis/remote_log_spec.rb
+++ b/spec/lib/travis/remote_log_spec.rb
@@ -81,9 +81,14 @@ describe Travis::RemoteLog do
     subject.archived_url.should eq 'yep'
   end
 
-  it 'never has parts' do
-    subject.parts.should be_empty
-    subject.log_parts.should be_empty
+  it 'has parts' do
+    found_parts = [
+      Travis::RemoteLogPart.new(number: 42, content: 'yey', final: false)
+    ]
+    described_class.stubs(:find_parts_by_job_id)
+      .with(5, after: nil, part_numbers: [])
+      .returns(found_parts)
+    subject.parts.should eq found_parts
   end
 
   {

--- a/spec/unit/serialize/v2/http/job_spec.rb
+++ b/spec/unit/serialize/v2/http/job_spec.rb
@@ -8,7 +8,9 @@ describe Travis::Api::Serialize::V2::Http::Job do
     { include_log_id: true }
   ].each do |options|
     it 'job', logs_api_enabled: false do
-      serialized = described_class.new(test, options).data
+      instance = described_class.new(test)
+      instance.serialization_options = options
+      serialized = instance.data
       serialized['job'].should == {
         'id' => 1,
         'repository_id' => 1,

--- a/spec/unit/serialize/v2/http/job_spec.rb
+++ b/spec/unit/serialize/v2/http/job_spec.rb
@@ -3,24 +3,31 @@ describe Travis::Api::Serialize::V2::Http::Job do
 
   let(:data) { described_class.new(test).data }
 
-  it 'job', logs_api_enabled: false do
-    data['job'].should == {
-      'id' => 1,
-      'repository_id' => 1,
-      'repository_slug' => 'svenfuchs/minimal',
-      'build_id' => 1,
-      'commit_id' => 1,
-      'log_id' => 1,
-      'number' => '2.1',
-      'state' => 'passed',
-      'started_at' => json_format_time(Time.now.utc - 1.minute),
-      'finished_at' => json_format_time(Time.now.utc),
-      'config' => { 'rvm' => '1.8.7', 'gemfile' => 'test/Gemfile.rails-2.3.x' },
-      'queue' => 'builds.linux',
-      'allow_failure' => false,
-      'tags' => 'tag-a,tag-b',
-      'annotation_ids' => [1],
-    }
+  [
+    {},
+    { include_log_id: true }
+  ].each do |options|
+    it 'job', logs_api_enabled: false do
+      serialized = described_class.new(test, options).data
+      serialized['job'].should == {
+        'id' => 1,
+        'repository_id' => 1,
+        'repository_slug' => 'svenfuchs/minimal',
+        'build_id' => 1,
+        'commit_id' => 1,
+        'number' => '2.1',
+        'state' => 'passed',
+        'started_at' => json_format_time(Time.now.utc - 1.minute),
+        'finished_at' => json_format_time(Time.now.utc),
+        'config' => { 'rvm' => '1.8.7', 'gemfile' => 'test/Gemfile.rails-2.3.x' },
+        'queue' => 'builds.linux',
+        'allow_failure' => false,
+        'tags' => 'tag-a,tag-b',
+        'annotation_ids' => [1],
+      }.tap do |expected|
+        expected['log_id'] = 1 if options[:include_log_id]
+      end
+    end
   end
 
   it 'commit' do

--- a/spec/unit/serialize/v2/http/jobs_spec.rb
+++ b/spec/unit/serialize/v2/http/jobs_spec.rb
@@ -4,23 +4,30 @@ describe Travis::Api::Serialize::V2::Http::Jobs do
   let(:data) { described_class.new([test]).data }
   let!(:time) { Time.now.utc }
 
-  it 'jobs', logs_api_enabled: false do
-    data['jobs'].first.should == {
-      'id' => 1,
-      'repository_id' => 1,
-      'repository_slug' => 'svenfuchs/minimal',
-      'build_id' => 1,
-      'commit_id' => 1,
-      'log_id' => 1,
-      'number' => '2.1',
-      'state' => 'passed',
-      'started_at' => json_format_time(time - 1.minute),
-      'finished_at' => json_format_time(time),
-      'config' => { 'rvm' => '1.8.7', 'gemfile' => 'test/Gemfile.rails-2.3.x' },
-      'queue' => 'builds.linux',
-      'allow_failure' => false,
-      'tags' => 'tag-a,tag-b'
-    }
+  [
+    {},
+    { include_log_id: true }
+  ].each do |options|
+    it 'jobs', logs_api_enabled: false do
+      serialized = described_class.new([test], options).data
+      serialized['jobs'].first.should == {
+        'id' => 1,
+        'repository_id' => 1,
+        'repository_slug' => 'svenfuchs/minimal',
+        'build_id' => 1,
+        'commit_id' => 1,
+        'number' => '2.1',
+        'state' => 'passed',
+        'started_at' => json_format_time(time - 1.minute),
+        'finished_at' => json_format_time(time),
+        'config' => { 'rvm' => '1.8.7', 'gemfile' => 'test/Gemfile.rails-2.3.x' },
+        'queue' => 'builds.linux',
+        'allow_failure' => false,
+        'tags' => 'tag-a,tag-b'
+      }.tap do |expected|
+        expected['log_id'] = 1 if options[:include_log_id]
+      end
+    end
   end
 
   it 'commits' do

--- a/spec/unit/serialize/v2/http/jobs_spec.rb
+++ b/spec/unit/serialize/v2/http/jobs_spec.rb
@@ -9,7 +9,9 @@ describe Travis::Api::Serialize::V2::Http::Jobs do
     { include_log_id: true }
   ].each do |options|
     it 'jobs', logs_api_enabled: false do
-      serialized = described_class.new([test], options).data
+      instance = described_class.new([test])
+      instance.serialization_options = options
+      serialized = instance.data
       serialized['jobs'].first.should == {
         'id' => 1,
         'repository_id' => 1,

--- a/spec/v3/services/log/find_spec.rb
+++ b/spec/v3/services/log/find_spec.rb
@@ -16,7 +16,7 @@ describe Travis::API::V3::Services::Log::Find, set_app: true do
   let(:log2)        { Travis::API::V3::Models::Log.create(job: job2) }
   let(:log3)        { Travis::API::V3::Models::Log.create(job: job3) }
   let(:s3log)       { Travis::API::V3::Models::Log.create(job: s3job, content: 'minimal log 1') }
-  let(:no_s3log)    { Travis::API::V3::Models::Log.create(archived_at: Time.now, job: s3job2, content: 'minimal log 2') }
+  let(:no_s3log)    { Travis::API::V3::Models::Log.create(archived_at: Time.now, archive_verified: true, job: s3job2, content: 'minimal log 2') }
   let(:find_log)    { "string" }
   let(:time)        { Time.now }
   let(:xml_content) {
@@ -126,7 +126,7 @@ describe Travis::API::V3::Services::Log::Find, set_app: true do
   context 'when log not found in db but stored on S3', logs_api_enabled: false do
     describe 'returns log with an array of Log Parts' do
       example do
-        s3log.update_attributes(archived_at: time)
+        s3log.update_attributes(archived_at: time, archive_verified: true)
         get("/v3/job/#{s3log.job.id}/log", {}, headers)
 
         expect(parsed_body).to eq(
@@ -144,7 +144,7 @@ describe Travis::API::V3::Services::Log::Find, set_app: true do
     end
     describe 'returns log as plain text' do
       example do
-        s3log.update_attributes(archived_at: Time.now)
+        s3log.update_attributes(archived_at: Time.now, archive_verified: true)
         get("/v3/job/#{s3log.job.id}/log", {}, headers.merge('HTTP_ACCEPT' => 'text/plain'))
         expect(last_response.headers).to include("Content-Type" => "text/plain")
         expect(body).to eq(
@@ -154,7 +154,7 @@ describe Travis::API::V3::Services::Log::Find, set_app: true do
 
     describe 'it returns the correct content type' do
       example do
-        s3log.update_attributes(archived_at: Time.now)
+        s3log.update_attributes(archived_at: Time.now, archive_verified: true)
         get("/v3/job/#{s3log.job.id}/log", {}, headers.merge('HTTP_ACCEPT' => 'fun/times'))
         expect(last_response.headers).to include("Content-Type" => "application/json")
       end


### PR DESCRIPTION
plus (back?) to conditionally including a job's `log_id` in order to make the interactions with the travis-logs API *much* less chatty during normal use via travis-web while retaining compatibility with https://github.com/travis-ci/travis.rb.

- [x] plays nicely when web requests `chunked`