### PR TITLE
Add support for `/builds` for_current_user on V3 API 

### DIFF
--- a/lib/travis/api/v3/queries/builds.rb
+++ b/lib/travis/api/v3/queries/builds.rb
@@ -21,7 +21,7 @@ module Travis::API::V3
       relation = relation.where(previous_state: list(previous_state)) if previous_state
       relation = relation.where(event_type:     list(event_type))     if event_type
       relation = relation.where(branch:         list(branch_name))    if branch_name
-      relation = for_login(relation)                                  if created_by
+      relation = for_owner(relation)                                  if created_by
 
       relation = relation.includes(:commit).includes(branch: :last_build).includes(:repository)
       relation = relation.includes(branch: { last_build: :commit }) if includes? 'build.commit'.freeze
@@ -29,7 +29,7 @@ module Travis::API::V3
       relation
     end
 
-    def for_login(relation)
+    def for_owner(relation)
       users = V3::Models::User.where(login: list(created_by)).pluck(:id)
       orgs = V3::Models::Organization.where(login: list(created_by)).pluck(:id)
 

--- a/lib/travis/api/v3/queries/builds.rb
+++ b/lib/travis/api/v3/queries/builds.rb
@@ -21,7 +21,7 @@ module Travis::API::V3
       relation = relation.where(previous_state: list(previous_state)) if previous_state
       relation = relation.where(event_type:     list(event_type))     if event_type
       relation = relation.where(branch:         list(branch_name))    if branch_name
-      relation = for_owner(relation)                                  if created_by
+      relation = for_login(relation)                                  if created_by
 
       relation = relation.includes(:commit).includes(branch: :last_build).includes(:repository)
       relation = relation.includes(branch: { last_build: :commit }) if includes? 'build.commit'.freeze
@@ -29,12 +29,18 @@ module Travis::API::V3
       relation
     end
 
-    def for_owner(relation)
+    def for_login(relation)
       users = V3::Models::User.where(login: list(created_by)).pluck(:id)
       orgs = V3::Models::Organization.where(login: list(created_by)).pluck(:id)
 
       relation.where(%Q((builds.sender_type = 'User' AND builds.sender_id IN (?))
                     OR (builds.sender_type = 'Organization' AND builds.sender_id IN (?))), users, orgs)
+    end
+
+    def for_user(user)
+      V3::Models::Build.where(
+        sender_id: user.id,
+        sender_type: 'User')
     end
   end
 end

--- a/lib/travis/api/v3/routes.rb
+++ b/lib/travis/api/v3/routes.rb
@@ -22,6 +22,10 @@ module Travis::API::V3
       end
     end
 
+    resource :builds do
+      route '/builds'
+      get :for_current_user
+    end
 
     resource :cron do
       capture id: :digit

--- a/lib/travis/api/v3/services/builds/for_current_user.rb
+++ b/lib/travis/api/v3/services/builds/for_current_user.rb
@@ -1,0 +1,11 @@
+module Travis::API::V3
+  class Services::Builds::ForCurrentUser < Service
+    # params :active, prefix: :broadcast
+    paginate(default_limit: 100)
+
+    def run!
+      raise LoginRequired unless access_control.logged_in?
+      result query.for_user(access_control.user)
+    end
+  end
+end

--- a/lib/travis/api/v3/services/builds/for_current_user.rb
+++ b/lib/travis/api/v3/services/builds/for_current_user.rb
@@ -1,6 +1,5 @@
 module Travis::API::V3
   class Services::Builds::ForCurrentUser < Service
-    # params :active, prefix: :broadcast
     paginate(default_limit: 100)
 
     def run!

--- a/spec/v3/services/builds/for_current_user.rb
+++ b/spec/v3/services/builds/for_current_user.rb
@@ -18,9 +18,7 @@ describe Travis::API::V3::Services::Builds::Find, set_app: true do
   describe "builds for current_user, authenticated as user with access" do
     let(:token)   { Travis::Api::App::AccessToken.create(user: repo.owner, app_id: 1) }
     let(:headers) {{ 'HTTP_AUTHORIZATION' => "token #{token}"                        }}
-    # before        { Travis::API::V3::Models::Permission.create(repository: repo, user: repo.owner, pull: true) }
     before        { get("/v3/builds", {}, headers)                           }
