### PR TITLE
Add hidden_representations to exclude :active from service index

### DIFF
--- a/lib/travis/api/v3/model_renderer.rb
+++ b/lib/travis/api/v3/model_renderer.rb
@@ -26,15 +26,15 @@ module Travis::API::V3
       @representations ||= superclass.representations.dup
     end
 
-    @experimental_representations = []
-    def self.experimental_representations(*representations)
-      @experimental_representations ||= superclass.experimental_representations.dup
+    @hidden_representations = []
+    def self.hidden_representations(*representations)
+      @hidden_representations ||= superclass.hidden_representations.dup
 
       if representations.first
-        @experimental_representations.push(*representations)
+        @hidden_representations.push(*representations)
       end
 
-      @experimental_representations
+      @hidden_representations
     end
 
     @available_attributes = Set.new

--- a/lib/travis/api/v3/renderer/build.rb
+++ b/lib/travis/api/v3/renderer/build.rb
@@ -4,6 +4,8 @@ module Travis::API::V3
     representation(:standard, *representations[:minimal], :repository, :branch, :commit, :jobs, :stages)
     representation(:active, *representations[:standard])
 
+    hidden_representations(:active)
+
     def jobs
       return model.active_jobs if include_full_jobs? && representation?(:active)
       return model.jobs if include_full_jobs?

--- a/lib/travis/api/v3/renderer/job.rb
+++ b/lib/travis/api/v3/renderer/job.rb
@@ -3,5 +3,7 @@ module Travis::API::V3
     representation(:minimal, :id)
     representation(:standard, *representations[:minimal], :number, :state, :started_at, :finished_at, :build, :queue, :repository, :commit, :owner, :stage)
     representation(:active, *representations[:standard])
+
+    hidden_representations(:active)
   end
 end

--- a/lib/travis/api/v3/renderer/repository.rb
+++ b/lib/travis/api/v3/renderer/repository.rb
@@ -4,7 +4,7 @@ module Travis::API::V3
     representation(:standard, :id, :name, :slug, :description, :github_language, :active, :private, :owner, :default_branch, :starred)
     representation(:experimental, :id, :name, :slug, :description, :github_language, :active, :private, :owner, :default_branch, :starred, :current_build)
 
-    experimental_representations(:experimental)
+    hidden_representations(:experimental)
 
     def active
       !!model.active

--- a/lib/travis/api/v3/renderer/stage.rb
+++ b/lib/travis/api/v3/renderer/stage.rb
@@ -3,5 +3,7 @@ module Travis::API::V3
     representation(:minimal, :id, :number, :name, :state, :started_at, :finished_at)
     representation(:standard, *representations[:minimal], :jobs)
     representation(:active, *representations[:standard])
+
+    hidden_representations(:active)
   end
 end

--- a/lib/travis/api/v3/service_index.rb
+++ b/lib/travis/api/v3/service_index.rb
@@ -91,8 +91,8 @@ module Travis::API::V3
 
           if renderer.respond_to? :representations
             representations = renderer.representations
-            if renderer.respond_to? :experimental_representations
-              representations = representations.reject { |k| renderer.experimental_representations.include? k }
+            if renderer.respond_to? :hidden_representations
+              representations = representations.reject { |k| renderer.hidden_representations.include? k }
             end
             data[:representations] = representations
           end


### PR DESCRIPTION
This addresses this issue: https://github.com/travis-pro/team-teal/issues/1915

The changes are aimed at hiding certain representations from the Service Index, as they are used for experimental features, or for endpoints that require an 'active' representation defined, despite it being an exact copy of a 'standard' representation (see the issue linked above for an explanation of why this is necessary).

Hiding these from the Service Index will mean they won't appear in the API V3 Developer docs, which will avoid further confusion in that regard.

This has been deployed on org-staging and all working as intended.
`developer` has been redeployed to staging to injest the changes. 
All working there as expected too: https://developer-staging.travis-ci.org/resource/build#Build