### PR TITLE
Add private log token

### DIFF
--- a/lib/travis/api/v3/access_control.rb
+++ b/lib/travis/api/v3/access_control.rb
@@ -3,9 +3,15 @@ module Travis::API::V3
     REGISTER = {}
 
     def self.new(env)
-      type, payload  = env['HTTP_AUTHORIZATION'.freeze].to_s.split(" ", 2)
-      payload      &&= payload.unpack(?m.freeze).first if type == 'basic'.freeze
-      payload      &&= type == 'token'.freeze ? payload.gsub(/^"(.+)"$/, '\1'.freeze) : payload.split(?:.freeze)
+      if token = env['rack.request.query_hash']['log.token']
+        type = 'log.token'
+        payload = token
+      else
+        type, payload  = env['HTTP_AUTHORIZATION'.freeze].to_s.split(" ", 2)
+        payload      &&= payload.unpack(?m.freeze).first if type == 'basic'.freeze
+        payload      &&= type == 'token'.freeze ? payload.gsub(/^"(.+)"$/, '\1'.freeze) : payload.split(?:.freeze)
+      end
+
       modes          = REGISTER.fetch(type, [])
       access_control = modes.inject(nil) { |current, mode| current || mode.for_request(type, payload, env) }
       raise WrongCredentials unless access_control

--- a/lib/travis/api/v3/access_control/log_token.rb
+++ b/lib/travis/api/v3/access_control/log_token.rb
@@ -1,0 +1,36 @@
+require 'travis/api/v3/access_control/generic'
+require 'travis/api/v3/log_token'
+
+module Travis::API::V3
+  class AccessControl::LogToken < AccessControl::Generic
+    auth_type('log.token')
+
+    attr_accessor :token
+
+    def self.for_request(type, token, env)
+      new(token)
+    end
+
+    def initialize(token)
+      self.token = token
+    end
+
+    def logged_in?
+      false
+    end
+
+    def full_access?
+      false
+    end
+
+    def job_visible?(job)
+      token_for_job?(job, token)
+    end
+
+    private
+
+    def token_for_job?(job, token)
+      Travis::API::V3::LogToken.find(token).matches?(job)
+    end
+  end
+end

--- a/lib/travis/api/v3/log_token.rb
+++ b/lib/travis/api/v3/log_token.rb
@@ -1,0 +1,29 @@
+module Travis::API::V3
+  class LogToken
+    attr_accessor :job_id
+
+    def self.find(token)
+      new(redis.get("l:#{token}").to_i)
+    end
+
+    def self.create(job)
+      token = SecureRandom.urlsafe_base64(16)
+      redis.set("l:#{token}", job.id)
+      redis.expire("l:#{token}", 1.day)
+      token
+    end
+
+    def self.redis
+      Thread.current[:redis] ||= ::Redis.connect(url: Travis.config.redis.url)
+    end
+
+    def initialize(job_id)
+      self.job_id = job_id
+    end
+
+    def matches?(job)
+      job_id == job.id
+    end
+
+  end
+end

--- a/lib/travis/api/v3/models/log.rb
+++ b/lib/travis/api/v3/models/log.rb
@@ -6,11 +6,12 @@ module Travis::API::V3::Models
 
     def_delegators :remote_log, :id, :attributes, :archived?
 
-    attr_accessor :remote_log, :archived_content
+    attr_accessor :remote_log, :archived_content, :job
 
-    def initialize(remote_log: nil, archived_content: nil)
+    def initialize(remote_log: nil, archived_content: nil, job: nil)
       @remote_log = remote_log
       @archived_content = archived_content
+      @job = job
     end
 
     def content
@@ -20,6 +21,10 @@ module Travis::API::V3::Models
     def log_parts
       return remote_log.log_parts if archived_content.nil?
       [archived_log_part]
+    end
+
+    def repository_private?
+      job.repository.private?
     end
 
     private

