### PR TITLE
Sort branches.last_build by last_build.id

### DIFF
--- a/lib/travis/api/v3/queries/branches.rb
+++ b/lib/travis/api/v3/queries/branches.rb
@@ -3,7 +3,7 @@ module Travis::API::V3
     params :exists_on_github, prefix: :branch
 
     sortable_by :name,
-      last_build:       "builds.started_at %{order}  NULLS LAST".freeze,
+      last_build:       "builds.id".freeze,
       exists_on_github: sort_condition(:exists_on_github),
       default_branch:   sort_condition(name: "repositories.default_branch")
 

--- a/spec/v3/services/branches/find_spec.rb
+++ b/spec/v3/services/branches/find_spec.rb
@@ -172,19 +172,18 @@ describe Travis::API::V3::Services::Branches::Find, set_app: true do
 
   describe "sorting by last_build" do
     let!(:repository) { FactoryGirl.create(:repository) }
-    let!(:build1) { FactoryGirl.create(:v3_build, started_at: Time.now) }
-    let!(:build2) { FactoryGirl.create(:v3_build, started_at: Time.now - 10.seconds) }
-    let!(:build3) { FactoryGirl.create(:v3_build, started_at: nil) }
-    let!(:branch1) { FactoryGirl.create(:branch, name: 'newer', last_build: build1, repository: repository) }
-    let!(:branch2) { FactoryGirl.create(:branch, name: 'older', last_build: build2, repository: repository) }
-    let!(:branch3) { FactoryGirl.create(:branch, name: 'not-started', last_build: build3, repository: repository) }
+    let!(:build1) { FactoryGirl.create(:v3_build) }
+    let!(:build2) { FactoryGirl.create(:v3_build) }
+    let!(:branch1) { FactoryGirl.create(:branch, name: 'older', last_build: build1, repository: repository) }
+    let!(:branch2) { FactoryGirl.create(:branch, name: 'newer', last_build: build2, repository: repository) }
+    let!(:branch3) { FactoryGirl.create(:branch, name: 'no-builds', last_build: nil, repository: repository) }
 
     context 'desc' do
       before  { get("/v3/repo/#{repo.id}/branches?sort_by=last_build:desc&limit=10") }
       example { expect(last_response).to be_ok }
       example {
         branch_names = parsed_body["branches"].map { |branch| branch['name'] }
-        expect(branch_names).to be == ['newer', 'older', 'not-started']
+        expect(branch_names).to be == ['newer', 'older']
       }
     end
 
@@ -193,7 +192,7 @@ describe Travis::API::V3::Services::Branches::Find, set_app: true do
       example { expect(last_response).to be_ok }
       example {
         branch_names = parsed_body["branches"].map { |branch| branch['name'] }
-        expect(branch_names).to be == ['older', 'newer', 'not-started']
+        expect(branch_names).to be == ['older', 'newer']
       }
     end
   end


### PR DESCRIPTION
After I committed 755b831 I realised that this is still not right. When
you restart a job and cancel it right away, started_at will be set to
null, so even though the build might be new, the branch will be put at
the end of the results. Even if we defaulted to the previous behaviour
of NULLs going to the beginning, it would still not be entirely right,
because an old branch with a cancelled build could come up on top.
Sorting by id seems like a best way to achieve what we want, ie. sort by
the most recent build.