### PR TITLE
Subscribe to private user channel

### DIFF
--- a/lib/travis/api/serialize/v2/http/user.rb
+++ b/lib/travis/api/serialize/v2/http/user.rb
@@ -7,12 +7,6 @@ module Travis
       module V2
         module Http
           class User
-            class PusherChannels < Struct.new(:user)
-              def channels
-                ["user-#{user.id}"]
-              end
-            end
-
             include Formats
 
             attr_reader :user, :options
@@ -48,7 +42,9 @@ module Travis
               end
 
               def channels
-                PusherChannels.new(user).channels
+                # TODO: once we switch other apps to use private channel
+                # we can drop public channel from here
+                ["user-#{user.id}", "private-user-#{user.id}"]
               end
           end
         end

--- a/spec/integration/v2/users_spec.rb
+++ b/spec/integration/v2/users_spec.rb
@@ -15,7 +15,7 @@ describe 'Users', set_app: true do
 
     it 'fetches a list of channels for a user' do
       response = get "/users/#{user.id}", {}, headers
-      JSON.parse(response.body)['user']['channels'].should == ["user-#{user.id}"]
+      JSON.parse(response.body)['user']['channels'].should == ["user-#{user.id}", "private-user-#{user.id}"]
     end
   end
 

--- a/spec/unit/endpoint/users_spec.rb
+++ b/spec/unit/endpoint/users_spec.rb
@@ -6,8 +6,6 @@ describe Travis::Api::App::Endpoint::Users, set_app: true do
     User.stubs(:find_by_github_id).returns(user)
     User.stubs(:find).returns(user)
     user.stubs(:github_scopes).returns(['public_repo', 'user:email'])
-    pusher_channel_instance = stub('pusher_channel_instance', channels: ['user-1'])
-    Travis::Api::Serialize::V2::Http::User::PusherChannels.stubs(:new).returns(pusher_channel_instance)
   end
 
   it 'needs to be authenticated' do
@@ -28,7 +26,7 @@ describe Travis::Api::App::Endpoint::Users, set_app: true do
       'created_at'     => user.created_at.strftime('%Y-%m-%dT%H:%M:%SZ'),
       'synced_at'      => user.synced_at.strftime('%Y-%m-%dT%H:%M:%SZ'),
       'correct_scopes' => true,
-      'channels'       => ["user-1"]
+      'channels'       => ["user-1", "private-user-1"]
     }
   end
 

--- a/spec/unit/serialize/v2/http/user_spec.rb
+++ b/spec/unit/serialize/v2/http/user_spec.rb
@@ -6,8 +6,6 @@ describe Travis::Api::Serialize::V2::Http::User do
 
   before do
     user.stubs(:github_scopes).returns(['public_repo', 'user:email'])
-    pusher_channel_instance = stub('pusher_channel_instance', channels: ['user-1'])
-    Travis::Api::Serialize::V2::Http::User::PusherChannels.stubs(:new).returns(pusher_channel_instance)
   end
 
   it 'user' do
@@ -23,7 +21,7 @@ describe Travis::Api::Serialize::V2::Http::User do
       'synced_at' => json_format_time(Time.now.utc - 1.hour),
       'correct_scopes' => true,
       'created_at' => json_format_time(Time.now.utc - 2.hours),
-      'channels' => ["user-1"]
+      'channels' => ["user-1", "private-user-1"]
     }
   end
 end


### PR DESCRIPTION
Since the recent switch to per-user channels we always use public user
channel on .org and private user channel on .com. This doesn't make a
lot of sense, especially that when we merge the platforms, we will stay
with only private user channel. To unify the behaviour and simplify the
code in other places, this commit changes API to subscribe user to both
public and private user channels, which will allow to seamlessly switch
the rest of the apps to use private user channel (and then we can drop
public user channel).