--- a/lib/travis/api/v3/queries/log.rb
+++ b/lib/travis/api/v3/queries/log.rb
@@ -4,7 +4,7 @@ module Travis::API::V3
       @job = job
       remote_log = Travis::RemoteLog.find_by_job_id(@job.id)
       raise EntityMissing, 'log not found'.freeze if remote_log.nil?
-      log = Travis::API::V3::Models::Log.new(remote_log: remote_log)
+      log = Travis::API::V3::Models::Log.new(remote_log: remote_log, job: job)
       # if the log has been archived, go to s3
       if log.archived?
         content = fetch.first

--- a/lib/travis/api/v3/renderer/log.rb
+++ b/lib/travis/api/v3/renderer/log.rb
@@ -10,15 +10,15 @@ module Travis::API::V3
     def render(representation)
       result = super
 
-      raw_url = "#{href}.txt"
-      if raw_url !~ /^\/v3/
-        raw_url = "/v3#{raw_url}"
+      raw_log_href = "#{href}.txt"
+      if raw_log_href !~ /^\/v3/
+        raw_log_href = "/v3#{raw_log_href}"
       end
       if model.repository_private?
         token = LogToken.create(model.job)
-        raw_url += "?log.token=#{token}"
+        raw_log_href += "?log.token=#{token}"
       end
-      result['@raw_url'] = raw_url
+      result['@raw_log_href'] = raw_log_href
 
       result
     end

--- a/lib/travis/api/v3/renderer/log.rb
+++ b/lib/travis/api/v3/renderer/log.rb
@@ -11,6 +11,9 @@ module Travis::API::V3
       result = super
 
       raw_url = "#{href}.txt"
+      if raw_url !~ /^\/v3/
+        raw_url = "/v3#{raw_url}"
+      end
       if model.repository_private?
         token = LogToken.create(model.job)
         raw_url += "?log.token=#{token}"

--- a/lib/travis/api/v3/renderer/log.rb
+++ b/lib/travis/api/v3/renderer/log.rb
@@ -1,8 +1,23 @@
+require 'travis/api/v3/log_token'
+
 module Travis::API::V3
   class Renderer::Log < ModelRenderer
     def self.render(model, representation = :standard, **options)
       return super unless options[:accept] == 'text/plain'.freeze
       model.content
+    end
+
+    def render(representation)
+      result = super
+
+      raw_url = "#{href}.txt"
+      if model.repository_private?
+        token = LogToken.create(model.job)
+        raw_url += "?log.token=#{token}"
+      end
+      result['@raw_url'] = raw_url
+
+      result
     end
 
     representation(:minimal, :id)

--- a/lib/travis/api/v3/router.rb
+++ b/lib/travis/api/v3/router.rb
@@ -17,6 +17,9 @@ module Travis::API::V3
       ::Metriks.meter("api.v3.total_requests").mark
 
       return service_index(env) if env['PATH_INFO'.freeze] == ?/.freeze
+
+      process_txt_extension!(env)
+
       metrics         = @metrics_processor.create
       access_control  = AccessControl.new(env)
       env_params      = params(env)
@@ -69,6 +72,14 @@ module Travis::API::V3
       allowed_content_types = [default_content_type, 'text/plain'.freeze]
       content_type = env.fetch('HTTP_ACCEPT'.freeze, default_content_type)
       allowed_content_types.find{ |d| d == content_type} || default_content_type
+    end
+
+    def process_txt_extension!(env)
+      if env['PATH_INFO'] =~ /.txt$/
+        # if the URL ends with .txt we want to overwrite whatever is in Accept
+        # header as usually it's because the URL is opened in the browser
+        env['HTTP_ACCEPT'] = 'text/plain'.freeze
+      end
     end
 
     def params(env)

--- a/lib/travis/api/v3/routes.rb
+++ b/lib/travis/api/v3/routes.rb
@@ -51,6 +51,7 @@ module Travis::API::V3
       resource :log do
         route '/log'
         get   :find
