### PR TITLE
include request_id in 5xx error responses

### DIFF
--- a/lib/travis/api/app/middleware/error_handler.rb
+++ b/lib/travis/api/app/middleware/error_handler.rb
@@ -8,7 +8,12 @@ class Travis::Api::App
       def call(env)
         app.call(env)
       rescue Exception => e
-        [500, {'Content-Type' => 'text/plain'}, ['Sorry, we experienced an error.']]
+        body = "Sorry, we experienced an error.\n"
+        if env['HTTP_X_REQUEST_ID']
+          body += "\n"
+          body += "request_id=#{env['HTTP_X_REQUEST_ID']}\n"
+        end
+        [500, {'Content-Type' => 'text/plain'}, [body]]
       end
     end
   end

--- a/lib/travis/testing/stubs.rb
+++ b/lib/travis/testing/stubs.rb
@@ -121,7 +121,6 @@ module Travis
           commit: '62aae5f70ceee39123ef',
           range: '0cd9ffaab2c4ffee...62aae5f70ceee39123ef',
           branch: 'master',
-          tag_name: nil,
           ref: 'refs/master',
           tag_name: nil,
           message: 'the commit message',

--- a/spec/integration/error_handling_spec.rb
+++ b/spec/integration/error_handling_spec.rb
@@ -40,6 +40,7 @@ describe 'Exception', set_app: true do
   it 'returns request_id in body' do
     error = TestError.new('Konstantin broke all the thingz!')
     Travis::Api::App::Endpoint::Repos.any_instance.stubs(:service).raises(error)
+    Raven.stub(:send_event)
     res = get '/repos/1', 'HTTP_X_REQUEST_ID' => '235dd08f-10d5-4fcc-9a4d-6b8e6a24f975'
     expect(res.status).to eq(500)
     expect(res.body).to eq("Sorry, we experienced an error.\n\nrequest_id=235dd08f-10d5-4fcc-9a4d-6b8e6a24f975\n")

--- a/spec/integration/error_handling_spec.rb
+++ b/spec/integration/error_handling_spec.rb
@@ -29,10 +29,23 @@ describe 'Exception', set_app: true do
     end
     res = get '/repos/1'
     expect(res.status).to eq(500)
-    expect(res.body).to eq('Sorry, we experienced an error.')
+    expect(res.body).to eq("Sorry, we experienced an error.\n")
     expect(res.headers).to eq({
       'Content-Type' => 'text/plain',
-      'Content-Length' => '31',
+      'Content-Length' => '32',
+    })
+    sleep 0.1
+  end
+
+  it 'returns request_id in body' do
+    error = TestError.new('Konstantin broke all the thingz!')
+    Travis::Api::App::Endpoint::Repos.any_instance.stubs(:service).raises(error)
+    res = get '/repos/1', 'HTTP_X_REQUEST_ID' => '235dd08f-10d5-4fcc-9a4d-6b8e6a24f975'
+    expect(res.status).to eq(500)
+    expect(res.body).to eq("Sorry, we experienced an error.\n\nrequest_id=235dd08f-10d5-4fcc-9a4d-6b8e6a24f975\n")
+    expect(res.headers).to eq({
+      'Content-Type' => 'text/plain',
+      'Content-Length' => '81',
     })
     sleep 0.1
   end

--- a/spec/integration/error_handling_spec.rb
+++ b/spec/integration/error_handling_spec.rb
@@ -40,13 +40,14 @@ describe 'Exception', set_app: true do
   it 'returns request_id in body' do
     error = TestError.new('Konstantin broke all the thingz!')
     Travis::Api::App::Endpoint::Repos.any_instance.stubs(:service).raises(error)
-    Raven.stub(:send_event)
-    res = get '/repos/1', 'HTTP_X_REQUEST_ID' => '235dd08f-10d5-4fcc-9a4d-6b8e6a24f975'
+    Raven.stubs(:send_event)
+    res = get '/repos/1', nil, 'HTTP_X_REQUEST_ID' => '235dd08f-10d5-4fcc-9a4d-6b8e6a24f975'
     expect(res.status).to eq(500)
     expect(res.body).to eq("Sorry, we experienced an error.\n\nrequest_id=235dd08f-10d5-4fcc-9a4d-6b8e6a24f975\n")
     expect(res.headers).to eq({
       'Content-Type' => 'text/plain',
       'Content-Length' => '81',
+      'X-Request-ID' => '235dd08f-10d5-4fcc-9a4d-6b8e6a24f975',
     })
     sleep 0.1
   end


### PR DESCRIPTION
This allows users to make reports with that id, that we can correlate in sentry to get the actual exception.