### PR TITLE
[Enterprise Backport] Add `/request/:id` endpoint #489

### DIFF
--- a/lib/travis/api/v3/access_control/generic.rb
+++ b/lib/travis/api/v3/access_control/generic.rb
@@ -124,6 +124,10 @@ module Travis::API::V3
       private_repository_visible?(repository)
     end
 
+    def request_visible?(request)
+      repository_visible?(request.repository)
+    end
+
     def private_repository_visible?(repository)
       false
     end

--- a/lib/travis/api/v3/queries/request.rb
+++ b/lib/travis/api/v3/queries/request.rb
@@ -1,6 +1,11 @@
 module Travis::API::V3
   class Queries::Request < Query
-    params :message, :branch, :config, :token, prefix: :request
+    params  :id, :message, :branch, :config, :token, prefix: :request
+
+    def find
+      return Models::Request.find_by_id(id) if id
+      raise WrongParams, 'missing request.id'.freeze
+    end
 
     def schedule(repository, user)
       raise ServerError, 'repository does not have a github_id'.freeze unless repository.github_id

--- a/lib/travis/api/v3/renderer/request.rb
+++ b/lib/travis/api/v3/renderer/request.rb
@@ -2,7 +2,7 @@ require 'travis/api/v3/renderer/model_renderer'
 
 module Travis::API::V3
   class Renderer::Request < Renderer::ModelRenderer
-    representation(:minimal,  :id)
-    representation(:standard, :id, :repository, :branch_name, :commit, :owner, :created_at, :result, :message, :event_type)
+    representation(:minimal,  :id, :state, :result, :message)
+    representation(:standard, *representations[:minimal], :repository, :branch_name, :commit, :owner, :created_at, :event_type)
   end
 end

--- a/lib/travis/api/v3/routes.rb
+++ b/lib/travis/api/v3/routes.rb
@@ -136,6 +136,11 @@ module Travis::API::V3
         post :create
       end
 
+      resource :request do
+        route '/request/{request.id}'
+        get  :find
+      end
+
       resource :user_settings do
         route '/settings'
         get   :for_repository

--- a/lib/travis/api/v3/services.rb
+++ b/lib/travis/api/v3/services.rb
@@ -27,6 +27,7 @@ module Travis::API::V3
     Owner         = Module.new { extend Services }
     Repositories  = Module.new { extend Services }
     Repository    = Module.new { extend Services }
+    Request       = Module.new { extend Services }
     Requests      = Module.new { extend Services }
     SslKey        = Module.new { extend Services }
     User          = Module.new { extend Services }

--- a/lib/travis/api/v3/services/request/find.rb
+++ b/lib/travis/api/v3/services/request/find.rb
@@ -2,7 +2,7 @@ module Travis::API::V3
   class Services::Request::Find < Service
 
     def run!
-      result find
+      find
     end
   end
 end

--- a/lib/travis/api/v3/services/request/find.rb
+++ b/lib/travis/api/v3/services/request/find.rb
@@ -1,0 +1,8 @@
+module Travis::API::V3
+  class Services::Request::Find < Service
+
+    def run!
+      result find
+    end
+  end
+end

--- a/spec/v3/services/request/find_spec.rb
+++ b/spec/v3/services/request/find_spec.rb
@@ -1,0 +1,49 @@
+describe Travis::API::V3::Services::Request::Find, set_app: true do
+
+  let(:repo) { Travis::API::V3::Models::Repository.where(owner_name: 'svenfuchs', name: 'minimal').first }
+  let(:request) { repo.requests.first }
+
+  describe "retrieve request on a public repository" do
+    before     { get("/v3/repo/#{repo.id}/request/#{request.id}")     }
+    example    { expect(last_response).to be_ok }
+    example    { expect(JSON.load(body).to_s).to include(
+                  "@type",
+                  "request",
+                  "/v3/repo/#{repo.id}/request",
+                  "id",
+                  "state",
+                  "message",
+                  "result",
+                  "@representation",
+                  "repository",
+                  "owner",
+                  "event_type",
+                  "push")
+    }
+  end
+
+  describe "retrieve request on private repository, private API, authenticated as user with access" do
+    let(:token)   { Travis::Api::App::AccessToken.create(user: repo.owner, app_id: 1) }
+    let(:headers) {{ 'HTTP_AUTHORIZATION' => "token #{token}"                        }}
+    before        { Travis::API::V3::Models::Permission.create(repository: repo, user: repo.owner, pull: true) }
+    before        { repo.update_attribute(:private, true)                             }
+    before        { get("/v3/repo/#{repo.id}/request/#{request.id}", {}, headers)                             }
+    after         { repo.update_attribute(:private, false)                            }
+    example       { expect(last_response).to be_ok                                    }
+    example       { expect(JSON.load(body).to_s).to include(
+                      "@type",
+                      "request",
+                      "/v3/repo/#{repo.id}/request",
+                      "id",
+                      "state",
+                      "message",
+                      "result",
+                      "@representation",
+                      "repository",
+                      "owner",
+                      "event_type",
+                      "push")
+    }
+
+  end
+end


### PR DESCRIPTION
Backporting #489 for Enterprise 2.1. 

Can I get a review on how this looks I had the following conflicts and want to make sure I merged them right. Particularly request.rb: 

Conflicts:
       lib/travis/api/v3/renderer/request.rb
       lib/travis/api/v3/routes.rb

