### PR TITLE
Avoid N+1 queries problem in /builds/:id/jobs

### DIFF
--- a/lib/travis/api/v3/queries/jobs.rb
+++ b/lib/travis/api/v3/queries/jobs.rb
@@ -5,7 +5,9 @@ module Travis::API::V3
     default_sort "id:desc"
 
     def find(build)
-      build.jobs
+      relation = build.jobs
+      relation = relation.includes(:commit) if includes? 'job.commit'.freeze
+      relation
     end
 
     def filter(relation)
@@ -14,6 +16,7 @@ module Travis::API::V3
       relation = for_owner(relation)                  if created_by
 
       relation = relation.includes(:build)
+      relation = relation.includes(:commit) if includes? 'job.commit'.freeze
       relation
     end
 


### PR DESCRIPTION
We should always include build when fetching jobs and commit if it's in
an `include` query param