### PR TITLE
Add tag to v3 build payloads

### DIFF
--- a/lib/travis/api/serialize/v2/http/build.rb
+++ b/lib/travis/api/serialize/v2/http/build.rb
@@ -52,6 +52,7 @@ module Travis
                   'sha' => commit.commit,
                   'branch' => commit.branch,
                   'branch_is_default' => branch_is_default,
+                  'tag' => commit.tag_name,
                   'message' => commit.message,
                   'committed_at' => format_date(commit.committed_at),
                   'author_name' => commit.author_name,

--- a/lib/travis/api/serialize/v2/http/builds.rb
+++ b/lib/travis/api/serialize/v2/http/builds.rb
@@ -53,6 +53,7 @@ module Travis
                   'id' => commit.id,
                   'sha' => commit.commit,
                   'branch' => commit.branch,
+                  'tag' => commit.tag_name,
                   'message' => commit.message,
                   'committed_at' => format_date(commit.committed_at),
                   'author_name' => commit.author_name,

--- a/lib/travis/api/serialize/v2/http/job.rb
+++ b/lib/travis/api/serialize/v2/http/job.rb
@@ -54,6 +54,7 @@ module Travis
                   'sha' => commit.commit,
                   'branch' => commit.branch,
                   'branch_is_default' => branch_is_default(commit, repository),
+                  'tag' => commit.tag_name,
                   'message' => commit.message,
                   'committed_at' => format_date(commit.committed_at),
                   'author_name' => commit.author_name,

--- a/lib/travis/api/serialize/v2/http/jobs.rb
+++ b/lib/travis/api/serialize/v2/http/jobs.rb
@@ -52,6 +52,7 @@ module Travis
                   'id' => commit.id,
                   'sha' => commit.commit,
                   'branch' => commit.branch,
+                  'tag' => commit.tag_name,
                   'message' => commit.message,
                   'committed_at' => format_date(commit.committed_at),
                   'author_name' => commit.author_name,

--- a/lib/travis/api/v3/models/build.rb
+++ b/lib/travis/api/v3/models/build.rb
@@ -1,6 +1,7 @@
 module Travis::API::V3
   class Models::Build < Model
     belongs_to :commit
+    belongs_to :tag
     belongs_to :pull_request
     belongs_to :request
     belongs_to :repository, autosave: true

--- a/lib/travis/api/v3/models/commit.rb
+++ b/lib/travis/api/v3/models/commit.rb
@@ -2,6 +2,7 @@ module Travis::API::V3
   class Models::Commit < Model
     belongs_to :repository
     has_one    :request
+    belongs_to :tag
     has_many   :builds
 
     has_one :branch,

--- a/lib/travis/api/v3/models/tag.rb
+++ b/lib/travis/api/v3/models/tag.rb
@@ -1,0 +1,7 @@
+module Travis::API::V3
+  class Models::Tag < Model
+    belongs_to :repository
+    has_many   :builds,  foreign_key: [:repository_id, :branch], primary_key: [:repository_id, :name], order: 'builds.id DESC'.freeze, conditions: { event_type: 'push' }
+    has_many   :commits, foreign_key: [:repository_id, :branch], primary_key: [:repository_id, :name], order: 'commits.id DESC'.freeze
+  end
+end

--- a/lib/travis/api/v3/queries/builds.rb
+++ b/lib/travis/api/v3/queries/builds.rb
@@ -23,7 +23,7 @@ module Travis::API::V3
       relation = relation.where(branch:         list(branch_name))    if branch_name
       relation = for_owner(relation)                                  if created_by
 
-      relation = relation.includes(:commit).includes(branch: :last_build).includes(:repository)
+      relation = relation.includes(:commit).includes(branch: :last_build).includes(:tag).includes(:repository)
       relation = relation.includes(branch: { last_build: :commit }) if includes? 'build.commit'.freeze
       relation
     end