-    # after         { repo.update_attribute(:private, false)                            }
     example       { expect(last_response).to be_ok                                    }
     example    { expect(parsed_body).to be == {
       "@type"                 => "builds",

--- a/spec/v3/services/builds/for_current_user.rb
+++ b/spec/v3/services/builds/for_current_user.rb
@@ -1,0 +1,131 @@
+describe Travis::API::V3::Services::Builds::Find, set_app: true do
+  let(:repo)   { Travis::API::V3::Models::Repository.where(owner_name: 'svenfuchs', name: 'minimal').first }
+  let(:build)  { repo.builds.first }
+  let(:stages) { build.stages }
+  let(:jobs)   { Travis::API::V3::Models::Build.find(build.id).jobs }
+  let(:parsed_body) { JSON.load(body) }
+
+  before do
+    # TODO should this go into the scenario? is it ok to keep it here?
+    build.update_attributes!(sender_id: repo.owner.id, sender_type: 'User')
+    test   = build.stages.create(number: 1, name: 'test')
+    deploy = build.stages.create(number: 2, name: 'deploy')
+    build.jobs[0, 2].each { |job| job.update_attributes!(stage: test) }
+    build.jobs[2, 2].each { |job| job.update_attributes!(stage: deploy) }
+  end
+
+  
+  describe "builds for current_user, authenticated as user with access" do
+    let(:token)   { Travis::Api::App::AccessToken.create(user: repo.owner, app_id: 1) }
+    let(:headers) {{ 'HTTP_AUTHORIZATION' => "token #{token}"                        }}
+    # before        { Travis::API::V3::Models::Permission.create(repository: repo, user: repo.owner, pull: true) }
+    before        { get("/v3/builds", {}, headers)                           }
+    # after         { repo.update_attribute(:private, false)                            }
+    example       { expect(last_response).to be_ok                                    }
+    example    { expect(parsed_body).to be == {
+      "@type"                 => "builds",
+      "@href"                 => "/v3/builds",
+      "@representation"       => "standard",
+      "@pagination"           => {
+        "limit"               => 100,
+        "offset"              => 0,
+        "count"               => 1,
+        "is_first"            => true,
+        "is_last"             => true,
+        "next"                => nil,
+        "prev"                => nil,
+        "first"               => {
+          "@href"             => "/v3/builds",
+          "offset"            => 0,
+          "limit"             => 100 },
+        "last"                => {
+          "@href"             => "/v3/builds",
+          "offset"            => 0,
+          "limit"             => 100 }},
+      "builds"                => [{
+        "@type"               => "build",
+        "@href"               => "/v3/build/#{build.id}",
+        "@representation"     => "standard",
+        "@permissions"        => {
+          "read"              => true,
+          "cancel"            => false,
+          "restart"           => false },
+        "id"                  => build.id,
+        "number"              => "3",
+        "state"               => "configured",
+        "duration"            => nil,
+        "event_type"          => "push",
+        "previous_state"      => "passed",
+        "pull_request_number" => nil,
+        "pull_request_title"  => nil,
+        "started_at"          => "2010-11-12T13:00:00Z",
+        "finished_at"         => nil,
+        "stages"              => [{
+           "@type"            => "stage",
+           "@representation"  => "minimal",
+           "id"               => stages[0].id,
+           "number"           => 1,
+           "name"             => "test",
+           "state"            => stages[0].state,
+           "started_at"       => stages[0].started_at,
+           "finished_at"      => stages[0].finished_at},
+          {"@type"            => "stage",
+           "@representation" => "minimal",
+           "id"               => stages[1].id,
+           "number"          => 2,
+           "name"             => "deploy",
+           "state"            => stages[1].state,
+           "started_at"       => stages[1].started_at,
+           "finished_at"      => stages[1].finished_at}],
+        "jobs"                => [
+          {
+          "@type"             => "job",
+          "@href"             => "/v3/job/#{jobs[0].id}",
+          "@representation"   => "minimal",
+          "id"                => jobs[0].id},
+          {
+          "@type"             => "job",
+          "@href"             => "/v3/job/#{jobs[1].id}",
+          "@representation"   => "minimal",
+          "id"                => jobs[1].id},
+          {
+          "@type"             => "job",
+          "@href"             => "/v3/job/#{jobs[2].id}",
+          "@representation"   => "minimal",
+          "id"                => jobs[2].id},
+          {
+          "@type"             => "job",
+          "@href"             => "/v3/job/#{jobs[3].id}",
+          "@representation"   => "minimal",
+          "id"                => jobs[3].id}],
+        "repository"          => {
+          "@type"             => "repository",
+          "@href"             => "/v3/repo/#{repo.id}",
+          "@representation"   => "minimal",
+          "id"                => repo.id,
+          "name"              => "minimal",
+          "slug"              => "svenfuchs/minimal"},
+        "branch"              => {
+          "@type"             => "branch",
+          "@href"             => "/v3/repo/#{repo.id}/branch/master",
+          "@representation"   => "minimal",
+          "name"              => "master"},
+        "commit"              => {
+          "@type"             => "commit",
+          "@representation"   => "minimal",
+          "id"                => 5,
+          "sha"               => "add057e66c3e1d59ef1f",
+          "ref"               => "refs/heads/master",
+          "message"           => "unignore Gemfile.lock",
+          "compare_url"       => "https://github.com/svenfuchs/minimal/compare/master...develop",
+          "committed_at"      => "2010-11-12T12:55:00Z"},
+        "created_by"          => {
+          "@type"             => "user",
+          "@href"             => "/v3/user/1",
+          "@representation"   => "minimal",
+          "id"                => 1,
+          "login"             => "svenfuchs"}
+      }]
+    }}
+  end
+end


### PR DESCRIPTION
This addresses this ticket: https://github.com/travis-pro/team-teal/issues/2005 which would like the ability to list a user's builds on a tab of their dashboard.

I've chosen to implement the endpoint by using a `for_current_user` action on the `/builds` endpoint. 
This is similar to `/repos` and `/broadcasts`, which also use a `for_current_user` action to list repos or broadcasts for the current logged-in user. 

A test has been added and is passing. The branch has also been deployed to org-staging and, using the explorer on the updated developer docs, is returning builds as expected.
