### PR TITLE
Omit repo pusher channels for a user when per-user channel is enabled

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,6 +13,7 @@ gem 'travis-config',   git: 'https://github.com/travis-ci/travis-config'
 gem 'travis-settings', git: 'https://github.com/travis-ci/travis-settings'
 gem 'travis-sidekiqs', git: 'https://github.com/travis-ci/travis-sidekiqs'
 gem 'travis-lock',     git: 'https://github.com/travis-ci/travis-lock'
+gem 'travis-rollout',  git: 'https://github.com/travis-ci/travis-rollout', branch: 'sf-refactor'
 
 gem 'travis-yaml',     git: 'https://github.com/travis-ci/travis-yaml'
 gem 'mustermann'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -46,6 +46,13 @@ GIT
     travis-lock (0.1.1)
 
 GIT
+  remote: https://github.com/travis-ci/travis-rollout
+  revision: 71cc9102dff01f95c281f99183e54b6695faa7ec
+  branch: sf-refactor
+  specs:
+    travis-rollout (0.0.1)
+
+GIT
   remote: https://github.com/travis-ci/travis-settings
   revision: d510e63b6c6f059cccae141c265e7a0c7236d1fd
   specs:
@@ -405,6 +412,7 @@ DEPENDENCIES
   travis-api!
   travis-config!
   travis-lock!
+  travis-rollout!
   travis-settings!
   travis-sidekiqs!
   travis-support!
@@ -417,4 +425,4 @@ RUBY VERSION
    ruby 2.3.4p301
 
 BUNDLED WITH
-   1.15.1
+   1.15.2

--- a/lib/travis/api/serialize/v2/http/user.rb
+++ b/lib/travis/api/serialize/v2/http/user.rb
@@ -8,6 +8,31 @@ module Travis
       module V2
         module Http
           class User
+            class PusherChannels < Struct.new(:user)
+              def channels
+                repository_ids = []
+                uids = user.repositories
+                  .select(['repositories.id', 'repositories.owner_id', 'repositories.owner_type'])
+                  .group_by { |r| "#{r.owner_id}-#{r.owner_type[0]}" }
+                  .each do |uid, repositories|
+                    # for each owner we need to add repositories to the list
+                    # only if user channel is not enabled
+                    rollout = Travis::Rollout.new('user-channel', redis: redis, uid: uid)
+                    unless rollout.matches?
+                      repository_ids.push(*repositories.map(&:id))
+                    end
+                  end
+
+                ["user-#{user.id}"] + repository_ids.map { |id| "repo-#{id}" }
+              end
+
+              private
+
+                def redis
+                  Thread.current[:redis] ||= ::Redis.connect(url: Travis.config.redis.url)
+                end
+            end
+
             include Formats
 
             attr_reader :user, :options
@@ -43,24 +68,7 @@ module Travis
               end
 
               def channels
-                repository_ids = []
-                uids = user.repositories
-                  .select(['repositories.id', 'repositories.owner_id', 'repositories.owner_type'])
-                  .group_by { |r| "#{r.owner_id}-#{r.owner_type[0]}" }
-                  .each do |uid, repositories|
-                    # for each owner we need to add repositories to the list
-                    # only if user channel is not enabled
-                    rollout = Travis::Rollout.new('user-channel', redis: redis, uid: uid)
-                    unless rollout.matches?
-                      repository_ids.push(*repositories.map(&:id))
-                    end
-                  end
-
-                ["user-#{user.id}"] + repository_ids.map { |id| "repo-#{id}" }
-              end
-
-              def redis
-                Thread.current[:redis] ||= ::Redis.connect(url: Travis.config.redis.url)
+                PusherChannels.new(user).channels
               end
           end
         end

--- a/spec/unit/endpoint/users_spec.rb
+++ b/spec/unit/endpoint/users_spec.rb
@@ -5,9 +5,9 @@ describe Travis::Api::App::Endpoint::Users, set_app: true do
   before do
     User.stubs(:find_by_github_id).returns(user)
     User.stubs(:find).returns(user)
-    user.stubs(:repositories).returns(stub(administratable: stub(select: [repository])))
-    user.stubs(:repository_ids).returns([1, 2, 3])
     user.stubs(:github_scopes).returns(['public_repo', 'user:email'])
+    pusher_channel_instance = stub('pusher_channel_instance', channels: ['user-1', 'repo-1', 'repo-2', 'repo-3'])
+    Travis::Api::Serialize::V2::Http::User::PusherChannels.stubs(:new).returns(pusher_channel_instance)
   end
 
   it 'needs to be authenticated' do

--- a/spec/unit/serialize/v2/http/user_spec.rb
+++ b/spec/unit/serialize/v2/http/user_spec.rb
@@ -4,7 +4,11 @@ describe Travis::Api::Serialize::V2::Http::User do
   let(:user) { stub_user(repository_ids: [1, 4, 8]) }
   let(:data) { described_class.new(user).data }
 
-  before { user.stubs(:github_scopes).returns(['public_repo', 'user:email']) }
+  before do
+    user.stubs(:github_scopes).returns(['public_repo', 'user:email'])
+    pusher_channel_instance = stub('pusher_channel_instance', channels: ['user-1', 'repo-1', 'repo-4', 'repo-8'])
+    Travis::Api::Serialize::V2::Http::User::PusherChannels.stubs(:new).returns(pusher_channel_instance)
+  end
 
   it 'user' do
     data['user'].should == {


### PR DESCRIPTION
We plan to move to a per-user channel instead of per-repo channels. This
commit skips sending channels for repositories belonging to owners with
per-user channels enabled.