--- a/lib/travis/api/v3/renderer/build.rb
+++ b/lib/travis/api/v3/renderer/build.rb
@@ -1,7 +1,7 @@
 module Travis::API::V3
   class Renderer::Build < ModelRenderer
     representation(:minimal,  :id, :number, :state, :duration, :event_type, :previous_state, :pull_request_title, :pull_request_number, :started_at, :finished_at)
-    representation(:standard, *representations[:minimal], :repository, :branch, :commit, :jobs, :stages, :created_by)
+    representation(:standard, *representations[:minimal], :repository, :branch, :tag, :commit, :jobs, :stages, :created_by)
     representation(:active, *representations[:standard])
 
     hidden_representations(:active)

--- a/lib/travis/api/v3/renderer/tag.rb
+++ b/lib/travis/api/v3/renderer/tag.rb
@@ -1,0 +1,6 @@
+module Travis::API::V3
+  class Renderer::Tag < ModelRenderer
+    representation(:minimal, :repository_id, :name, :last_build_id)
+    representation(:standard, :repository_id, :name, :last_build_id)
+  end
+end

--- a/lib/travis/api/v3/result.rb
+++ b/lib/travis/api/v3/result.rb
@@ -31,6 +31,9 @@ module Travis::API::V3
         access_control: access_control,
         meta_data:      meta_data,
         accept:         env.fetch('HTTP_ACCEPT'.freeze, 'application/json'.freeze))
+    rescue => e
+      puts e.message, e.backtrace
+      raise
     end
 
     def add_info(payload)

--- a/lib/travis/model/commit.rb
+++ b/lib/travis/model/commit.rb
@@ -8,6 +8,10 @@ class Commit < Travis::Model
 
   validates :commit, :branch, :committed_at, :presence => true
 
+  def tag_name
+    ref =~ %r(^refs/tags/(.*)$) && $1
+  end
+
   def pull_request?
     ref =~ %r(^refs/pull/\d+/merge$)
   end

--- a/lib/travis/testing/stubs.rb
+++ b/lib/travis/testing/stubs.rb
@@ -121,6 +121,7 @@ module Travis
           commit: '62aae5f70ceee39123ef',
           range: '0cd9ffaab2c4ffee...62aae5f70ceee39123ef',
           branch: 'master',
+          tag_name: nil,
           ref: 'refs/master',
           message: 'the commit message',
           author_name: 'Sven Fuchs',

--- a/spec/unit/serialize/v2/http/build_spec.rb
+++ b/spec/unit/serialize/v2/http/build_spec.rb
@@ -28,6 +28,7 @@ describe Travis::Api::Serialize::V2::Http::Build do
       'sha' => '62aae5f70ceee39123ef',
       'branch' => 'master',
       'branch_is_default' => true,
+      'tag' => nil,
       'message' => 'the commit message',
       'committed_at' => json_format_time(Time.now.utc - 1.hour),
       'committer_email' => 'svenfuchs@artweb-design.de',
@@ -52,6 +53,16 @@ describe Travis::Api::Serialize::V2::Http::Build do
       data['build']['pull_request_number'].should == 44
     end
 
+  end
+
+  describe 'with a tag' do
+    before do
+      build.commit.stubs(tag_name: 'v1.0.0')
+    end
+
+    it 'includes the tag name to commit' do
+      data['commit']['tag'].should == 'v1.0.0'
+    end
   end
 
   context 'with encrypted env vars' do

--- a/spec/unit/serialize/v2/http/builds_spec.rb
+++ b/spec/unit/serialize/v2/http/builds_spec.rb
@@ -27,6 +27,7 @@ describe Travis::Api::Serialize::V2::Http::Builds do
       'id' => commit.id,
       'sha' => '62aae5f70ceee39123ef',
       'branch' => 'master',
+      'tag' => nil,
       'message' => 'the commit message',
       'committed_at' => json_format_time(Time.now.utc - 1.hour),
       'committer_email' => 'svenfuchs@artweb-design.de',
