### PR TITLE
Revert of Revert of Ensuring RemoteLog serializes more like direct database Log

### DIFF
--- a/lib/travis/api/app.rb
+++ b/lib/travis/api/app.rb
@@ -27,6 +27,7 @@ require 'metriks/librato_metrics_reporter'
 require 'travis/support/log_subscriber/active_record_metrics'
 require 'fileutils'
 require 'securerandom'
+require 'fog/aws'
 
 module Travis::Api
 end
@@ -194,6 +195,12 @@ module Travis::Api
 
         if use_monitoring? && !console?
           setup_monitoring
+        end
+
+        if defined?(Fog) && defined?(Fog::Logger)
+          %i(warning deprecation debug).each do |channel|
+            Fog::Logger[channel] = nil
+          end
         end
       end
 

--- a/lib/travis/api/app/endpoint/builds.rb
+++ b/lib/travis/api/app/endpoint/builds.rb
@@ -9,12 +9,12 @@ class Travis::Api::App
         prefer_follower do
           name = params[:branches] ? :find_branches : :find_builds
           params['ids'] = params['ids'].split(',') if params['ids'].respond_to?(:split)
-          respond_with service(name, params)
+          respond_with service(name, params), include_log_id: include_log_id?
         end
       end
 
       get '/:id' do
-        respond_with service(:find_build, params)
+        respond_with service(:find_build, params), include_log_id: include_log_id?
       end
 
       post '/:id/cancel' do
@@ -65,6 +65,12 @@ class Travis::Api::App
 
         respond_with(result: result, flash: service.messages)
       end
+    end
+
+    private def include_log_id?
+      params[:include_log_id] ||
+        !Travis.config.logs_api.enabled? ||
+        request.user_agent.to_s.start_with?('Travis')
     end
   end
 end

--- a/lib/travis/api/app/endpoint/jobs.rb
+++ b/lib/travis/api/app/endpoint/jobs.rb
@@ -77,7 +77,10 @@ class Travis::Api::App
         resource = service(:find_log, params).run
         if (resource && resource.removed_at) && accepts?('application/json')
           respond_with resource
-        elsif (!resource || resource.archived?)
+        elsif resource.nil?
+          status 200
+          body empty_log(Integer(params[:job_id])).to_json
+        elsif resource.archived?
           # the way we use responders makes it hard to validate proper format
           # automatically here, so we need to check it explicitly
           if accepts?('text/plain') || request.user_agent.to_s.start_with?('Travis')
@@ -145,6 +148,11 @@ class Travis::Api::App
         params[:include_log_id] ||
           !Travis.config.logs_api.enabled? ||
           request.user_agent.to_s.start_with?('Travis')
+      end
+
+      private def empty_log(job_id)
+        # XXX: Should this empty version be defined elsewhere?
+        { log: { job_id: job_id, parts: [], :@type => 'Log' } }
       end
     end
   end

--- a/lib/travis/api/app/endpoint/jobs.rb
+++ b/lib/travis/api/app/endpoint/jobs.rb
@@ -151,7 +151,6 @@ class Travis::Api::App
       end
 
       private def empty_log(job_id)
-        # XXX: Should this empty version be defined elsewhere?
         { log: { job_id: job_id, parts: [], :@type => 'Log' } }
       end
     end

--- a/lib/travis/api/app/endpoint/jobs.rb
+++ b/lib/travis/api/app/endpoint/jobs.rb
@@ -9,14 +9,14 @@ class Travis::Api::App
 
       get '/' do
         prefer_follower do
-          respond_with service(:find_jobs, params)
+          respond_with service(:find_jobs, params), include_log_id: include_log_id?
         end
       end
 
       get '/:id' do
         job = service(:find_job, params).run
         if job && job.repository
-          respond_with job
+          respond_with job, include_log_id: include_log_id?
         else
           json = { error: { message: "The job(#{params[:id]}) couldn't be found" } }
           status 404
@@ -139,6 +139,12 @@ class Travis::Api::App
 
       def hostname(name)
         "#{name}#{'-staging' if Travis.env == 'staging'}.#{Travis.config.host.split('.')[-2, 2].join('.')}"
+      end
+
+      private def include_log_id?
+        params[:include_log_id] ||
+          !Travis.config.logs_api.enabled? ||
+          request.user_agent.to_s.start_with?('Travis')
       end
     end
   end

