### PR TITLE
Re-introduce sentry and faraday update

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -155,7 +155,7 @@ GEM
     excon (0.55.0)
     factory_girl (2.4.2)
       activesupport
-    faraday (0.9.2)
+    faraday (0.12.1)
       multipart-post (>= 1.2, < 3)
     ffi (1.9.14)
     fog-aws (0.12.0)
@@ -303,8 +303,8 @@ GEM
     rspec-mocks (2.99.4)
     ruby_dep (1.5.0)
     safe_yaml (1.0.4)
-    sentry-raven (2.1.2)
-      faraday (>= 0.7.6, < 0.10.x)
+    sentry-raven (2.5.3)
+      faraday (>= 0.7.6, < 1.0)
     sidekiq (4.2.6)
       concurrent-ruby (~> 1.0)
       connection_pool (~> 2.2, >= 2.2.0)
@@ -414,4 +414,4 @@ RUBY VERSION
    ruby 2.3.4p301
 
 BUNDLED WITH
-   1.15.0
+   1.15.1

--- a/lib/travis/api/app/endpoint/authorization.rb
+++ b/lib/travis/api/app/endpoint/authorization.rb
@@ -300,7 +300,7 @@ class Travis::Api::App
         end
 
         def get_token(endpoint, values)
-          response   = Faraday.new(ssl: Travis.config.github.ssl).post(endpoint, values)
+          response   = Faraday.new(ssl: Travis.config.github.ssl || {}).post(endpoint, values)
           parameters = Addressable::URI.form_unencode(response.body)
           token_info = parameters.assoc("access_token")
 

--- a/spec/integration/error_handling_spec.rb
+++ b/spec/integration/error_handling_spec.rb
@@ -17,7 +17,7 @@ describe 'Exception', set_app: true do
 
   before do
     set_app Raven::Rack.new(FixRaven.new(app))
-    Travis.config.sentry.dsn = "test"
+    Travis.config.sentry.dsn = 'https://fake:token@app.getsentry.com/12345'
     Travis::Api::App.setup_monitoring
   end
 


### PR DESCRIPTION
Fixes this issue that the previous patch had: https://sentry.io/travis-ci/org-api-production/issues/304707588/

refs https://github.com/travis-ci/travis-api/pull/511