+        get   :find, '.txt'
         delete :delete
       end
 

--- a/lib/travis/api/v3/services/log/find.rb
+++ b/lib/travis/api/v3/services/log/find.rb
@@ -1,5 +1,7 @@
 module Travis::API::V3
   class Services::Log::Find < Service
+    params 'log.token'
+
     def run!
       job = find(:job)
       result query.find(job)

--- a/spec/v3/services/log/find_spec.rb
+++ b/spec/v3/services/log/find_spec.rb
@@ -111,8 +111,9 @@ describe Travis::API::V3::Services::Log::Find, set_app: true do
       before { repo.update_attributes(private: true) }
 
       it 'returns the text version of the log with log token supplied' do
-        get("/v3/job/#{s3log.job.id}/log", {}, headers.merge('HTTP_AUTHORIZATION' => "token #{token}"))
+        get("/job/#{s3log.job.id}/log", {}, headers.merge('HTTP_AUTHORIZATION' => "token #{token}", 'HTTP_TRAVIS_API_VERSION' => '3'))
         raw_url = parsed_body['@raw_url']
+        expect(raw_url).to match(%r{/v3/job/#{s3log.job.id}/log\.txt\?log\.token=})
         get(raw_url, {}, headers)
         expect(last_response.headers).to include('Content-Type' => 'text/plain')
         expect(body).to eq(archived_content)

--- a/spec/v3/services/log/find_spec.rb
+++ b/spec/v3/services/log/find_spec.rb
@@ -99,6 +99,12 @@ describe Travis::API::V3::Services::Log::Find, set_app: true do
         expect(parsed_body['@type']).to eq('log')
         expect(parsed_body['id']).to eq(log_from_api[:id])
       end
+
+      it 'returns the text version of the log' do
+        get("/v3/job/#{s3log.job.id}/log.txt", {}, headers)
+        expect(last_response.headers).to include('Content-Type' => 'text/plain')
+        expect(body).to eq(archived_content)
+      end
     end
 
     describe 'when repo is private' do

--- a/spec/v3/services/log/find_spec.rb
+++ b/spec/v3/services/log/find_spec.rb
@@ -112,9 +112,9 @@ describe Travis::API::V3::Services::Log::Find, set_app: true do
 
       it 'returns the text version of the log with log token supplied' do
         get("/job/#{s3log.job.id}/log", {}, headers.merge('HTTP_AUTHORIZATION' => "token #{token}", 'HTTP_TRAVIS_API_VERSION' => '3'))
-        raw_url = parsed_body['@raw_url']
-        expect(raw_url).to match(%r{/v3/job/#{s3log.job.id}/log\.txt\?log\.token=})
-        get(raw_url, {}, headers)
+        raw_log_href = parsed_body['@raw_log_href']
+        expect(raw_log_href).to match(%r{/v3/job/#{s3log.job.id}/log\.txt\?log\.token=})
+        get(raw_log_href, {}, headers)
         expect(last_response.headers).to include('Content-Type' => 'text/plain')
         expect(body).to eq(archived_content)
       end
@@ -153,7 +153,7 @@ describe Travis::API::V3::Services::Log::Find, set_app: true do
           '@type' => 'log',
           '@href' => "/v3/job/#{s3job.id}/log",
           '@representation' => 'standard',
-          '@raw_url' => "/v3/job/#{s3job.id}/log.txt",
+          '@raw_log_href' => "/v3/job/#{s3job.id}/log.txt",
           '@permissions' => {
             'read' => true,
             'debug' => false,


### PR DESCRIPTION
This PR adds a feature that we have in V2, but is missing from V3 - ability to fetch private logs with a supplied token. Whenever we return a log response it will now contain `@raw_url`, which will lead to a text version of the log and which will contain a token for private version. I needed to use `log.token` instead of just `token` in the query params, because otherwise V2 picks it up. That doesn't really matter much, though, because since we return the full URL we can rename the query param later without breaking stuff.