### PR TITLE
Include the ssl options from config when grabbing remote logs

### DIFF
--- a/lib/travis/remote_log.rb
+++ b/lib/travis/remote_log.rb
@@ -176,7 +176,7 @@ module Travis
 
       def find_id_by_job_id(job_id)
         resp = conn.get do |req|
-          req.url "/logs/#{job_id}/id"
+          req.url "logs/#{job_id}/id"
           req.params['source'] = 'api'
         end
         return nil unless resp.success?
@@ -185,7 +185,7 @@ module Travis
 
       def find_parts_by_job_id(job_id, after: nil, part_numbers: [])
         resp = conn.get do |req|
-          req.url "/log-parts/#{job_id}"
+          req.url "log-parts/#{job_id}"
           req.params['after'] = after unless after.nil?
           unless part_numbers.empty?
             req.params['part_numbers'] = part_numbers.map(&:to_s).join(',')
@@ -201,7 +201,7 @@ module Travis
 
       def write_content_for_job_id(job_id, content: '', removed_by: nil)
         resp = conn.put do |req|
-          req.url "/logs/#{job_id}"
+          req.url "logs/#{job_id}"
           req.params['source'] = 'api'
           req.params['removed_by'] = removed_by unless removed_by.nil?
           req.headers['Content-Type'] = 'application/octet-stream'
@@ -215,7 +215,7 @@ module Travis
 
       private def find_by(by, id)
         resp = conn.get do |req|
-          req.url "/logs/#{id}", by: by
+          req.url "logs/#{id}", by: by
           req.params['source'] = 'api'
         end
         return nil unless resp.success?

--- a/lib/travis/remote_log.rb
+++ b/lib/travis/remote_log.rb
@@ -223,11 +223,15 @@ module Travis
       end
 
       private def conn
-        @conn ||= Faraday.new(url: url) do |c|
+        @conn ||= Faraday.new(http_options.merge(url: url)) do |c|
           c.request :authorization, :token, token
           c.request :retry, max: 5, interval: 0.1, backoff_factor: 2
           c.adapter :net_http
         end
+      end
+
+      private def http_options
+        { ssl: Travis.config.ssl.compact.to_h }
       end
     end
 


### PR DESCRIPTION
In Enterprise we sometimes deal with self signed certs and certs signed by CAs that aren't standard. As a result we do some configuration of SSL and things like add the cert to the bundles located in `/usr/lib/ssl/certs/ca-certificates.crt`. 

When setting up the new logs for 2.2 I ran into an issue where `travis-api` couldn't read from the  logs end point due to not being able to verify the SSL cert. In other places we usually blend in the ssl options (eg https://github.com/travis-ci/travis-api/blob/2c3540b9eb4328d891fc3c2234f8a3ed0f9acc5d/lib/travis/task.rb#L78-L87) but weren't in this case. 

This PR attempts to fix that by merging in these options. 


-----------------

Later edit: Also fixed in this is some API path issues where we used a leading `/`. When we do that it causes the way we avoid using subdomains in Enterprise to break. (eg, the logs api is under `/__logs__`) We see something similar with API as it's under `/api`)