### PR TITLE
Install knapsack for all environments

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -47,6 +47,8 @@ gem 'rake', '~> 0.9.2'
 
 gem 'appsignal'
 
+gem 'knapsack'
+
 group :test do
   gem 'rspec',         '~> 2.13'
   gem 'rspec-its'
@@ -55,7 +57,6 @@ group :test do
   gem 'database_cleaner', '~> 0.8.0'
   gem 'timecop',       '~> 0.8.0'
   gem 'webmock'
-  gem 'knapsack'
 end
 
 group :development do


### PR DESCRIPTION
to avoid logs like:
```
-----> Detecting rake tasks
       Could not detect rake tasks
       ensure you can run `$ bundle exec rake -P` against your app
       and using the production group of your Gemfile.
       rake aborted!
       cannot load such file -- knapsack
```
during deployment.