### PR TITLE
Sort branches by `last_build.started_at NULLS LAST`

### DIFF
--- a/lib/travis/api/v3/queries/branches.rb
+++ b/lib/travis/api/v3/queries/branches.rb
@@ -3,7 +3,7 @@ module Travis::API::V3
     params :exists_on_github, prefix: :branch
 
     sortable_by :name,
-      last_build:       "builds.started_at".freeze,
+      last_build:       "builds.started_at %{order}  NULLS LAST".freeze,
       exists_on_github: sort_condition(:exists_on_github),
       default_branch:   sort_condition(name: "repositories.default_branch")
 

--- a/spec/v3/services/branches/find_spec.rb
+++ b/spec/v3/services/branches/find_spec.rb
@@ -170,6 +170,34 @@ describe Travis::API::V3::Services::Branches::Find, set_app: true do
     }
   end
 
+  describe "sorting by last_build" do
+    let!(:repository) { FactoryGirl.create(:repository) }
+    let!(:build1) { FactoryGirl.create(:v3_build, started_at: Time.now) }
+    let!(:build2) { FactoryGirl.create(:v3_build, started_at: Time.now - 10.seconds) }
+    let!(:build3) { FactoryGirl.create(:v3_build, started_at: nil) }
+    let!(:branch1) { FactoryGirl.create(:branch, name: 'newer', last_build: build1, repository: repository) }
+    let!(:branch2) { FactoryGirl.create(:branch, name: 'older', last_build: build2, repository: repository) }
+    let!(:branch3) { FactoryGirl.create(:branch, name: 'not-started', last_build: build3, repository: repository) }
+
+    context 'desc' do
+      before  { get("/v3/repo/#{repo.id}/branches?sort_by=last_build:desc&limit=10") }
+      example { expect(last_response).to be_ok }
+      example {
+        branch_names = parsed_body["branches"].map { |branch| branch['name'] }
+        expect(branch_names).to be == ['newer', 'older', 'not-started']
+      }
+    end
+
+    context 'asc' do
+      before  { get("/v3/repo/#{repo.id}/branches?sort_by=last_build:asc&limit=10") }
+      example { expect(last_response).to be_ok }
+      example {
+        branch_names = parsed_body["branches"].map { |branch| branch['name'] }
+        expect(branch_names).to be == ['older', 'newer', 'not-started']
+      }
+    end
+  end
+
   describe "sorting by name:desc" do
     before  { get("/v3/repo/#{repo.id}/branches?sort_by=name%3Adesc&limit=1") }
     example { expect(last_response).to be_ok }


### PR DESCRIPTION
Sorting without `NULLS LAST` results with not started builds on the beginning, which isn't really something that we want.