### PR TITLE
Raise exceptions when testing

### DIFF
--- a/lib/travis.rb
+++ b/lib/travis.rb
@@ -6,6 +6,8 @@ require 'travis/errors'
 
 module Travis
   class << self
+    attr_accessor :testing
+
     def services=(services)
       @services = services
     end

--- a/lib/travis/api/app/middleware/error_handler.rb
+++ b/lib/travis/api/app/middleware/error_handler.rb
@@ -8,6 +8,8 @@ class Travis::Api::App
       def call(env)
         app.call(env)
       rescue Exception => e
+        raise if Travis.testing
+
         body = "Sorry, we experienced an error.\n"
         if env['HTTP_X_REQUEST_ID']
           body += "\n"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -65,6 +65,7 @@ RSpec.configure do |c|
   c.include TestHelpers
 
   c.before :suite do
+    Travis.testing = true
     Travis.logger = Logger.new(StringIO.new)
     Travis::Api::App.setup
     Travis.config.client_domain = "www.example.com"


### PR DESCRIPTION
Every time I work in API the first thing I do is to go to the [error handler middleware](https://github.com/travis-ci/travis-api/blob/8fac307ad258becd0a1b2c44c1b257232d7d65b0/lib/travis/api/app/middleware/error_handler.rb#L10) and remove the rescue part, so I get actual exceptions when running tests rather than the `Sorry, we experienced an error` response. So, I decided that I need to finally fix it for everyone.