### PR TITLE
Remove cron if repo has been disabled

### DIFF
--- a/lib/travis/api/v3/models/cron.rb
+++ b/lib/travis/api/v3/models/cron.rb
@@ -43,7 +43,7 @@ module Travis::API::V3
         raise StandardError, "Repository does not have a github_id"
       end
 
-      if !branch.exists_on_github
+      if !branch.repository.active? or !branch.exists_on_github
         self.destroy
         return false
       end

--- a/spec/v3/models/cron_spec.rb
+++ b/spec/v3/models/cron_spec.rb
@@ -100,6 +100,11 @@ describe Travis::API::V3::Models::Cron do
       subject.branch.exists_on_github = false
       expect{ subject.enqueue }.to change { Travis::API::V3::Models::Cron.count}.by(-1)
     end
+
+    it "destroys cron if repo is no longer active" do
+      subject.branch.repository.active = false
+      expect{ subject.enqueue }.to change { Travis::API::V3::Models::Cron.count}.by(-1)
+    end
   end
 
   context "when always_run? is false" do


### PR DESCRIPTION
Fixes https://github.com/travis-pro/team-teal/issues/2037 : Cron build is started even if the repository is disabled