### PR TITLE
API v3: Fix 'home' entry in service index

### DIFF
--- a/lib/travis/api/v3/service_index.rb
+++ b/lib/travis/api/v3/service_index.rb
@@ -31,11 +31,11 @@ module Travis::API::V3
     def all_resources
       @all_resources ||= begin
         home_actions = {
-          find: {
+          find: [{
             :@type          => :template,
             :request_method => :GET,
             :uri_template   => prefix + ?/
-          }
+          }]
         }
 
         all = routes.resources + [

--- a/spec/v3/service_index_spec.rb
+++ b/spec/v3/service_index_spec.rb
@@ -30,6 +30,17 @@ describe Travis::API::V3::ServiceIndex, set_app: true do
         end
       end
 
+      describe "home resource" do
+        let(:resource) { resources.fetch("home") }
+        specify { expect(resources)         .to include("home")   }
+        specify { expect(resource["@type"]) .to be == "resource"  }
+
+        describe "find action" do
+          let(:action) { resource.fetch("actions").fetch("find") }
+          specify { expect(action).to include("@type"=>"template", "request_method"=>"GET", "uri_template"=>path) }
+        end
+      end
+
       describe "branch resource" do
         let(:resource) { resources.fetch("branch") }
         specify { expect(resources)         .to include("branch") }
@@ -177,7 +188,7 @@ describe Travis::API::V3::ServiceIndex, set_app: true do
           specify { expect(action).to include("@type"=>"template", "request_method"=>"GET", "uri_template"=>"#{path}build/{build.id}{?include}") }
         end
       end
-      
+
       describe "key pair resource" do
         let(:resource) { resources.fetch("key_pair") }
         specify { expect(resources)         .to include("key_pair") }
@@ -200,7 +211,7 @@ describe Travis::API::V3::ServiceIndex, set_app: true do
           end
         end
       end
-      
+
       describe "key pair (generated) resource" do
         let(:resource) { resources.fetch("key_pair_generated") }
         specify { expect(resources)         .to include("key_pair_generated") }


### PR DESCRIPTION
All resources listed in the service index have the templates in their actions listed as an array (main reason being that URI templates don't support unions), except for the `home` entry.

This PR fixes it.

@mislav reported this issue a long time ago via Slack, but I only just came across it again while playing reviewing the API. Automated scripts are likely to run into this issue.