### PR TITLE
Only send private user channel from pusher channels

### DIFF
--- a/lib/travis/api/serialize/v2/http/user.rb
+++ b/lib/travis/api/serialize/v2/http/user.rb
@@ -42,9 +42,7 @@ module Travis
               end
 
               def channels
-                # TODO: once we switch other apps to use private channel
-                # we can drop public channel from here
-                ["user-#{user.id}", "private-user-#{user.id}"]
+                ["private-user-#{user.id}"]
               end
           end
         end

--- a/spec/integration/v2/users_spec.rb
+++ b/spec/integration/v2/users_spec.rb
@@ -15,7 +15,7 @@ describe 'Users', set_app: true do
 
     it 'fetches a list of channels for a user' do
       response = get "/users/#{user.id}", {}, headers
-      JSON.parse(response.body)['user']['channels'].should == ["user-#{user.id}", "private-user-#{user.id}"]
+      JSON.parse(response.body)['user']['channels'].should == ["private-user-#{user.id}"]
     end
   end
 

--- a/spec/unit/endpoint/users_spec.rb
+++ b/spec/unit/endpoint/users_spec.rb
@@ -26,7 +26,7 @@ describe Travis::Api::App::Endpoint::Users, set_app: true do
       'created_at'     => user.created_at.strftime('%Y-%m-%dT%H:%M:%SZ'),
       'synced_at'      => user.synced_at.strftime('%Y-%m-%dT%H:%M:%SZ'),
       'correct_scopes' => true,
-      'channels'       => ["user-1", "private-user-1"]
+      'channels'       => ["private-user-1"]
     }
   end
 

--- a/spec/unit/serialize/v2/http/user_spec.rb
+++ b/spec/unit/serialize/v2/http/user_spec.rb
@@ -21,7 +21,7 @@ describe Travis::Api::Serialize::V2::Http::User do
       'synced_at' => json_format_time(Time.now.utc - 1.hour),
       'correct_scopes' => true,
       'created_at' => json_format_time(Time.now.utc - 2.hours),
-      'channels' => ["user-1", "private-user-1"]
+      'channels' => ["private-user-1"]
     }
   end
 end


### PR DESCRIPTION
travis-live already sends messages only to a private channel, so there's
no need to keep the public channel in the response