--- a/lib/travis/api/app/responders/json.rb
+++ b/lib/travis/api/app/responders/json.rb
@@ -38,7 +38,13 @@ class Travis::Api::App
             p = params
             p[:root] = options[:root] if options[:root]
             p[:root] = options[:type] if options[:type] && !p[:root]
-            builder.new(resource, p).data
+            builder_instance = builder.new(resource, p)
+
+            if builder_instance.respond_to?(:serialization_options=)
+              builder_instance.serialization_options = options
+            end
+
+            builder_instance.data
           else
             basic_type_resource
           end

--- a/lib/travis/api/serialize/v0/pusher/job.rb
+++ b/lib/travis/api/serialize/v0/pusher/job.rb
@@ -13,11 +13,13 @@ module Travis
           class Job
             include Formats
 
-            attr_reader :job, :options
+            attr_reader :job, :params
+            attr_accessor :serialization_options
 
-            def initialize(job, options = {})
+            def initialize(job, params = {})
               @job = job
-              @options = options
+              @params = params
+              @serialization_options = {}
             end
 
             def data
@@ -31,7 +33,6 @@ module Travis
               def job_data(job)
                 {
                   'id' => job.id,
-                  'log_id' => job.log_id,
                   'repository_id' => job.repository_id,
                   'repository_slug' => job.repository.slug,
                   'repository_private' => job.repository.private,
@@ -44,7 +45,9 @@ module Travis
                   'queue' => job.queue,
                   'allow_failure' => job.allow_failure,
                   'annotation_ids' => job.annotation_ids
-                }
+                }.tap do |ret|
+                  ret['log_id'] = job.log_id if include_log_id?
+                end
               end
 
               def commit_data(commit)
@@ -60,6 +63,10 @@ module Travis
                   'committer_email' => commit.committer_email,
                   'compare_url' => commit.compare_url,
                 }
+              end
+
+              def include_log_id?
+                !!serialization_options[:include_log_id]
               end
           end
         end

--- a/lib/travis/api/serialize/v2/http/build.rb
+++ b/lib/travis/api/serialize/v2/http/build.rb
@@ -84,12 +84,10 @@ module Travis
               end
 
               def jobs_data
-                return [] unless params[:include_jobs]
                 build.matrix.map { |job| job_data(job) }
               end
 
               def annotations_data
-                return [] unless params[:include_jobs]
                 Annotations.new(annotations, params).data["annotations"]
               end
 

--- a/lib/travis/api/serialize/v2/http/jobs.rb
+++ b/lib/travis/api/serialize/v2/http/jobs.rb
@@ -8,11 +8,13 @@ module Travis
           class Jobs
             include Formats
 
-            attr_reader :jobs, :options
+            attr_reader :jobs, :params
+            attr_accessor :serialization_options
 
-            def initialize(jobs, options = {})
+            def initialize(jobs, params = {})
               @jobs = jobs
-              @options = options
+              @params = params
+              @serialization_options = {}
             end
 
             def data
@@ -27,7 +29,6 @@ module Travis
               def job_data(job)
                 {
                   'id' => job.id,
-                  'log_id' => job.log_id,
                   'repository_id' => job.repository_id,
                   'repository_slug' => job.repository.slug,
                   'build_id' => job.source_id,
@@ -40,7 +41,9 @@ module Travis
                   'queue' => job.queue,
                   'allow_failure' => job.allow_failure,
                   'tags' => job.tags
-                }
+                }.tap do |ret|
+                  ret['log_id'] = job.log_id if include_log_id?
+                end
               end
 
               def commit_data(commit)
@@ -56,6 +59,10 @@ module Travis
                   'committer_email' => commit.committer_email,
                   'compare_url' => commit.compare_url,
                 }
+              end
+
+              def include_log_id?
+                !!serialization_options[:include_log_id]
               end
           end
         end

--- a/lib/travis/api/serialize/v2/http/remote_log.rb
+++ b/lib/travis/api/serialize/v2/http/remote_log.rb
@@ -4,15 +4,33 @@ module Travis
       module V2
         module Http
           class RemoteLog
-            attr_reader :log
+            attr_reader :log, :params
+            attr_accessor :serialization_options
 
-            def initialize(log, options = {})
+            def initialize(log, params = {})
               @log = log