@@ -43,6 +44,16 @@ describe Travis::Api::Serialize::V2::Http::Builds do
     build.expects(:cached_matrix_ids).returns([1, 2, 3])
     data = described_class.new([build]).data
     data['builds'].first['job_ids'].should == [1, 2, 3]
+  end
+
+  describe 'with a tag' do
+    before do
+      build.commit.stubs(tag_name: 'v1.0.0')
+    end
+
+    it 'includes the tag name to commit' do
+      data['commits'][0]['tag'].should == 'v1.0.0'
+    end
   end
 
   describe 'with a pull request' do

--- a/spec/unit/serialize/v2/http/job_spec.rb
+++ b/spec/unit/serialize/v2/http/job_spec.rb
@@ -10,6 +10,7 @@ describe Travis::Api::Serialize::V2::Http::Job do
       'message' => 'the commit message',
       'branch' => 'master',
       'branch_is_default' => true,
+      'tag' => nil,
       'committed_at' => json_format_time(Time.now.utc - 1.hour),
       'committer_name' => 'Sven Fuchs',
       'committer_email' => 'svenfuchs@artweb-design.de',
@@ -17,6 +18,16 @@ describe Travis::Api::Serialize::V2::Http::Job do
       'author_email' => 'svenfuchs@artweb-design.de',
       'compare_url' => 'https://github.com/svenfuchs/minimal/compare/master...develop',
     }
+  end
+
+  describe 'with a tag' do
+    before do
+      test.commit.stubs(tag_name: 'v1.0.0')
+    end
+
+    it 'includes the tag name to commit' do
+      data['commit']['tag'].should == 'v1.0.0'
+    end
   end
 
   it 'annotations' do

--- a/spec/unit/serialize/v2/http/jobs_spec.rb
+++ b/spec/unit/serialize/v2/http/jobs_spec.rb
@@ -9,6 +9,7 @@ describe Travis::Api::Serialize::V2::Http::Jobs do
       'id' => 1,
       'sha' => '62aae5f70ceee39123ef',
       'branch' => 'master',
+      'tag' => nil,
       'message' => 'the commit message',
       'committed_at' => json_format_time(time - 1.hour),
       'committer_name' => 'Sven Fuchs',
@@ -17,6 +18,16 @@ describe Travis::Api::Serialize::V2::Http::Jobs do
       'author_email' => 'svenfuchs@artweb-design.de',
       'compare_url' => 'https://github.com/svenfuchs/minimal/compare/master...develop',
     }
+  end
+
+  describe 'with a tag' do
+    before do
+      test.commit.stubs(tag_name: 'v1.0.0')
+    end
+
+    it 'includes the tag name to commit' do
+      data['commits'][0]['tag'].should == 'v1.0.0'
+    end
   end
 end
 

--- a/spec/v3/services/builds/find_spec.rb
+++ b/spec/v3/services/builds/find_spec.rb
@@ -74,23 +74,28 @@ describe Travis::API::V3::Services::Builds::Find, set_app: true do
         "pull_request_title"  => build.pull_request_title,
         "started_at"          => "2010-11-12T13:00:00Z",
         "finished_at"         => nil,
