### PR TITLE
[Enterprise] Make cron logs less chatty when theres nothing to enqueue

### DIFF
--- a/lib/travis/api/app/schedulers/schedule_cron_jobs.rb
+++ b/lib/travis/api/app/schedulers/schedule_cron_jobs.rb
@@ -32,7 +32,7 @@ class Travis::Api::App
         scheduled = Travis::API::V3::Models::Cron.scheduled
         count = scheduled.count
 
-        Travis.logger.info "Found #{count} cron jobs to enqueue"
+        Travis.logger.info "Found #{count} cron jobs to enqueue" unless count == 0
 
         Metriks.gauge("api.v3.cron_scheduler.upcoming_jobs").set(count)
 


### PR DESCRIPTION
Much like https://github.com/travis-ci/travis-logs/pull/95 we often can only see 2000 lines of a customers logs, so anything that makes them chatty with low information can easily fill them up and make us miss problems. Many times we have logs that look like this: 

```
[2017-03-31T17:18:59+0000][travis-pro-api:cron] I TID=70024447185160 Found 0 cron jobs to enqueue
[2017-03-31T17:19:59+0000][travis-pro-api:cron] I TID=70024447185160 Found 0 cron jobs to enqueue
[2017-03-31T17:20:59+0000][travis-pro-api:cron] I TID=70024447185160 Found 0 cron jobs to enqueue
[2017-03-31T17:21:59+0000][travis-pro-api:cron] I TID=70024447185160 Found 0 cron jobs to enqueue
[2017-03-31T17:22:59+0000][travis-pro-api:cron] I TID=70024447185160 Found 0 cron jobs to enqueue
[2017-03-31T17:17:59+0000][travis-pro-api:cron] I TID=70024447185160 Found 0 cron jobs to enqueue
[2017-03-31T17:18:59+0000][travis-pro-api:cron] I TID=70024447185160 Found 0 cron jobs to enqueue
[2017-03-31T17:19:59+0000][travis-pro-api:cron] I TID=70024447185160 Found 0 cron jobs to enqueue
[2017-03-31T17:20:59+0000][travis-pro-api:cron] I TID=70024447185160 Found 0 cron jobs to enqueue
[2017-03-31T17:21:59+0000][travis-pro-api:cron] I TID=70024447185160 Found 0 cron jobs to enqueue
[2017-03-31T17:22:59+0000][travis-pro-api:cron] I TID=70024447185160 Found 0 cron jobs to enqueue
```

This makes it so that log message only shows up when there is something to enqueue. But for now only in the `enterprise-2.1` branch since we're releasing soon. 