+              @params = params
             end
 
             def data
-              log.as_json
+              log.as_json(
+                chunked: chunked?,
+                after: params[:after],
+                part_numbers: part_numbers
+              )
             end
+
+            private
+
+              def chunked?
+                !!params.fetch(:chunked, serialization_options[:chunked])
+              end
+
+              def part_numbers
+                @part_numbers ||= params[:part_numbers].to_s
+                                                       .split(',')
+                                                       .map(&:to_i)
+              end
           end
         end
       end

--- a/lib/travis/api/v3/constant_resolver.rb
+++ b/lib/travis/api/v3/constant_resolver.rb
@@ -11,6 +11,7 @@ module Travis::API::V3
 
     def [](key, raise_unknown = true)
       return key unless key.is_a? Symbol
+      resolver_cache[key] ||= Travis::API::V3::Permissions::Job if key == :"travis/remote_log"
       resolver_cache[key] ||= const_get(key.to_s.camelize, false)
     rescue NameError => e
       raise e if raise_unknown

--- a/lib/travis/api/v3/models/job.rb
+++ b/lib/travis/api/v3/models/job.rb
@@ -15,7 +15,7 @@ module Travis::API::V3
 
     if Travis::Config.logs_api_enabled?
       def log
-        @log ||= Models::RemoteLog.find_by_job_id(id)
+        @log ||= Travis::RemoteLog.find_by_job_id(id)
       end
     end
   end

--- a/lib/travis/api/v3/models/log.rb
+++ b/lib/travis/api/v3/models/log.rb
@@ -17,5 +17,9 @@ module Travis::API::V3
       log_parts.destroy_all
       log_parts.create(content: message, number: 1, final: true)
     end
+
+    def archived?
+      archived_at && archive_verified?
+    end
   end
 end

--- a/lib/travis/api/v3/models/remote_log.rb
+++ b/lib/travis/api/v3/models/remote_log.rb
@@ -1,5 +1,1 @@
 require 'travis/remote_log'
-
-module Travis::API::V3::Models
-  RemoteLog = Class.new(Travis::RemoteLog)
-end

--- a/lib/travis/api/v3/queries/log.rb
+++ b/lib/travis/api/v3/queries/log.rb
@@ -58,7 +58,7 @@ module Travis::API::V3
       "#{name}#{'-staging' if Travis.env == 'staging'}.#{Travis.config.host.split('.')[-2, 2].join('.')}"
     end
 
-    private def logs_model
+    def logs_model
       return Travis::RemoteLog if Travis.config.logs_api.enabled?
       Travis::API::V3::Models::Log
     end

--- a/lib/travis/api/v3/queries/log.rb
+++ b/lib/travis/api/v3/queries/log.rb
@@ -58,8 +58,8 @@ module Travis::API::V3
       "#{name}#{'-staging' if Travis.env == 'staging'}.#{Travis.config.host.split('.')[-2, 2].join('.')}"
     end
 
-    def logs_model
-      return Travis::API::V3::Models::RemoteLog if Travis.config.logs_api.enabled?
+    private def logs_model
+      return Travis::RemoteLog if Travis.config.logs_api.enabled?
       Travis::API::V3::Models::Log
     end
   end

--- a/lib/travis/api/v3/queries/log.rb
+++ b/lib/travis/api/v3/queries/log.rb
@@ -7,7 +7,7 @@ module Travis::API::V3
       log = logs_model.find_by_job_id(@job.id)
       raise EntityMissing, 'log not found'.freeze if log.nil?
       #if the log has been archived, go to s3
-      if log.archived_at
+      if log.archived?
         content = fetch.first
         raise EntityMissing, 'could not retrieve log'.freeze if content.nil?
         body = content.body.force_encoding('UTF-8') unless content.body.nil?

--- a/lib/travis/api/v3/renderer.rb
+++ b/lib/travis/api/v3/renderer.rb
@@ -50,6 +50,7 @@ module Travis::API::V3
       when ActiveRecord::Relation then render_value(value.to_a, **options)
       when ActiveRecord::Associations::CollectionProxy then render_value(value.to_a, **options)
       when Travis::Settings::EncryptedValue then value.decrypt
+      when Travis::RemoteLogPart then render_value(value.as_json, **options)
       else raise ArgumentError, 'cannot render %p (%p)' % [value.class, value]
       end
     end

