### PR TITLE
Include nested resources to avoid n+1 queries

### DIFF
--- a/lib/travis/api/v3/models/build.rb
+++ b/lib/travis/api/v3/models/build.rb
@@ -26,6 +26,19 @@ module Travis::API::V3
       primary_key: [:repository_id, :branch],
       class_name:  'Travis::API::V3::Models::Branch'.freeze
 
+    def created_by
+      return unless sender
+      sender.becomes(created_by_class)
+    end
+
+    def created_by_class
+      return unless sender
+      case sender_type
+      when 'User' then V3::Models::User
+      when 'Organization' then V3::Models::Organization
+      end
+    end
+
     def state
       super || 'created'
     end

--- a/lib/travis/api/v3/queries/repositories.rb
+++ b/lib/travis/api/v3/queries/repositories.rb
@@ -45,7 +45,7 @@ module Travis::API::V3
       end
 
       list = list.includes(default_branch: :last_build)
-      list = list.includes(:current_build) if includes? 'repository.current_build'.freeze
+      list = list.includes(current_build: [:repository, :branch, :commit, :stages, :sender]) if includes? 'repository.current_build'.freeze
       list = list.includes(default_branch: { last_build: :commit }) if includes? 'build.commit'.freeze
       sort list
     end

--- a/lib/travis/api/v3/renderer/build.rb
+++ b/lib/travis/api/v3/renderer/build.rb
@@ -14,7 +14,24 @@ module Travis::API::V3
     end
 
     def created_by
-      model.sender
+      if created_by = model.created_by
+        payload = {
+          '@type' => model.sender_type.downcase,
+          '@href' => created_by_href(created_by),
+          '@representation' => 'minimal'.freeze,
+          'id' => created_by.id,
+          'login' => created_by.login
+        }
+        payload['avatar_url'] = V3::Renderer::AvatarURL.avatar_url(created_by) if include?('created_by.avatar_url')
+        payload
+      end
+    end
+
+    private def created_by_href(created_by)
+      case created_by
+      when V3::Models::Organization then Renderer.href(:organization, script_name: script_name, id: created_by.id)
+      when V3::Models::User         then Renderer.href(:user, script_name: script_name, id: created_by.id)
+      end
     end
 
     private def include_full_jobs?

--- a/lib/travis/api/v3/renderer/build.rb
+++ b/lib/travis/api/v3/renderer/build.rb
@@ -14,23 +14,23 @@ module Travis::API::V3
     end
 
     def created_by
-      if created_by = model.created_by
+      if creator = model.created_by
         payload = {
           '@type' => model.sender_type.downcase,
-          '@href' => created_by_href(created_by),
+          '@href' => created_by_href(creator),
           '@representation' => 'minimal'.freeze,
-          'id' => created_by.id,
-          'login' => created_by.login
+          'id' => creator.id,
+          'login' => creator.login
         }
-        payload['avatar_url'] = V3::Renderer::AvatarURL.avatar_url(created_by) if include?('created_by.avatar_url')
+        payload['avatar_url'] = V3::Renderer::AvatarURL.avatar_url(creator) if include?('created_by.avatar_url')
         payload
       end
     end
 
-    private def created_by_href(created_by)
-      case created_by
-      when V3::Models::Organization then Renderer.href(:organization, script_name: script_name, id: created_by.id)
-      when V3::Models::User         then Renderer.href(:user, script_name: script_name, id: created_by.id)
+    private def created_by_href(creator)
+      case creator
+      when V3::Models::Organization then Renderer.href(:organization, script_name: script_name, id: creator.id)
+      when V3::Models::User         then Renderer.href(:user, script_name: script_name, id: creator.id)
       end
     end
 

--- a/spec/v3/models/build_spec.rb
+++ b/spec/v3/models/build_spec.rb
@@ -1,6 +1,18 @@
 describe Travis::API::V3::Models::Build do
   let(:build) { Factory(:build, state: nil) }
-  subject { Travis::API::V3::Models::Build.find_by_id(build.id).state }
+  subject { Travis::API::V3::Models::Build.find_by_id(build.id) }
 
-  it { should eq 'created' }
+  example { expect(subject.state).to eq 'created' }
+
+  describe 'casting sender to V3 model' do
+    let(:sender) { Factory(:user) }
+
+    before do
+      subject.update_attributes(sender_type: 'User', sender_id: sender.id)
+    end
+
+    it 'always returns a V3 namespaced sender instance' do
+      expect(subject.created_by).to be_a Travis::API::V3::Models::User
+    end
+  end
 end


### PR DESCRIPTION
1. The following request was noticed to be very slow:
```
curl -iL -H "Authentication: token abc" \
  https://api.travis-ci.org/v3/owner/travis-ci?include=owner.repositories,repository.current_build
```
2. This was tracked down to the lack of [preloading in
   v3/queries/repositories.rb](https://github.com/travis-ci/travis-api/blob/jc-slow-repos/lib/travis/api/v3/queries/repositories.rb#L48) when including `repository.current_build`
3. More work was then required to get the rendering to work,
   because the polymorphic `belongs_to` between `build` and `sender` is
   not smart enough to work out that we need the V3 namespaced
   model and renderer classes. [Details here](https://github.com/travis-ci/travis-api/commit/cef85e52618258cad6553fa9131cb59db920a9ab).

I've run this locally, connected to the org prod follower database, and it made a big difference in time taken – it actually completed the request after a second or two, instead of timing out. :)