### PR TITLE
add stages endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ $ bundle install
 $ sudo -u postgres psql -c "CREATE USER yourusername WITH SUPERUSER PASSWORD 'yourpassword'"
 ```
 
-Databases are set up with a Rake task that uses the database schemas (`structure.sql`) in `travis-migrations`. Details can be found in the `Rakefile`. 
+Databases are set up with a Rake task that uses the database schemas (`structure.sql`) in `travis-migrations`. Details can be found in the `Rakefile`.
 
 
 To create and migrate the Databases:
@@ -58,6 +58,7 @@ $ bundle exec rake
 ```sh-session
 ENV=development bundle exec ruby -Ilib -S rackup
 ```
+(The database connection can be overwritten by setting a DATABASE_URL env var. Please ensure you also set RAILS_ENV to corresponding env and add encryption key config to `config/travis.ylm`)
 
 ### Run the server (production)
 ```sh-session

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ $ bundle exec rake
 ```sh-session
 ENV=development bundle exec ruby -Ilib -S rackup
 ```
-(The database connection can be overwritten by setting a DATABASE_URL env var. Please ensure you also set RAILS_ENV to corresponding env and add encryption key config to `config/travis.ylm`)
+(The database connection can be overwritten by setting a DATABASE_URL env var. Please ensure you also set RAILS_ENV to corresponding env and add encryption key config to `config/travis.yml`)
 
 ### Run the server (production)
 ```sh-session

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ $ bundle exec rake
 ```sh-session
 ENV=development bundle exec ruby -Ilib -S rackup
 ```
-(The database connection can be overwritten by setting a DATABASE_URL env var. Please ensure you also set RAILS_ENV to corresponding env and add encryption key config to `config/travis.yml`)
+(The database connection can be overwritten by setting a DATABASE_URL env var. Please ensure you also set ENV to the corresponding env and add encryption key config to `config/travis.yml`)
 
 ### Run the server (production)
 ```sh-session

--- a/lib/travis/api/v3/queries/builds.rb
+++ b/lib/travis/api/v3/queries/builds.rb
@@ -25,7 +25,6 @@ module Travis::API::V3
 
       relation = relation.includes(:commit).includes(branch: :last_build).includes(:repository)
       relation = relation.includes(branch: { last_build: :commit }) if includes? 'build.commit'.freeze
-      # relation = relation.includes(jobs: [:repository, :commit, :stage]) if includes? 'build.jobs'.freeze or includes? 'job'.freeze
       relation
     end
 

--- a/lib/travis/api/v3/queries/builds.rb
+++ b/lib/travis/api/v3/queries/builds.rb
@@ -25,7 +25,7 @@ module Travis::API::V3
 
       relation = relation.includes(:commit).includes(branch: :last_build).includes(:repository)
       relation = relation.includes(branch: { last_build: :commit }) if includes? 'build.commit'.freeze
-      relation = relation.includes(:jobs) if includes? 'build.jobs'.freeze or includes? 'job'.freeze
+      # relation = relation.includes(jobs: [:repository, :commit, :stage]) if includes? 'build.jobs'.freeze or includes? 'job'.freeze
       relation
     end
 

--- a/lib/travis/api/v3/queries/jobs.rb
+++ b/lib/travis/api/v3/queries/jobs.rb
@@ -1,11 +1,7 @@
 module Travis::API::V3
   class Queries::Jobs < Query
     def find(build)
-      sort filter(build.jobs)
-    end
-
-    def filter(list)
-      list
+      build.jobs
     end
   end
 end

--- a/lib/travis/api/v3/queries/stages.rb
+++ b/lib/travis/api/v3/queries/stages.rb
@@ -1,7 +1,8 @@
 module Travis::API::V3
-  class Queries::Jobs < Query
+  class Queries::Stages < Query
+
     def find(build)
-      sort filter(build.jobs)
+      sort filter(build.stages)
     end
 
     def filter(list)

--- a/lib/travis/api/v3/queries/stages.rb
+++ b/lib/travis/api/v3/queries/stages.rb
@@ -2,11 +2,7 @@ module Travis::API::V3
   class Queries::Stages < Query
 
     def find(build)
-      sort filter(build.stages)
-    end
-
-    def filter(list)
-      list
+      build.stages
     end
   end
 end

--- a/lib/travis/api/v3/renderer/stages.rb
+++ b/lib/travis/api/v3/renderer/stages.rb
@@ -1,0 +1,6 @@
+module Travis::API::V3
+  class Renderer::Stages < CollectionRenderer
+    type            :stages
+    collection_key  :stages
+  end
+end

--- a/lib/travis/api/v3/routes.rb
+++ b/lib/travis/api/v3/routes.rb
@@ -20,6 +20,11 @@ module Travis::API::V3
         route '/jobs'
         get  :find
       end
