### PR TITLE
Request relation with repository is duped

### DIFF
--- a/lib/travis/model/request.rb
+++ b/lib/travis/model/request.rb
@@ -38,7 +38,6 @@ class Request < Travis::Model
   belongs_to :pull_request
   belongs_to :repository
   belongs_to :owner, polymorphic: true
-  belongs_to :repository
   has_many   :builds
   has_many   :events, as: :source
 


### PR DESCRIPTION
Taking a look at the code, I've found that there are two defined
relations with the repository model. I've read the request model in
travis-core and there it has only one of it so it seems like a typo
or mistake