### PR TITLE
Add auto cancel settings to V2 model

### DIFF
--- a/lib/travis/model/repository/settings.rb
+++ b/lib/travis/model/repository/settings.rb
@@ -88,6 +88,8 @@ class Repository::Settings < Travis::Settings
   attribute :timeout_hard_limit
   attribute :timeout_log_silence
   attribute :api_builds_rate_limit, Integer
+  attribute :auto_cancel_pushes, Boolean
+  attribute :auto_cancel_pull_requests, Boolean
 
   validates :maximum_number_of_builds, numericality: true
 


### PR DESCRIPTION
This ensures that using V2 settings endpoint will not overwrite cancellation settings. The proper fix will be to make V2 settings merge data instead of overwrite, I hope to also do it soon.