### PR TITLE
v3: add stage resource to service index, remove account

### DIFF
--- a/lib/travis/api/v3/service_index.rb
+++ b/lib/travis/api/v3/service_index.rb
@@ -39,10 +39,10 @@ module Travis::API::V3
         }
 
         all = routes.resources + [
-          Routes::Resource.new(:account),   # dummy as there are only accounts routes right now
           Routes::Resource.new(:broadcast), # dummy as there are only broadcasts routes right now
           Routes::Resource.new(:commit),    # dummy as commits can only be embedded
           Routes::Resource.new(:request),   # dummy as there are only requests routes right now
+          Routes::Resource.new(:stage),     # dummy as there is no stage endpoint at the moment
           Routes::Resource.new(:error),
           Routes::Resource.new(:home,     attributes: [:config, :errors, :resources], actions: home_actions),
           Routes::Resource.new(:resource, attributes: [:actions, :attributes, :representations, :access_rights]),

--- a/spec/v3/service_index_spec.rb
+++ b/spec/v3/service_index_spec.rb
@@ -41,6 +41,13 @@ describe Travis::API::V3::ServiceIndex, set_app: true do
         end
       end
 
+      describe "home resource" do
+        let(:resource) { resources.fetch("stage") }
+        specify { expect(resources)              .to include("stage") }
+        specify { expect(resource["@type"])      .to be == "resource" }
+        specify { expect(resource["attributes"]) .to include("name")  }
+      end
+
       describe "branch resource" do
         let(:resource) { resources.fetch("branch") }
         specify { expect(resources)         .to include("branch") }


### PR DESCRIPTION
Stage objects are now returned within build and job payloads by API v3, but as there's no endpoint for stages at the moment, the service index did not pick it up automatically. This fixes it, and the home document will now include:

``` json
{
    "stage": {
      "@type": "resource",
      "actions": {
      },
      "attributes": ["id","number","name","jobs"],
      "representations": {
        "minimal": [
          "id",
          "number",
          "name"
        ],
        "standard": [
          "id",
          "number",
          "name",
          "jobs"
        ],
        "active": [
          "id",
          "number",
          "name",
          "jobs"
        ]
      }
    }
}
```

It also removes the `account` entry, fixing travis-pro/team-teal#1838.