### PR TITLE
restart_model: ensure user is logged in before permission check

### DIFF
--- a/lib/travis/api/enqueue/services/restart_model.rb
+++ b/lib/travis/api/enqueue/services/restart_model.rb
@@ -48,7 +48,7 @@ module Travis
         private
 
           def permission?
-            current_user.permission?(required_role, repository_id: target.repository_id)
+            current_user && current_user.permission?(required_role, repository_id: target.repository_id)
           end
 
           def resetable?


### PR DESCRIPTION
this missing check is causing the following error message for unauthenticated
users:

    NoMethodError: undefined method `permission?' for nil:NilClass

Fixes https://sentry.io/travis-ci/org-api-production/issues/244070234/