--- a/lib/travis/model/remote_log.rb
+++ b/lib/travis/model/remote_log.rb
@@ -1,3 +1,1 @@
 require 'travis/remote_log'
-
-RemoteLog = Class.new(Travis::RemoteLog)

--- a/lib/travis/remote_log.rb
+++ b/lib/travis/remote_log.rb
@@ -80,11 +80,11 @@ module Travis
 
     private def solo_part
       [
-        {
-          'number' => 1,
-          'content' => content,
-          'final' => true
-        }
+        RemoteLogPart.new(
+          number: 0,
+          content: content,
+          final: true
+        )
       ]
     end
 
@@ -193,9 +193,8 @@ module Travis
         unless resp.success?
           raise Error, "failed to fetch log-parts job_id=#{job_id}"
         end
-
         JSON.parse(resp.body).fetch('log_parts').map do |part|
-          Travis::RemoteLogPart.new(part)
+          RemoteLogPart.new(part)
         end
       end
 
@@ -209,7 +208,7 @@ module Travis
         unless resp.success?
           raise Error, "failed to write content job_id=#{job_id}"
         end
-        Travis::RemoteLog.new(JSON.parse(resp.body))
+        RemoteLog.new(JSON.parse(resp.body))
       end
 
       private def find_by(by, id)
@@ -217,7 +216,7 @@ module Travis
           req.url "/logs/#{id}", by: by
         end
         return nil unless resp.success?
-        Travis::RemoteLog.new(JSON.parse(resp.body))
+        RemoteLog.new(JSON.parse(resp.body))
       end
 
       private def conn
@@ -272,7 +271,7 @@ module Travis
     attribute :number, Integer
 
     def as_json
-      attributes.dup
+      attributes.slice(*%i(content final number))
     end
   end
 end

--- a/lib/travis/remote_log.rb
+++ b/lib/travis/remote_log.rb
@@ -10,7 +10,7 @@ module Travis
       extend Forwardable
 
       def_delegators :client, :find_by_job_id, :find_by_id,
-        :find_id_by_job_id, :write_content_for_job_id
+        :find_id_by_job_id, :find_parts_by_job_id, :write_content_for_job_id
 
       def_delegators :archive_client, :fetch_archived_url
 
@@ -65,12 +65,28 @@ module Travis
       @removed_by ||= User.find(removed_by_id)
     end
 
-    def parts
-      # The content field is always pre-aggregated.
-      []
+    def removed?
+      !removed_by_id.nil?
+    end
+
+    def parts(after: nil, part_numbers: [])
+      return solo_part if removed? || aggregated?
+      self.class.find_parts_by_job_id(
+        job_id, after: after, part_numbers: part_numbers
+      )
     end
 
     alias log_parts parts
+
+    private def solo_part
+      [
+        {
+          'number' => 1,
+          'content' => content,
+          'final' => true
+        }
+      ]
+    end
 
     def aggregated?
       !!aggregated_at
@@ -84,16 +100,36 @@ module Travis
       @archived_url ||= self.class.fetch_archived_url(job_id, expires: expires)
     end
 
-    def to_json
-      as_json.to_json
+    def to_json(chunked: false, after: nil, part_numbers: [])
+      as_json(
+        chunked: chunked,
+        after: after,
+        part_numbers: part_numbers
+      ).to_json
     end
 
