### PR TITLE
default job and build state to :created

### DIFF
--- a/lib/travis/api/v3/models/build.rb
+++ b/lib/travis/api/v3/models/build.rb
@@ -25,6 +25,10 @@ module Travis::API::V3
       primary_key: [:repository_id, :branch],
       class_name:  'Travis::API::V3::Models::Branch'.freeze
 
+    def state
+      super || 'created'
+    end
+
     def branch_name
       read_attribute(:branch)
     end

--- a/lib/travis/api/v3/models/job.rb
+++ b/lib/travis/api/v3/models/job.rb
@@ -14,6 +14,10 @@ module Travis::API::V3
     serialize :config
     serialize :debug_options
 
+    def state
+      super || 'created'
+    end
+
     if Travis::Config.logs_api_enabled?
       def log
         @log ||= Travis::RemoteLog.find_by_job_id(id)

--- a/lib/travis/model/build.rb
+++ b/lib/travis/model/build.rb
@@ -169,6 +169,10 @@ class Build < Travis::Model
     end
   end
 
+  def state
+    super || 'created'
+  end
+
   # AR 3.2 does not handle pg arrays and the plugins supporting them
   # do not work well with jdbc drivers
   # TODO: remove this once we're on >= 4.0

--- a/lib/travis/model/job.rb
+++ b/lib/travis/model/job.rb
@@ -103,6 +103,10 @@ class Job < Travis::Model
     true
   end
 
+  def state
+    super || 'created'
+  end
+
   def duration
     started_at && finished_at ? finished_at - started_at : nil
   end

--- a/lib/travis/model/request.rb
+++ b/lib/travis/model/request.rb
@@ -51,11 +51,6 @@ class Request < Travis::Model
     read_attribute(:event_type) || 'push'
   end
 
-  def payload
-    puts "[deprectated] Reading request.payload. Called from #{caller.reject { |line| line.include?('request.rb') }.first}"
-    super
-  end
-
   def ref
     commit.ref
   end

--- a/lib/travis/testing/factories.rb
+++ b/lib/travis/testing/factories.rb
@@ -24,7 +24,7 @@ FactoryGirl.define do
     compare_url 'https://github.com/svenfuchs/minimal/compare/master...develop'
   end
 
-  factory :test, :class => 'Job::Test' do
+  factory :test, :class => 'Job::Test', aliases: [:job] do
     owner      { User.first || Factory(:user) }
     repository { Repository.first || Factory(:repository) }
     commit     { Factory(:commit) }
@@ -33,6 +33,7 @@ FactoryGirl.define do
     config     { { 'rvm' => '1.8.7', 'gemfile' => 'test/Gemfile.rails-2.3.x' } }
     number     '2.1'
     tags       ""
+    state      :created
   end
 
   factory :log do

--- a/spec/unit/model/build_spec.rb
+++ b/spec/unit/model/build_spec.rb
@@ -1,0 +1,8 @@
+describe Build do
+  context 'given state is nil' do
+    let(:build) { FactoryGirl.build(:build, state: nil) }
+    subject { build.state }
+
+    it { should eq 'created' }
+  end
+end

--- a/spec/unit/model/job_spec.rb
+++ b/spec/unit/model/job_spec.rb
@@ -1,0 +1,8 @@
+describe Job do
+  context 'given state is nil' do
+    let(:job) { FactoryGirl.build(:job, state: nil) }
+    subject { job.state }
+
+    it { should eq 'created' }
+  end
+end

--- a/spec/v3/models/build_spec.rb
+++ b/spec/v3/models/build_spec.rb
@@ -1,0 +1,6 @@
+describe Travis::API::V3::Models::Build do
+  let(:build) { Factory(:build, state: nil) }
+  subject { Travis::API::V3::Models::Build.find_by_id(build.id).state }
+
+  it { should eq 'created' }
+end

--- a/spec/v3/models/job_spec.rb
+++ b/spec/v3/models/job_spec.rb
@@ -1,0 +1,6 @@
+describe Travis::API::V3::Models::Job do
+  let(:job) { Factory(:job, state: nil) }
+  subject { Travis::API::V3::Models::Job.find_by_id(job.id).state }
+
+  it { should eq 'created' }
+end


### PR DESCRIPTION
Gatekeeper does not set `build.state` and `job.state` to `created` at the moment in order to help prevent a race condition that might end up queueing jobs twice when it shouldn't. We might keep this in place in Gatekeeper for a while, just to be sure, but we should not expose it to the user.