### PR TITLE
Create `User#tokens` record on sign up

### DIFF
--- a/lib/travis/api/app/endpoint/authorization.rb
+++ b/lib/travis/api/app/endpoint/authorization.rb
@@ -244,6 +244,7 @@ class Travis::Api::App
 
             ActiveRecord::Base.transaction do
               if user
+                ensure_token_is_available
                 rename_repos_owner(user.login, info['login'])
                 user.update_attributes info
               else
@@ -260,6 +261,12 @@ class Travis::Api::App
             unless retried
               retried = true
               retry
+            end
+          end
+
+          def ensure_token_is_available
+            unless user.tokens.first
+              user.create_a_token
             end
           end
         end

--- a/lib/travis/model/user.rb
+++ b/lib/travis/model/user.rb
@@ -150,6 +150,10 @@ class User < Travis::Model
     github_oauth_token ? super.gsub(github_oauth_token, '[REDACTED]') : super
   end
 
+  def create_a_token
+    self.tokens.create!
+  end
+
   protected
 
     def track_previous_changes
@@ -158,9 +162,5 @@ class User < Travis::Model
 
     def set_as_recent
       @recently_signed_up = true
-    end
-
-    def create_a_token
-      self.tokens.create!
     end
 end

--- a/spec/unit/endpoint/authorization/user_manager_spec.rb
+++ b/spec/unit/endpoint/authorization/user_manager_spec.rb
@@ -35,7 +35,7 @@ describe Travis::Api::App::Endpoint::Authorization::UserManager do
      }
 
     it 'drops the token when drop_token is set to true' do
-      user = stub('user', login: 'drogus', github_id: 456, previous_changes: {}, recently_signed_up?: false)
+      user = stub('user', login: 'drogus', github_id: 456, previous_changes: {}, recently_signed_up?: false, tokens: [stub('token')])
       User.expects(:find_by_github_id).with(456).returns(user)
 
       manager = described_class.new(data, 'abc123', true)
@@ -54,6 +54,18 @@ describe Travis::Api::App::Endpoint::Authorization::UserManager do
 
       before do
         manager.stubs(:education).returns(false)
+      end
+
+      context 'without any User#tokens record' do
+        before do
+          user.tokens.destroy_all
+        end
+
+        it 'creates a User#tokens record' do
+          User.any_instance.expects(:create_a_token)
+          User.any_instance.expects(:tokens).returns([])
+          manager.fetch.should == user
+        end
       end
 
       it 'updates user data' do


### PR DESCRIPTION
From the commit message

```
We still use user tokens that are stored in `tokens` table to
authenticate status images and cc.xml requests. Because of that
travis-web does a check for a token when it fetches the user. Recently
we started creating new user records outside of auth flow - we're basing
it on GitHub payloads. It means that some of the users may not have a
token available. We don't need tokens for users that never signed in, so
the best thing to do is to create a token when a user tries to sigin in.
```