### PR TITLE
`/jobs` endpoint

### DIFF
--- a/lib/travis/api/v3/queries/jobs.rb
+++ b/lib/travis/api/v3/queries/jobs.rb
@@ -1,7 +1,42 @@
 module Travis::API::V3
   class Queries::Jobs < Query
+    params :state, :created_by, :active, prefix: :job
+    sortable_by :id
+    default_sort "id:desc"
+
     def find(build)
       build.jobs
     end
+
+    def filter(relation)
+      relation = relation.where(state: active_states) if bool(active)
+      relation = relation.where(state: list(state))   if state
+      relation = for_owner(relation)                  if created_by
+
+      relation = relation.includes(:build)
+      relation
+    end
+
+    def for_owner(relation)
+      users = V3::Models::User.where(login: list(created_by)).pluck(:id)
+      orgs = V3::Models::Organization.where(login: list(created_by)).pluck(:id)
+
+      relation.where(%Q((builds.sender_type = 'User' AND builds.sender_id IN (?))
+                     OR (builds.sender_type = 'Organization' AND builds.sender_id IN (?))), users, orgs)
+    end
+
+    def for_user(user)
+      repositories = V3::Models::Permission.where(["permissions.user_id = ?", user.id]).select(:repository_id)
+      jobs = V3::Models::Job.where(repository_id: repositories)
+      result = sort filter(jobs)
+
+      result
+    end
+
+
+    private
+      def active_states
+        ['created', 'queued', 'received', 'started']
+      end
   end
 end

--- a/lib/travis/api/v3/routes.rb
+++ b/lib/travis/api/v3/routes.rb
@@ -32,6 +32,11 @@ module Travis::API::V3
       get :for_current_user
     end
 
+    resource :jobs do
+      route '/jobs'
+      get :for_current_user
+    end
+
     resource :cron do
       capture id: :digit
       route '/cron/{cron.id}'

--- a/lib/travis/api/v3/services/active/for_current_user.rb
+++ b/lib/travis/api/v3/services/active/for_current_user.rb
@@ -1,0 +1,10 @@
+module Travis::API::V3
+  class Services::Builds::ForCurrentUser < Service
+    paginate(default_limit: 100)
+
+    def run!
+      raise LoginRequired unless access_control.logged_in?
+      result query.active_for_user(access_control.user)
+    end
+  end
+end

--- a/lib/travis/api/v3/services/jobs/for_current_user.rb
+++ b/lib/travis/api/v3/services/jobs/for_current_user.rb
@@ -1,0 +1,11 @@
+module Travis::API::V3
+  class Services::Jobs::ForCurrentUser < Service
+    params :active, :created_by, :state, prefix: :job
+    paginate(default_limit: 100)
+
+    def run!
+      raise LoginRequired unless access_control.logged_in?
+      result query.for_user(access_control.user)
+    end
+  end
+end

--- a/spec/v3/services/jobs/find_for_current_user_spec.rb
+++ b/spec/v3/services/jobs/find_for_current_user_spec.rb
@@ -1,0 +1,51 @@
+describe Travis::API::V3::Services::Jobs::Find, set_app: true do
+  def create(type, attributes = {})
+    FactoryGirl.create(type, attributes)
+  end
+
+  let!(:repo1)   { create(:repository, owner: user) }
+  let!(:repo2)   { create(:repository, owner: user) }
+  let!(:build1)  { create(:build, repository: repo1) }
+  let!(:build2)  { create(:build, repository: repo2, sender_id: other_user.id, sender_type: 'User') }
+  let!(:other_repo) { create(:repository) }
+  let!(:other_build) { create(:build, repository: other_repo) }
+  let!(:user)    { create(:user) }
+  let!(:other_user) { create(:user, login: 'a-feminist') }
+  let(:parsed_body) { JSON.load(body) }
+
+  before do
+    Travis::API::V3::Models::Permission.create!(user: user, repository: repo1)
+    Travis::API::V3::Models::Permission.create!(user: user, repository: repo2)
+  end
+
+  describe 'for current user' do
+    let(:token)   { Travis::Api::App::AccessToken.create(user: user, app_id: 1) }
+    let(:headers) {{ 'HTTP_AUTHORIZATION' => "token #{token}" }}
+    it 'returns jobs that belong to current user' do
+      get("/v3/jobs", {}, headers)
+
+      job_ids = parsed_body['jobs'].map { |j| j['id'] }
+      expect(job_ids).to eq([build2.matrix.first.id, build1.matrix.first.id])
+    end
+
+    it 'returns jobs sent by a user when created_by is passed' do
+      get("/v3/jobs?created_by=a-feminist", {}, headers)
+
+      job_ids = parsed_body['jobs'].map { |j| j['id'] }
+      expect(job_ids).to eq([build2.matrix.first.id])
+    end
+
+    context "with active jobs" do
+      before do
+        build1.matrix.first.update_attributes(state: 'started')
+      end
+
+      it "returns only active jobs when active=true is passed" do
+        get("/v3/jobs?active=true", {}, headers)
+
+        job_ids = parsed_body['jobs'].map { |j| j['id'] }
+        expect(job_ids).to eq([build1.matrix.first.id])
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR adds a `/jobs` endpoint that returns jobs from repositories to which a user has access. It can be filtered using `active` param, which will return only jobs that are currently "active", ie. either queued or running.