-    def as_json
-      {
-        'log' => attributes.slice(
-          *%i(id content created_at job_id updated_at)
-        )
+    def as_json(chunked: false, after: nil, part_numbers: [])
+      ret = {
+        'id' => id,
+        'job_id' => job_id,
+        'type' => 'Log'
       }
+
+      unless removed_at.nil?
+        ret['removed_at'] = removed_at.utc.to_s
+        ret['removed_by'] = removed_by.name || removed_by.login
+      end
+
+      if chunked
+        ret['parts'] = parts(
+          after: after,
+          part_numbers: part_numbers
+        ).map(&:as_json)
+      else
+        ret['body'] = content
+      end
+
+      { 'log' => ret }
     end
 
     def clear!(user = nil)
@@ -144,6 +180,23 @@ module Travis
         end
         return nil unless resp.success?
         JSON.parse(resp.body).fetch('id')
+      end
+
+      def find_parts_by_job_id(job_id, after: nil, part_numbers: [])
+        resp = conn.get do |req|
+          req.url "/log-parts/#{job_id}"
+          req.params['after'] = after unless after.nil?
+          unless part_numbers.empty?
+            req.params['part_numbers'] = part_numbers.map(&:to_s).join(',')
+          end
+        end
+        unless resp.success?
+          raise Error, "failed to fetch log-parts job_id=#{job_id}"
+        end
+
+        JSON.parse(resp.body).fetch('log_parts').map do |part|
+          Travis::RemoteLogPart.new(part)
+        end
       end
 
       def write_content_for_job_id(job_id, content: '', removed_by: nil)
@@ -207,6 +260,19 @@ module Travis
         return nil if candidates.empty?
         candidates.first
       end
+    end
+  end
+
+  class RemoteLogPart
+    include Virtus.model(nullify_blank: true)
+
+    attribute :content, String
+    attribute :final, Boolean
+    attribute :id, Integer
+    attribute :number, Integer
+
+    def as_json
+      attributes.dup
     end
   end
 end

--- a/spec/integration/v2/builds_spec.rb
+++ b/spec/integration/v2/builds_spec.rb
@@ -8,12 +8,12 @@ describe 'Builds', set_app: true do
     response.should deliver_json_for(repo.builds.order('id DESC'), version: 'v2')
   end
 
-  it 'GET /builds/1' do
+  it 'GET /builds/1', logs_api_enabled: true do
     response = get "/builds/#{build.id}", {}, headers
     response.should deliver_json_for(build, version: 'v2')
   end
 
-  it 'GET /builds/1?repository_id=1' do
+  it 'GET /builds/1?repository_id=1', logs_api_enabled: true do
     response = get "/builds/#{build.id}", { repository_id: repo.id }, headers
     response.should deliver_json_for(build, version: 'v2')
   end

--- a/spec/integration/v2/jobs_spec.rb
+++ b/spec/integration/v2/jobs_spec.rb
@@ -13,7 +13,12 @@ describe 'Jobs', set_app: true do
 
   it '/jobs/:id' do
     response = get "/jobs/#{job.id}", {}, headers
-    response.should deliver_json_for(job, version: 'v2')
+    response.status.should == 200
+    expected = Travis::Api::Serialize.data(job, version: 'v2')
+    expected.delete('log_id')
+    parsed = MultiJson.decode(response.body)
+    parsed['job'].delete('log_id')
+    parsed.should == expected
   end
 
   context 'GET /jobs/:job_id/log.txt', logs_api_enabled: false do

--- a/spec/unit/serialize/v2/http/job_spec.rb
+++ b/spec/unit/serialize/v2/http/job_spec.rb
@@ -3,24 +3,33 @@ describe Travis::Api::Serialize::V2::Http::Job do
 
   let(:data) { described_class.new(test).data }
 
-  it 'job', logs_api_enabled: false do
-    data['job'].should == {
-      'id' => 1,
-      'repository_id' => 1,
-      'repository_slug' => 'svenfuchs/minimal',
-      'build_id' => 1,
-      'commit_id' => 1,
-      'log_id' => 1,
-      'number' => '2.1',
-      'state' => 'passed',
-      'started_at' => json_format_time(Time.now.utc - 1.minute),
-      'finished_at' => json_format_time(Time.now.utc),
-      'config' => { 'rvm' => '1.8.7', 'gemfile' => 'test/Gemfile.rails-2.3.x' },
-      'queue' => 'builds.linux',
-      'allow_failure' => false,
-      'tags' => 'tag-a,tag-b',
-      'annotation_ids' => [1],
-    }
+  [
+    {},
+    { include_log_id: true }
+  ].each do |options|
+    it 'job', logs_api_enabled: false do
+      instance = described_class.new(test)
+      instance.serialization_options = options
+      serialized = instance.data
+      serialized['job'].should == {
+        'id' => 1,
+        'repository_id' => 1,
+        'repository_slug' => 'svenfuchs/minimal',
+        'build_id' => 1,
+        'commit_id' => 1,
+        'number' => '2.1',
+        'state' => 'passed',
+        'started_at' => json_format_time(Time.now.utc - 1.minute),
+        'finished_at' => json_format_time(Time.now.utc),
+        'config' => { 'rvm' => '1.8.7', 'gemfile' => 'test/Gemfile.rails-2.3.x' },
+        'queue' => 'builds.linux',
+        'allow_failure' => false,
+        'tags' => 'tag-a,tag-b',
+        'annotation_ids' => [1],
+      }.tap do |expected|
+        expected['log_id'] = 1 if options[:include_log_id]
+      end
+    end
   end
 
   it 'commit' do

--- a/spec/unit/serialize/v2/http/jobs_spec.rb
+++ b/spec/unit/serialize/v2/http/jobs_spec.rb
@@ -4,23 +4,32 @@ describe Travis::Api::Serialize::V2::Http::Jobs do
   let(:data) { described_class.new([test]).data }
   let!(:time) { Time.now.utc }
 
-  it 'jobs', logs_api_enabled: false do
-    data['jobs'].first.should == {
-      'id' => 1,
-      'repository_id' => 1,
-      'repository_slug' => 'svenfuchs/minimal',
-      'build_id' => 1,
-      'commit_id' => 1,
-      'log_id' => 1,
-      'number' => '2.1',
-      'state' => 'passed',
-      'started_at' => json_format_time(time - 1.minute),
-      'finished_at' => json_format_time(time),
-      'config' => { 'rvm' => '1.8.7', 'gemfile' => 'test/Gemfile.rails-2.3.x' },
-      'queue' => 'builds.linux',
-      'allow_failure' => false,
-      'tags' => 'tag-a,tag-b'
-    }
+  [
+    {},
+    { include_log_id: true }
+  ].each do |options|
+    it 'jobs', logs_api_enabled: false do
+      instance = described_class.new([test])
+      instance.serialization_options = options
+      serialized = instance.data
+      serialized['jobs'].first.should == {
+        'id' => 1,
+        'repository_id' => 1,
+        'repository_slug' => 'svenfuchs/minimal',
+        'build_id' => 1,
+        'commit_id' => 1,
+        'number' => '2.1',
+        'state' => 'passed',
+        'started_at' => json_format_time(time - 1.minute),
+        'finished_at' => json_format_time(time),
+        'config' => { 'rvm' => '1.8.7', 'gemfile' => 'test/Gemfile.rails-2.3.x' },
+        'queue' => 'builds.linux',
+        'allow_failure' => false,
+        'tags' => 'tag-a,tag-b'
+      }.tap do |expected|
+        expected['log_id'] = 1 if options[:include_log_id]
+      end
+    end
   end
 
   it 'commits' do

--- a/spec/v3/services/log/find_spec.rb
+++ b/spec/v3/services/log/find_spec.rb
@@ -16,7 +16,7 @@ describe Travis::API::V3::Services::Log::Find, set_app: true do
   let(:log2)        { Travis::API::V3::Models::Log.create(job: job2) }
   let(:log3)        { Travis::API::V3::Models::Log.create(job: job3) }
   let(:s3log)       { Travis::API::V3::Models::Log.create(job: s3job, content: 'minimal log 1') }
-  let(:no_s3log)    { Travis::API::V3::Models::Log.create(archived_at: Time.now, job: s3job2, content: 'minimal log 2') }
+  let(:no_s3log)    { Travis::API::V3::Models::Log.create(archived_at: Time.now, archive_verified: true, job: s3job2, content: 'minimal log 2') }
   let(:find_log)    { "string" }
   let(:time)        { Time.now }
   let(:xml_content) {
@@ -126,7 +126,7 @@ describe Travis::API::V3::Services::Log::Find, set_app: true do
   context 'when log not found in db but stored on S3', logs_api_enabled: false do
     describe 'returns log with an array of Log Parts' do
       example do
-        s3log.update_attributes(archived_at: time)
+        s3log.update_attributes(archived_at: time, archive_verified: true)
         get("/v3/job/#{s3log.job.id}/log", {}, headers)
 
         expect(parsed_body).to eq(
@@ -144,7 +144,7 @@ describe Travis::API::V3::Services::Log::Find, set_app: true do
     end
     describe 'returns log as plain text' do
       example do
-        s3log.update_attributes(archived_at: Time.now)
+        s3log.update_attributes(archived_at: Time.now, archive_verified: true)
         get("/v3/job/#{s3log.job.id}/log", {}, headers.merge('HTTP_ACCEPT' => 'text/plain'))
         expect(last_response.headers).to include("Content-Type" => "text/plain")
         expect(body).to eq(
@@ -154,7 +154,7 @@ describe Travis::API::V3::Services::Log::Find, set_app: true do
 
     describe 'it returns the correct content type' do
       example do
-        s3log.update_attributes(archived_at: Time.now)
+        s3log.update_attributes(archived_at: Time.now, archive_verified: true)
         get("/v3/job/#{s3log.job.id}/log", {}, headers.merge('HTTP_ACCEPT' => 'fun/times'))
         expect(last_response.headers).to include("Content-Type" => "application/json")
       end

--- a/spec/v3/services/log/find_spec.rb
+++ b/spec/v3/services/log/find_spec.rb
@@ -43,6 +43,24 @@ describe Travis::API::V3::Services::Log::Find, set_app: true do
     </ListBucketResult>"
   }
 
+  let :log_from_api do
+    {
+      aggregated_at: Time.now,
+      archive_verified: true,
+      archived_at: Time.now,
+      archiving: false,
+      content: 'hello world. this is a really cool log',
+      created_at: Time.now,
+      id: 345,
+      job_id: s3job.id,
+      purged_at: Time.now,
+      removed_at: Time.now,
+      removed_by_id: 45,
+      updated_at: Time.now
+    }
+  end
+
+  let(:json_log_from_api) { log_from_api.to_json }
 
   before do
     log3.delete
@@ -64,6 +82,9 @@ describe Travis::API::V3::Services::Log::Find, set_app: true do
       :key  => "jobs/#{s3job.id}/log.txt",
       :body => "$ git clean -fdx\nRemoving Gemfile.lock\n$ git fetch"
     )
+    stub_request(:get, "http://travis-logs-notset.example.com:1234/logs/#{s3job.id}?by=job_id").
+      with(headers: { 'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'token notset', 'User-Agent'=>'Faraday v0.9.2' }).
+      to_return(status: 200, body: json_log_from_api, headers: {})
   end
   after { Fog::Mock.reset }
 
@@ -157,6 +178,54 @@ describe Travis::API::V3::Services::Log::Find, set_app: true do
         s3log.update_attributes(archived_at: Time.now, archive_verified: true)
         get("/v3/job/#{s3log.job.id}/log", {}, headers.merge('HTTP_ACCEPT' => 'fun/times'))
         expect(last_response.headers).to include("Content-Type" => "application/json")
+      end
+    end
+  end
+
+  context 'when log not found in db but stored on S3', logs_api_enabled: true do
+    describe 'returns log with an array of Log Parts' do
+      example do
+        s3log.update_attributes(archived_at: time, archive_verified: true)
+        get("/v3/job/#{s3log.job.id}/log", {}, headers)
+
+        expect(parsed_body).to eq(
+          '@type' => 'log',
+          '@href' => "/v3/job/#{s3job.id}/log",
+          '@representation' => 'standard',
+          '@permissions' => {
+            'read' => true,
+            'debug' => false,
+            'cancel' => false,
+            'restart' => false,
+            'delete_log' => false
+          },
+          'id' => log_from_api[:id],
+          'content' => log_from_api[:content],
+          'log_parts' => [
+            {
+              'content' => 'hello world. this is a really cool log',
+              'final' => true,
+              'number' => 0
+            }
+          ]
+        )
+      end
+    end
+
+    describe 'returns log as plain text' do
+      example do
+        s3log.update_attributes(archived_at: Time.now, archive_verified: true)
+        get("/v3/job/#{s3log.job.id}/log", {}, headers.merge('HTTP_ACCEPT' => 'text/plain'))
+        expect(last_response.headers).to include('Content-Type' => 'text/plain')
+        expect(body).to eq(log_from_api[:content])
+      end
+    end
+
+    describe 'it returns the correct content type' do
+      example do
+        s3log.update_attributes(archived_at: Time.now, archive_verified: true)
+        get("/v3/job/#{s3log.job.id}/log", {}, headers.merge('HTTP_ACCEPT' => 'fun/times'))
+        expect(last_response.headers).to include('Content-Type' => 'application/json')
       end
     end
   end


### PR DESCRIPTION
Reverts travis-ci/travis-api#464

- [x] addresses empty `jobs` matrix on `builds/` resources