+
+      resource :stages do
+        route '/stages'
+        get   :find
+      end
     end
 
     resource :builds do

--- a/lib/travis/api/v3/services.rb
+++ b/lib/travis/api/v3/services.rb
@@ -30,6 +30,7 @@ module Travis::API::V3
     Request       = Module.new { extend Services }
     Requests      = Module.new { extend Services }
     SslKey        = Module.new { extend Services }
+    Stages        = Module.new { extend Services }
     User          = Module.new { extend Services }
     UserSetting   = Module.new { extend Services }
     UserSettings  = Module.new { extend Services }

--- a/lib/travis/api/v3/services/stages/find.rb
+++ b/lib/travis/api/v3/services/stages/find.rb
@@ -1,0 +1,7 @@
+module Travis::API::V3
+  class Services::Stages::Find < Service
+    def run!
+      result query.find(find(:build))
+    end
+  end
+end

--- a/spec/v3/services/stages/find_spec.rb
+++ b/spec/v3/services/stages/find_spec.rb
@@ -1,0 +1,172 @@
+describe Travis::API::V3::Services::Stages::Find, set_app: true do
+  let(:repo)   { Travis::API::V3::Models::Repository.where(owner_name: 'svenfuchs', name: 'minimal').first }
+  let(:build)  { repo.builds.first }
+  let(:stages) { build.stages }
+  let(:jobs)   { Travis::API::V3::Models::Build.find(build.id).jobs }
+  let(:commit) { build.commit }
+  let(:parsed_body) { JSON.load(body) }
+
+  before do
+    # TODO should this go into the scenario? is it ok to keep it here?
+    test   = build.stages.create(number: 1, name: 'test')
+    deploy = build.stages.create(number: 2, name: 'deploy')
+    jobs[0, 2].each { |job| job.update_attributes!(stage: test) }
+    jobs[2, 2].each { |job| job.update_attributes!(stage: deploy) }
+  end
+
+  describe "stages on public repository" do
+    before     { get("/v3/build/#{build.id}/stages") }
+    example    { expect(last_response).to be_ok }
+    example       { expect(parsed_body).to be == {
+      "@type"=>"stages",
+      "@href"=>"/v3/build/#{build.id}/stages",
+      "@representation"=>"standard",
+      "stages"=>[{
+        "@type"=>"stage",
+        "@representation"=>"standard",
+        "id"=>stages[0].id,
+        "number"=>1,
+        "name"=>"test",
+        "state"=>stages[0].state,
+        "started_at"=>stages[0].started_at,
+        "finished_at"=>stages[0].finished_at,
+        "jobs"=>[{
+          "@type"=>"job",
+          "@href"=>"/v3/job/#{stages[0].jobs[0].id}",
+          "@representation"=>"minimal",
+          "id"=>stages[0].jobs[0].id},
+          {
+          "@type"=>"job",
+          "@href"=>"/v3/job/#{stages[0].jobs[1].id}",
+          "@representation"=>"minimal",
+          "id"=>stages[0].jobs[1].id}]}, {
+        "@type"=>"stage",
+        "@representation"=>"standard",
+        "id"=>stages[1].id,
+        "number"=>2,
+        "name"=>"deploy",
+        "state"=>stages[1].state,
+        "started_at"=>stages[1].started_at,
+        "finished_at"=>stages[1].finished_at,
+        "jobs"=>[{
+          "@type"=>"job",
+          "@href"=>"/v3/job/#{stages[1].jobs[0].id}",
+          "@representation"=>"minimal",
+          "id"=>stages[1].jobs[0].id}, {
+          "@type"=>"job",
+          "@href"=>"/v3/job/#{stages[1].jobs[1].id}",
+          "@representation"=>"minimal",
+          "id"=>stages[1].jobs[1].id}
+        ]}
+      ]}
+    }
+  end
+
+  describe "stages private repository, private API, authenticated as user with pull access" do
+    let(:token)   { Travis::Api::App::AccessToken.create(user: repo.owner, app_id: 1) }
+    let(:headers) {{ 'HTTP_AUTHORIZATION' => "token #{token}"                        }}
+    before        { Travis::API::V3::Models::Permission.create(repository: repo, user: repo.owner, pull: true) }
+    before        { repo.update_attribute(:private, true)                             }
+    before        { get("/v3/build/#{build.id}/stages", {}, headers)                           }
+    after         { repo.update_attribute(:private, false)                            }
+    example       { expect(last_response).to be_ok                                    }
+    example       { expect(parsed_body).to be == {
+      "@type"=>"stages",
+      "@href"=>"/v3/build/#{build.id}/stages",
+      "@representation"=>"standard",
+      "stages"=>[{
+        "@type"=>"stage",
+        "@representation"=>"standard",
+        "id"=>stages[0].id,
+        "number"=>1,
+        "name"=>"test",
+        "state"=>stages[0].state,
+        "started_at"=>stages[0].started_at,
+        "finished_at"=>stages[0].finished_at,
+        "jobs"=>[{
+          "@type"=>"job",
+          "@href"=>"/v3/job/#{stages[0].jobs[0].id}",
+          "@representation"=>"minimal",
+          "id"=>stages[0].jobs[0].id},
+          {
+          "@type"=>"job",
+          "@href"=>"/v3/job/#{stages[0].jobs[1].id}",
+          "@representation"=>"minimal",
+          "id"=>stages[0].jobs[1].id}]}, {
+        "@type"=>"stage",
+        "@representation"=>"standard",
+        "id"=>stages[1].id,
+        "number"=>2,
+        "name"=>"deploy",
+        "state"=>stages[1].state,
+        "started_at"=>stages[1].started_at,
+        "finished_at"=>stages[1].finished_at,
+        "jobs"=>[{
+          "@type"=>"job",
+          "@href"=>"/v3/job/#{stages[1].jobs[0].id}",
+          "@representation"=>"minimal",
+          "id"=>stages[1].jobs[0].id}, {
+          "@type"=>"job",
+          "@href"=>"/v3/job/#{stages[1].jobs[1].id}",
+          "@representation"=>"minimal",
+          "id"=>stages[1].jobs[1].id}
+        ]}
+      ]}
+    }
+  end
+
+describe "stages private repository, private API, authenticated as user with push access" do
+    let(:token)   { Travis::Api::App::AccessToken.create(user: repo.owner, app_id: 1) }
+    let(:headers) {{ 'HTTP_AUTHORIZATION' => "token #{token}"                        }}
+    before        { Travis::API::V3::Models::Permission.create(repository: repo, user: repo.owner, pull: true, push: true) }
+    before        { Travis::API::V3::Permissions::Job.any_instance.stubs(:delete_log?).returns(true) }
+    before        { Travis::API::V3::Permissions::Job.any_instance.stubs(:debug?).returns(true) }
+    before        { repo.update_attribute(:private, true)                             }
+    before        { get("/v3/build/#{build.id}/stages", {}, headers)                           }
+    after         { repo.update_attribute(:private, false)                            }
+    example       { expect(last_response).to be_ok                                    }
+    example       { expect(parsed_body).to be == {
+      "@type"=>"stages",
+      "@href"=>"/v3/build/#{build.id}/stages",
+      "@representation"=>"standard",
+      "stages"=>[{
+        "@type"=>"stage",
+        "@representation"=>"standard",
+        "id"=>stages[0].id,
+        "number"=>1,
+        "name"=>"test",
+        "state"=>stages[0].state,
+        "started_at"=>stages[0].started_at,
+        "finished_at"=>stages[0].finished_at,
+        "jobs"=>[{
+          "@type"=>"job",
+          "@href"=>"/v3/job/#{stages[0].jobs[0].id}",
+          "@representation"=>"minimal",
+          "id"=>stages[0].jobs[0].id},
+          {
+          "@type"=>"job",
+          "@href"=>"/v3/job/#{stages[0].jobs[1].id}",
+          "@representation"=>"minimal",
+          "id"=>stages[0].jobs[1].id}]}, {
+        "@type"=>"stage",
+        "@representation"=>"standard",
+        "id"=>stages[1].id,
+        "number"=>2,
+        "name"=>"deploy",
+        "state"=>stages[1].state,
+        "started_at"=>stages[1].started_at,
+        "finished_at"=>stages[1].finished_at,
+        "jobs"=>[{
+          "@type"=>"job",
+          "@href"=>"/v3/job/#{stages[1].jobs[0].id}",
+          "@representation"=>"minimal",
+          "id"=>stages[1].jobs[0].id}, {
+          "@type"=>"job",
+          "@href"=>"/v3/job/#{stages[1].jobs[1].id}",
+          "@representation"=>"minimal",
+          "id"=>stages[1].jobs[1].id}
+        ]}
+      ]}
+    }
+  end
+end


### PR DESCRIPTION
This addresses the issue of timeouts when loading the Build History page in web when a repository has many builds with hundreds of jobs each.
https://github.com/travis-pro/team-teal/issues/2145

It was necessary to implement a `stages` endpoint: `/build/{build.id}/stages`
I also have commented out the filter on `builds` for `build.jobs` as this was the part of the request causing the timeout. (`build.jobs` was necessary in order to find the `build.stages`)

I've added local tests and deployed to staging. The new endpoint works and nothing seems to be effected re `build.jobs`