-        "stages"              => [{
-           "@type"            => "stage",
-           "@representation"  => "minimal",
-           "id"               => stages[0].id,
-           "number"           => 1,
-           "name"             => "test",
-           "state"            => stages[0].state,
-           "started_at"       => stages[0].started_at,
-           "finished_at"      => stages[0].finished_at},
-          {"@type"            => "stage",
-           "@representation" => "minimal",
-           "id"               => stages[1].id,
-           "number"          => 2,
-           "name"             => "deploy",
-           "state"            => stages[1].state,
-           "started_at"       => stages[1].started_at,
-           "finished_at"      => stages[1].finished_at}],
+        "repository"          => {
+          "@type"             => "repository",
+          "@href"             => "/v3/repo/#{repo.id}",
+          "@representation"   => "minimal",
+          "id"                => repo.id,
+          "name"              => "minimal",
+          "slug"              => "svenfuchs/minimal"},
+        "branch"              => {
+          "@type"             => "branch",
+          "@href"             => "/v3/repo/#{repo.id}/branch/master",
+          "@representation"   => "minimal",
+          "name"              => "master"},
+        "tag"                 => nil,
+        "commit"              => {
+          "@type"             => "commit",
+          "@representation"   => "minimal",
+          "id"                => 5,
+          "sha"               => "add057e66c3e1d59ef1f",
+          "ref"               => "refs/heads/master",
+          "message"           => "unignore Gemfile.lock",
+          "compare_url"       => "https://github.com/svenfuchs/minimal/compare/master...develop",
+          "committed_at"      => "2010-11-12T12:55:00Z"},
         "jobs"                => [
           {
           "@type"             => "job",
@@ -112,27 +117,23 @@ describe Travis::API::V3::Services::Builds::Find, set_app: true do
           "@href"             => "/v3/job/#{jobs[3].id}",
           "@representation"   => "minimal",
           "id"                => jobs[3].id}],
