### PR TITLE
enqueue gatekeeper messages to separate redis

### DIFF
--- a/lib/travis/api/app.rb
+++ b/lib/travis/api/app.rb
@@ -39,6 +39,7 @@ require 'travis/api/serialize/v2'
 require 'travis/api/v3'
 require 'travis/api/app/stack_instrumentation'
 require 'travis/api/app/error_handling'
+require 'travis/api/sidekiq'
 
 # Rack class implementing the HTTP API.
 # Instances respond to #call.

--- a/lib/travis/api/app/services/schedule_request.rb
+++ b/lib/travis/api/app/services/schedule_request.rb
@@ -27,7 +27,7 @@ class Travis::Api::App
 
         def schedule_request
           Metriks.meter('api.v2.request.create').mark
-          Travis::Sidekiq::BuildRequest.perform_async(type: 'api', payload: payload, credentials: {})
+          enqueue_build_request
           messages << { notice: 'Build request scheduled.' }
           :success
         end
@@ -49,6 +49,14 @@ class Travis::Api::App
 
         def active?
           true
+        end
+
+        def enqueue_build_request
+          ::Travis::API::Sidekiq.gatekeeper(
+            type: 'api',
+            payload: payload,
+            credentials: {}
+          )
         end
 
         def payload

--- a/lib/travis/api/sidekiq.rb
+++ b/lib/travis/api/sidekiq.rb
@@ -1,4 +1,4 @@
-module Travis::API::V3
+module Travis::API
   module Sidekiq
     extend self
 

--- a/lib/travis/api/v3/models/cron.rb
+++ b/lib/travis/api/v3/models/cron.rb
@@ -60,7 +60,7 @@ module Travis::API::V3
         user:       { id: user_id }
       }
 
-      Sidekiq.gatekeeper(
+      ::Travis::API::Sidekiq.gatekeeper(
         type:        'cron'.freeze,
         payload:     JSON.dump(payload),
         credentials: {}

--- a/lib/travis/api/v3/models/cron.rb
+++ b/lib/travis/api/v3/models/cron.rb
@@ -60,16 +60,11 @@ module Travis::API::V3
         user:       { id: user_id }
       }
 
-      class_name, queue = Query.sidekiq_queue(:build_request)
-
-      ::Sidekiq::Client.push(
-          'queue'.freeze => queue,
-          'class'.freeze => class_name,
-          'args'.freeze  => [{
-            type:        'cron'.freeze,
-            payload:     JSON.dump(payload),
-            credentials: {}
-            }])
+      Sidekiq.gatekeeper(
+        type:        'cron'.freeze,
+        payload:     JSON.dump(payload),
+        credentials: {}
+      )
 
       update_attribute(:last_run, DateTime.now.utc)
       schedule_next_build

--- a/lib/travis/api/v3/queries/request.rb
+++ b/lib/travis/api/v3/queries/request.rb
@@ -22,7 +22,7 @@ module Travis::API::V3
         config:     config || {}
       }
 
-      Sidekiq.gatekeeper(
+      ::Travis::API::Sidekiq.gatekeeper(
         type: 'api'.freeze,
         credentials: { token: token },
         payload: JSON.dump(payload)

--- a/lib/travis/api/v3/queries/request.rb
+++ b/lib/travis/api/v3/queries/request.rb
@@ -22,7 +22,11 @@ module Travis::API::V3
         config:     config || {}
       }
 
-      perform_async(:build_request, type: 'api'.freeze, credentials: { token: token }, payload: JSON.dump(payload))
+      Sidekiq.gatekeeper(
+        type: 'api'.freeze,
+        credentials: { token: token },
+        payload: JSON.dump(payload)
+      )
       payload
     end
 

--- a/lib/travis/api/v3/sidekiq.rb
+++ b/lib/travis/api/v3/sidekiq.rb
@@ -17,22 +17,18 @@ module Travis::API::V3
       end
 
       def gatekeeper_client
+        if ENV['REDIS_GATEKEEPER_ENABLED'] != 'true'
+          return client
+        end
+
         @gatekeeper_client ||= ::Sidekiq::Client.new(gatekeeper_pool)
       end
 
       def gatekeeper_pool
         ::Sidekiq::RedisConnection.create(
-          url: gatekeeper_url,
+          url: config.redis_gatekeeper.url,
           namespace: config.sidekiq.namespace
         )
-      end
-
-      def gatekeeper_url
-        if ENV['REDIS_GATEKEEPER_ENABLED'] == 'true'
-          config.redis_gatekeeper.url
-        else
-          config.redis.url
-        end
       end
 
       def config

--- a/lib/travis/api/v3/sidekiq.rb
+++ b/lib/travis/api/v3/sidekiq.rb
@@ -1,0 +1,42 @@
+module Travis
+  module Sidekiq
+    extend self
+
+    def gatekeeper(*args)
+      gatekeeper_client.push(
+        'queue' => 'build_requests',
+        'class' => 'Travis::Gatekeeper::Worker',
+        'args' => args
+      )
+    end
+
+    private
+
+      def client
+        ::Sidekiq::Client
+      end
+
+      def gatekeeper_client
+        @gatekeeper_client ||= ::Sidekiq::Client.new(gatekeeper_pool)
+      end
+
+      def gatekeeper_pool
+        ::Sidekiq::RedisConnection.create(
+          url: gatekeeper_url,
+          namespace: config.sidekiq.namespace
+        )
+      end
+
+      def gatekeeper_url
+        if ENV['REDIS_GATEKEEPER_ENABLED'] == 'true'
+          config.redis_gatekeeper.url
+        else
+          config.redis.url
+        end
+      end
+
+      def config
+        Travis.config
+      end
+  end
+end

--- a/lib/travis/api/v3/sidekiq.rb
+++ b/lib/travis/api/v3/sidekiq.rb
@@ -1,4 +1,4 @@
-module Travis
+module Travis::API::V3
   module Sidekiq
     extend self
 

--- a/lib/travis/config/defaults.rb
+++ b/lib/travis/config/defaults.rb
@@ -53,6 +53,7 @@ module Travis
             archive:       {},
             ssl:           {},
             redis:         { url: 'redis://localhost:6379' },
+            redis_gatekeeper: { url: ENV['REDIS_GATEKEEPER_URL'] || 'redis://localhost:6379' },
             repository:    { ssl_key: { size: 4096 } },
             encryption:    Travis.env == 'development' || Travis.env == 'test' ? { key: 'secret' * 10 } : {},
             sync:          { organizations: { repositories_limit: 1000 } },

--- a/spec/v3/services/requests/create_spec.rb
+++ b/spec/v3/services/requests/create_spec.rb
@@ -107,7 +107,7 @@ describe Travis::API::V3::Services::Requests::Create, set_app: true do
     }}
 
     example { expect(Sidekiq::Client.last['queue']).to be == 'build_requests'                }
-    example { expect(Sidekiq::Client.last['class']).to be == 'Travis::Sidekiq::BuildRequest' }
+    example { expect(Sidekiq::Client.last['class']).to be == 'Travis::Gatekeeper::Worker' }
 
     describe "setting id has no effect" do
       let(:params) {{ id: 42 }}


### PR DESCRIPTION
refs https://github.com/travis-pro/team-teal/issues/2064

travis-api enqueues messages to gatekeeper. this patch adds support for enqueueing to gatekeeper's dedicated sidekiq redis instance.

this is modeled after what we have in gatekeeper:

* https://github.com/travis-ci/travis-gatekeeper/blob/master/lib/travis/sidekiq.rb