### PR TITLE
Check for started_at for a recent build

### DIFF
--- a/lib/travis/api/v3/models/cron.rb
+++ b/lib/travis/api/v3/models/cron.rb
@@ -81,8 +81,7 @@ module Travis::API::V3
     end
 
     def last_non_cron_build_time
-      last_build = Build.find_by_id(branch.last_build_id)
-      last_build.finished_at.to_datetime.utc if last_build && last_build.finished_at
+      Build.find_by_id(branch.last_build_id)&.started_at&.to_datetime&.utc
     end
   end
 end

--- a/spec/v3/models/cron_spec.rb
+++ b/spec/v3/models/cron_spec.rb
@@ -119,8 +119,8 @@ describe Travis::API::V3::Models::Cron do
       end
     end
 
-    context "when last build within has no finished_at" do
-      let(:build) { Factory(:v3_build, finished_at: nil) }
+    context "when last build within last 24h has no started_at" do
+      let(:build) { Factory(:v3_build, started_at: nil) }
       let(:cron) { Factory(:cron, branch_id: Factory(:branch, last_build: build).id, dont_run_if_recent_build_exists: true) }
       it "needs_new_build? returns true" do
         cron.needs_new_build?.should be_truthy


### PR DESCRIPTION
Instead of checking the `finished_at` time to find if there has been a build in the last 24h, check for the `started_at` time. This ensures that daily builds aren't skipped for cases where builds take longer than a minute.

Fixes: https://github.com/travis-pro/team-teal/issues/1734