-        "repository"          => {
-          "@type"             => "repository",
-          "@href"             => "/v3/repo/#{repo.id}",
-          "@representation"   => "minimal",
-          "id"                => repo.id,
-          "name"              => "minimal",
-          "slug"              => "svenfuchs/minimal"},
-        "branch"              => {
-          "@type"             => "branch",
-          "@href"             => "/v3/repo/#{repo.id}/branch/master",
-          "@representation"   => "minimal",
-          "name"              => "master"},
-        "commit"              => {
-          "@type"             => "commit",
-          "@representation"   => "minimal",
-          "id"                => 5,
-          "sha"               => "add057e66c3e1d59ef1f",
-          "ref"               => "refs/heads/master",
-          "message"           => "unignore Gemfile.lock",
-          "compare_url"       => "https://github.com/svenfuchs/minimal/compare/master...develop",
-          "committed_at"      => "2010-11-12T12:55:00Z"},
+        "stages"              => [{
+           "@type"            => "stage",
+           "@representation"  => "minimal",
+           "id"               => stages[0].id,
+           "number"           => 1,
+           "name"             => "test",
+           "state"            => stages[0].state,
+           "started_at"       => stages[0].started_at,
+           "finished_at"      => stages[0].finished_at},
+          {"@type"            => "stage",
+           "@representation" => "minimal",
+           "id"               => stages[1].id,
+           "number"          => 2,
+           "name"             => "deploy",
+           "state"            => stages[1].state,
+           "started_at"       => stages[1].started_at,
+           "finished_at"      => stages[1].finished_at}],
         "created_by"          => {
           "@type"             => "user",
           "@href"             => "/v3/user/1",
@@ -192,23 +193,28 @@ describe Travis::API::V3::Services::Builds::Find, set_app: true do
         "pull_request_title"  => build.pull_request_title,
         "started_at"          => "2010-11-12T13:00:00Z",
         "finished_at"         => nil,
-        "stages"              => [{
-           "@type"            => "stage",
-           "@representation"  => "minimal",
-           "id"               => stages[0].id,
-           "number"           => 1,
-           "name"             => "test",
-           "state"            => stages[0].state,
-           "started_at"       => stages[0].started_at,
-           "finished_at"      => stages[0].finished_at},
-          {"@type"            => "stage",
-           "@representation" => "minimal",
-           "id"               => stages[1].id,
-           "number"          => 2,
-           "name"             => "deploy",
-           "state"            => stages[1].state,
-           "started_at"       => stages[1].started_at,
-           "finished_at"      => stages[1].finished_at}],
+        "repository"          => {
+          "@type"             => "repository",
+          "@href"             => "/v3/repo/#{repo.id}",
+          "@representation"   => "minimal",
+          "id"                => repo.id,
+          "name"              => "minimal",
+          "slug"              => "svenfuchs/minimal"},
+        "branch"              => {
+          "@type"             => "branch",
+          "@href"             => "/v3/repo/#{repo.id}/branch/master",
+          "@representation"   => "minimal",
+          "name"              => "master"},
+        "tag"                 => nil,
+        "commit"              => {
+          "@type"             => "commit",
+          "@representation"   => "minimal",
+          "id"                => 5,
+          "sha"               => "add057e66c3e1d59ef1f",
+          "ref"               => "refs/heads/master",
+          "message"           => "unignore Gemfile.lock",
+          "compare_url"       => "https://github.com/svenfuchs/minimal/compare/master...develop",
+          "committed_at"      => "2010-11-12T12:55:00Z"},
         "jobs"                => [
           {
           "@type"             => "job",
@@ -230,27 +236,23 @@ describe Travis::API::V3::Services::Builds::Find, set_app: true do
           "@href"             => "/v3/job/#{jobs[3].id}",
           "@representation"   => "minimal",
           "id"                => jobs[3].id}],
-        "repository"          => {
-          "@type"             => "repository",
-          "@href"             => "/v3/repo/#{repo.id}",
-          "@representation"   => "minimal",
-          "id"                => repo.id,
-          "name"              => "minimal",
-          "slug"              => "svenfuchs/minimal"},
-        "branch"              => {
-          "@type"             => "branch",
-          "@href"             => "/v3/repo/#{repo.id}/branch/master",
-          "@representation"   => "minimal",
-          "name"              => "master"},
-        "commit"              => {
-          "@type"             => "commit",
-          "@representation"   => "minimal",
-          "id"                => 5,
-          "sha"               => "add057e66c3e1d59ef1f",
-          "ref"               => "refs/heads/master",
-          "message"           => "unignore Gemfile.lock",
-          "compare_url"       => "https://github.com/svenfuchs/minimal/compare/master...develop",
-          "committed_at"      => "2010-11-12T12:55:00Z"},
+        "stages"              => [{
+           "@type"            => "stage",
+           "@representation"  => "minimal",
+           "id"               => stages[0].id,
+           "number"           => 1,
+           "name"             => "test",
+           "state"            => stages[0].state,
+           "started_at"       => stages[0].started_at,
+           "finished_at"      => stages[0].finished_at},
+          {"@type"            => "stage",
+           "@representation" => "minimal",
+           "id"               => stages[1].id,
+           "number"          => 2,
+           "name"             => "deploy",
+           "state"            => stages[1].state,
+           "started_at"       => stages[1].started_at,
+           "finished_at"      => stages[1].finished_at}],
         "created_by"          => {
           "@type"             => "user",
           "@href"             => "/v3/user/1",
@@ -290,5 +292,20 @@ describe Travis::API::V3::Services::Builds::Find, set_app: true do
     example { expect(last_response).to be_ok }
     example { expect(parsed_body['builds'].size).to be == (1) }
     example { expect(parsed_body['builds'].first['created_by']['id']).to be == (repo.owner.id) }
+  end
+
+  describe "build for a tag push event" do
+    before  { build.create_tag(repository: repo, name: 'v1.0.0') }
+    before  { build.save! } # not sure why i have to save it, any way around this?
+    before  { get("/v3/repo/svenfuchs%2Fminimal/builds")     }
+
+    example { expect(last_response).to be_ok  }
+    example { expect(parsed_body['builds'][0]['tag']).to be == {
+      "@type"           => "tag",
+      "@representation" => "minimal",
+      "repository_id"   => 1,
+      "name"            => "v1.0.0",
+      "last_build_id"   => nil
+    }}
   end
 end


### PR DESCRIPTION
This adds a `tag` to the `build` payloads in v3 like:

```
{
      "@type"           => "tag",
      "@representation" => "minimal",
      "repository_id"   => 1,
      "name"            => "v1.0.0",
      "last_build_id"   => 1
}
```

I am not entirely sure this is what we want, or all we want. I have not added the `tag` to `job` because those also don't have a `branch`. 