### PR TITLE
make sure to always re-freeze timecop

### DIFF
--- a/lib/travis/testing/stubs.rb
+++ b/lib/travis/testing/stubs.rb
@@ -353,4 +353,3 @@ module Travis
     end
   end
 end
-

--- a/spec/lib/schedulers/schedule_cron_jobs_spec.rb
+++ b/spec/lib/schedulers/schedule_cron_jobs_spec.rb
@@ -31,6 +31,7 @@ describe "ScheduleCronJobs" do
       subject
 
       Timecop.return
+      Timecop.freeze(Time.now.utc)
       cron1.destroy
       cron2.destroy
     end
@@ -46,6 +47,7 @@ describe "ScheduleCronJobs" do
       subject
 
       Timecop.return
+      Timecop.freeze(Time.now.utc)
       cron1.destroy
     end
 
@@ -63,7 +65,10 @@ describe "ScheduleCronJobs" do
           Timecop.travel(scheduler_interval.from_now)
         end
 
-        after { Timecop.return }
+        after do
+          Timecop.return
+          Timecop.freeze(Time.now.utc)
+        end
 
         it "skips enqueuing a cron job" do
           Sidekiq::Client.any_instance.expects(:push).never

--- a/spec/unit/serialize/v2/http/job_spec.rb
+++ b/spec/unit/serialize/v2/http/job_spec.rb
@@ -4,9 +4,6 @@ describe Travis::Api::Serialize::V2::Http::Job do
   let(:data) { described_class.new(test).data }
 
   it 'commit' do
-    puts "sleeping"
-    sleep 2.0
-    puts "done"
     data['commit'].should == {
       'id' => 1,
       'sha' => '62aae5f70ceee39123ef',

--- a/spec/unit/serialize/v2/http/job_spec.rb
+++ b/spec/unit/serialize/v2/http/job_spec.rb
@@ -4,6 +4,9 @@ describe Travis::Api::Serialize::V2::Http::Job do
   let(:data) { described_class.new(test).data }
 
   it 'commit' do
+    puts "sleeping"
+    sleep 2.0
+    puts "done"
     data['commit'].should == {
       'id' => 1,
       'sha' => '62aae5f70ceee39123ef',

--- a/spec/v3/models/cron_spec.rb
+++ b/spec/v3/models/cron_spec.rb
@@ -46,9 +46,6 @@ describe Travis::API::V3::Models::Cron do
   end
 
   context "for daily runs, when last_run is set" do
-    before { Timecop.freeze(Time.now) }
-    after { Timecop.return }
-
     it "sets the next_run correctly" do
       subject.last_run = 1.day.ago.utc + 5.minutes
       subject.schedule_next_build
@@ -57,9 +54,6 @@ describe Travis::API::V3::Models::Cron do
   end
 
   context "when last_run is not set" do
-    before { Timecop.freeze(Time.now) }
-    after { Timecop.return }
-
     context "and from: is not passed" do
       it "sets the next_run from now" do
         subject.schedule_next_build
@@ -82,9 +76,6 @@ describe Travis::API::V3::Models::Cron do
   end
 
   describe "enqueue" do
-    before { Timecop.freeze(Time.now) }
-    after { Timecop.return }
-
     it "enqueues the cron" do
       Sidekiq::Client.any_instance.expects(:push).once
       subject.enqueue

--- a/spec/v3/services/beta_feature/update_spec.rb
+++ b/spec/v3/services/beta_feature/update_spec.rb
@@ -45,6 +45,7 @@ describe Travis::API::V3::Services::BetaFeature::Update, set_app: true do
     end
     after do
       Timecop.return
+      Timecop.freeze(Time.now.utc)
     end
 
     example { expect(last_response.status).to eq 200 }


### PR DESCRIPTION
My hope is that this will fix these kinds of issues:

```
       -"committed_at" => "2017-07-03T09:37:51Z",
       +"committed_at" => "2017-07-03T09:37:50Z",
```