### PR TITLE
[WIP] order branches query by name to speed up query

### DIFF
--- a/lib/travis/api/serialize/v0/pusher/build.rb
+++ b/lib/travis/api/serialize/v0/pusher/build.rb
@@ -98,7 +98,7 @@ module Travis
               end
 
               def last_build_on_default_branch_id(repository)
-                default_branch = Branch.where(repository_id: repository.id, name: repository.default_branch).first
+                default_branch = Branch.where(repository_id: repository.id, name: repository.default_branch).order('name ASC').first
 
                 if default_branch
                   default_branch.last_build_id

--- a/lib/travis/api/v3/models/repository.rb
+++ b/lib/travis/api/v3/models/repository.rb
@@ -43,14 +43,14 @@ module Travis::API::V3
     # Will not create a branch object if we don't have any builds for it unless
     # the create_without_build option is set to true.
     def branch(name, create_without_build: false)
-      return nil    unless branch = branches.where(name: name).first_or_initialize
+      return nil    unless branch = branches.where(name: name).order('name ASC').first_or_initialize
       return branch unless branch.new_record?
       return nil    unless create_without_build or branch.builds.any?
       branch.last_build = branch.builds.first
       branch.save!
       branch
     rescue ActiveRecord::RecordNotUnique
-      branches.where(name: name).first
+      branches.where(name: name).order('name ASC').first
     end
 
     def id_default_branch

--- a/lib/travis/model/build/update_branch.rb
+++ b/lib/travis/model/build/update_branch.rb
@@ -19,7 +19,7 @@ class Build
       end
 
       def branch
-        Branch.where(repository_id: repository.id, name: branch_name).first_or_create
+        Branch.where(repository_id: repository.id, name: branch_name).order('name ASC').first_or_create
       end
 
       def branch_name


### PR DESCRIPTION
the query that `ActiveRecord::FinderMethods#first` generates adds an order by id. in this case that results in a very slow because it makes postgres use the wrong index.

this patch attempts to remedy that query by introducing a custom order clause.

refs https://github.com/travis-pro/team-teal/issues/1834