### PR TITLE
Properly check beta_features visibility

### DIFF
--- a/lib/travis/api/v3/services/beta_feature/delete.rb
+++ b/lib/travis/api/v3/services/beta_feature/delete.rb
@@ -2,7 +2,12 @@ module Travis::API::V3
   class Services::BetaFeature::Delete < Service
     def run!
       user = check_login_and_find(:user)
+      not_found(false, :beta_feature) unless beta_feature_visible?(user)
       result query.delete(user)
+    end
+
+    def beta_feature_visible?(user)
+      access_control.visible? user, :beta_feature
     end
   end
 end

--- a/lib/travis/api/v3/services/beta_feature/update.rb
+++ b/lib/travis/api/v3/services/beta_feature/update.rb
@@ -5,7 +5,12 @@ module Travis::API::V3
 
     def run!
       user = check_login_and_find(:user)
+      not_found(false, :beta_feature) unless beta_feature_visible?(user)
       result query.update(user)
+    end
+
+    def beta_feature_visible?(user)
+      access_control.visible? user, :beta_feature
     end
   end
 end

--- a/lib/travis/api/v3/services/beta_features/find.rb
+++ b/lib/travis/api/v3/services/beta_features/find.rb
@@ -2,7 +2,12 @@ module Travis::API::V3
   class Services::BetaFeatures::Find < Service
     def run!
       user = check_login_and_find(:user)
+      not_found(false, :beta_features) unless beta_features_visible?(user)
       result query.find(user)
+    end
+
+    def beta_features_visible?(user)
+      access_control.visible? user, :beta_features
     end
   end
 end

--- a/spec/v3/services/beta_feature/delete_spec.rb
+++ b/spec/v3/services/beta_feature/delete_spec.rb
@@ -11,6 +11,14 @@ describe Travis::API::V3::Services::BetaFeature::Delete, set_app: true do
     include_examples 'not authenticated'
   end
 
+  describe 'authenticated, other user' do
+    let(:other_user) { FactoryGirl.create(:user, login: 'noone') }
+    let(:token) { Travis::Api::App::AccessToken.create(user: other_user, app_id: 1) }
+    let(:auth_headers) { { 'HTTP_AUTHORIZATION' => "token #{token}" } }
+    before { patch("/v3/user/#{user.id}/beta_feature/#{beta_feature.id}", {}, auth_headers) }
+    include_examples 'missing beta_feature'
+  end
+
   context 'authenticated, right permissions' do
     describe 'missing user' do
       before { delete("/v3/user/999999999/beta_feature/#{beta_feature.id}", {}, auth_headers) }

--- a/spec/v3/services/beta_feature/update_spec.rb
+++ b/spec/v3/services/beta_feature/update_spec.rb
@@ -17,6 +17,14 @@ describe Travis::API::V3::Services::BetaFeature::Update, set_app: true do
     include_examples 'missing user'
   end
 
+  describe 'authenticated, other user' do
+    let(:other_user) { FactoryGirl.create(:user, login: 'noone') }
+    let(:token) { Travis::Api::App::AccessToken.create(user: other_user, app_id: 1) }
+    let(:auth_headers) { { 'HTTP_AUTHORIZATION' => "token #{token}" } }
+    before { patch("/v3/user/#{user.id}/beta_feature/#{beta_feature.id}", {}, auth_headers) }
+    include_examples 'missing beta_feature'
+  end
+
   describe 'authenticated, existing user, missing beta feature' do
     before { patch("/v3/user/#{user.id}/beta_feature/foo", {}, auth_headers) }
     example { expect(last_response.status).to eq(404) }

--- a/spec/v3/services/beta_features/find_spec.rb
+++ b/spec/v3/services/beta_features/find_spec.rb
@@ -5,6 +5,7 @@ describe Travis::API::V3::Services::BetaFeatures::Find, set_app: true do
   let(:token) { Travis::Api::App::AccessToken.create(user: user, app_id: 1) }
   let(:beta_feature) { Travis::API::V3::Models::BetaFeature.create(name: 'FOO3', description: "Bar Baz.", feedback_url: "http://thisisgreat.com")}
   let(:auth_headers) { { 'HTTP_AUTHORIZATION' => "token #{token}" } }
+  let(:other_user) { FactoryGirl.create(:user, login: 'noone') }
 
   describe 'not authenticated' do
     before { get("/v3/user/#{user.id}/beta_features") }
@@ -14,6 +15,13 @@ describe Travis::API::V3::Services::BetaFeatures::Find, set_app: true do
   describe 'authenticated, missing user' do
     before { get("/v3/user/999999999/beta_features", {}, auth_headers) }
     include_examples 'missing user'
+  end
+
+  describe 'authenticated, different user\'s beta feauters' do
+    before do
+      get("/v3/user/#{other_user.id}/beta_features", {}, auth_headers)
+    end
+    example { expect(last_response.status).to eq(404) }
   end
 
   describe 'authenticated, existing user, no beta features' do


### PR DESCRIPTION
Checking only for user visibility is not enough as it will be true for
all of the logged in users, that's why we need to explicitly check for
beta_features visibility.