### PR TITLE
Suggestion for rejecting restarts for abusive accounts

### DIFF
--- a/lib/travis/api/v3/service.rb
+++ b/lib/travis/api/v3/service.rb
@@ -150,6 +150,11 @@ module Travis::API::V3
       result(payload, status: 202, result_type: :accepted)
     end
 
+    def rejected(message = 'Abuse detected. Restart disabled. If you think you have received this message in error, please contact support: support@travis-ci.com')
+      payload = Error.new(message, status: 403)
+      result(payload, status: 403, result_type: :error)
+    end
+
     def not_implemented
       raise NotImplemented
     end

--- a/lib/travis/api/v3/service.rb
+++ b/lib/travis/api/v3/service.rb
@@ -150,9 +150,12 @@ module Travis::API::V3
       result(payload, status: 202, result_type: :accepted)
     end
 
-    def rejected(message = 'Abuse detected. Restart disabled. If you think you have received this message in error, please contact support: support@travis-ci.com')
-      payload = Error.new(message, status: 403)
+    def rejected(payload)
       result(payload, status: 403, result_type: :error)
+    end
+
+    def abuse_detected(message = 'Abuse detected. Restart disabled. If you think you have received this message in error, please contact support: support@travis-ci.com')
+      rejected(Error.new(message, status: 403))
     end
 
     def not_implemented

--- a/lib/travis/api/v3/services/build/restart.rb
+++ b/lib/travis/api/v3/services/build/restart.rb
@@ -6,9 +6,8 @@ module Travis::API::V3
       access_control.permissions(build).restart!
 
       build.clear_debug_options!
-      if query.restart(access_control.user)
-        accepted(build: build, state_change: :restart)
-      end
+      return rejected unless query.restart(access_control.user)
+      accepted(build: build, state_change: :restart)
     end
   end
 end

--- a/lib/travis/api/v3/services/build/restart.rb
+++ b/lib/travis/api/v3/services/build/restart.rb
@@ -6,7 +6,7 @@ module Travis::API::V3
       access_control.permissions(build).restart!
 
       build.clear_debug_options!
-      return rejected unless query.restart(access_control.user)
+      return abuse_detected unless query.restart(access_control.user)
       accepted(build: build, state_change: :restart)
     end
   end

--- a/spec/v3/services/build/restart_spec.rb
+++ b/spec/v3/services/build/restart_spec.rb
@@ -70,8 +70,12 @@ describe Travis::API::V3::Services::Build::Restart, set_app: true do
       post("/v3/build/#{build.id}/restart", {}, headers)
     end
 
-    example { expect(last_response.status).to be == 500 }
-    example { expect(body) == "Sorry, we experienced an error." }
+    example { expect(last_response.status).to be == 403 }
+    example { expect(JSON.load(body)).to      be ==     {
+      "@type"         => "error",
+      "error_type"    => "error",
+      "error_message" => "Abuse detected. Restart disabled. If you think you have received this message in error, please contact support: support@travis-ci.com"
+    }}
   end
 
   describe "private repository, no access" do


### PR DESCRIPTION
@aakritigupta I added a rejected method, similar the accepted method that returns a json error message about abuse. Please let me know if this is what you were looking for.