### PR TITLE
Add `eql_json` rspec matcher

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -62,6 +62,7 @@ group :test do
   gem 'database_cleaner', '~> 0.8.0'
   gem 'timecop',       '~> 0.8.0'
   gem 'webmock'
+  gem 'hashdiff'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -410,6 +410,7 @@ DEPENDENCIES
   faraday_middleware
   foreman
   gh!
+  hashdiff
   jemalloc
   knapsack
   libhoney!

--- a/lib/travis/testing/matchers.rb
+++ b/lib/travis/testing/matchers.rb
@@ -1,3 +1,5 @@
+require 'hashdiff'
+
 # RSpec::Matchers.define :serve_result_image do |result|
 #   match do |request|
 #     path = "#{Rails.root}/public/images/result/#{result}.png"
@@ -48,3 +50,34 @@ RSpec::Matchers.define :publish_instrumentation_event do |data|
     non_matching.empty? && missing_keys.empty?
   end
 end
+
+RSpec::Matchers.define :eql_json do |expected|
+  match do |actual|
+    actual == expected
+  end
+
+  failure_message_for_should do |actual|
+    message = "expected to match JSON:\n"
+    diff = HashDiff.diff(expected, actual)
+    diff_messages = diff.map do |type, path, a, b|
+      if type == '-'
+        "missing #{path} == #{a}"
+      elsif type == '+'
+        "extra entry #{path} == #{a}"
+      elsif type == '~'
+        "entries @#{path} do not match, expected: #{a}, actual: #{b}"
+      else
+        raise 'this should not happen'
+      end
+    end
+
+    message << diff_messages.map { |m| "  #{m}" }.join("\n")
+    message
+  end
+
+  description do
+    "equal JSON"
+  end
+end
+
+

--- a/spec/v3/services/branches/find_spec.rb
+++ b/spec/v3/services/branches/find_spec.rb
@@ -13,18 +13,18 @@ describe Travis::API::V3::Services::Branches::Find, set_app: true do
   describe "fetching branches on a non-existing repository by slug" do
     before  { get("/v3/repo/svenfuchs%2Fminimal1/branches")     }
     example { expect(last_response).to be_not_found }
-    example { expect(parsed_body).to be == {
+    example { expect(parsed_body).to eql_json({
       "@type"         => "error",
       "error_type"    => "not_found",
       "error_message" => "repository not found (or insufficient access)",
       "resource_type" => "repository"
-    }}
+    })}
   end
 
   describe "builds on public repository" do
     before     { get("/v3/repo/#{repo.id}/branches?limit=1") }
     example    { expect(last_response).to be_ok }
-    example    { expect(parsed_body).to be == {
+    example    { expect(parsed_body).to eql_json({
       "@type"              => "branches",
       "@href"              => "/v3/repo/#{repo.id}/branches?limit=1",
       "@representation"    => "standard",
@@ -71,7 +71,7 @@ describe Travis::API::V3::Services::Branches::Find, set_app: true do
           "pull_request_number" => build.pull_request_number,
           "pull_request_title" => build.pull_request_title,
           "started_at"     => "2010-11-12T13:00:00Z",
-          "finished_at"    => nil }}]}
+          "finished_at"    => nil }}]})
     }
   end
 
@@ -83,7 +83,7 @@ describe Travis::API::V3::Services::Branches::Find, set_app: true do
     before        { get("/v3/repo/#{repo.id}/branches?limit=1", {}, headers)                           }
     after         { repo.update_attribute(:private, false)                            }
     example       { expect(last_response).to be_ok                                    }
-    example    { expect(parsed_body).to be == {
+    example    { expect(parsed_body).to eql_json({
       "@type"              => "branches",
       "@href"              => "/v3/repo/#{repo.id}/branches?limit=1",
       "@representation"    => "standard",
@@ -130,7 +130,7 @@ describe Travis::API::V3::Services::Branches::Find, set_app: true do
           "pull_request_number" => build.pull_request_number,
           "pull_request_title" => build.pull_request_title,
           "started_at"     => "2010-11-12T13:00:00Z",
-          "finished_at"    => nil }}]}
+          "finished_at"    => nil }}]})
     }
   end
 
@@ -151,7 +151,7 @@ describe Travis::API::V3::Services::Branches::Find, set_app: true do
   describe "sorting by name" do
     before  { get("/v3/repo/#{repo.id}/branches?sort_by=name&limit=1") }
     example { expect(last_response).to be_ok }
-    example { expect(parsed_body["@pagination"]).to be == {
+    example { expect(parsed_body["@pagination"]).to eql_json({
         "limit"            => 1,
         "offset"           => 0,
         "count"            => 1,
@@ -166,7 +166,7 @@ describe Travis::API::V3::Services::Branches::Find, set_app: true do
         "last"             => {
           "@href"          => "/v3/repo/#{repo.id}/branches?sort_by=name&limit=1",
           "offset"         => 0,
-          "limit"          => 1 }}
+          "limit"          => 1 }})
     }
   end
 
@@ -200,7 +200,7 @@ describe Travis::API::V3::Services::Branches::Find, set_app: true do
   describe "sorting by name:desc" do
     before  { get("/v3/repo/#{repo.id}/branches?sort_by=name%3Adesc&limit=1") }
     example { expect(last_response).to be_ok }
-    example { expect(parsed_body["@pagination"]).to be == {
+    example { expect(parsed_body["@pagination"]).to eql_json({
         "limit"            => 1,
         "offset"           => 0,
         "count"            => 1,
@@ -215,14 +215,14 @@ describe Travis::API::V3::Services::Branches::Find, set_app: true do
         "last"             => {
           "@href"          => "/v3/repo/#{repo.id}/branches?sort_by=name%3Adesc&limit=1",
           "offset"         => 0,
-          "limit"          => 1 }}
+          "limit"          => 1 }})
     }
   end
 
   describe "sorting by exists_on_github" do
     before  { get("/v3/repo/#{repo.id}/branches?sort_by=exists_on_github&limit=1") }
     example { expect(last_response).to be_ok }
-    example { expect(parsed_body["@pagination"]).to be == {
+    example { expect(parsed_body["@pagination"]).to eql_json({
         "limit"            => 1,
         "offset"           => 0,
         "count"            => 1,
@@ -237,14 +237,14 @@ describe Travis::API::V3::Services::Branches::Find, set_app: true do
         "last"             => {
           "@href"          => "/v3/repo/#{repo.id}/branches?sort_by=exists_on_github&limit=1",
           "offset"         => 0,
-          "limit"          => 1 }}
+          "limit"          => 1 }})
     }
   end
 
   describe "sorting by default_branch" do
     before  { get("/v3/repo/#{repo.id}/branches?sort_by=default_branch&limit=1") }
     example { expect(last_response).to be_ok }
-    example { expect(parsed_body["@pagination"]).to be == {
+    example { expect(parsed_body["@pagination"]).to eql_json({
         "limit"            => 1,
         "offset"           => 0,
         "count"            => 1,
@@ -259,19 +259,19 @@ describe Travis::API::V3::Services::Branches::Find, set_app: true do
         "last"             => {
           "@href"          => "/v3/repo/#{repo.id}/branches?sort_by=default_branch&limit=1",
           "offset"         => 0,
-          "limit"          => 1 }}
+          "limit"          => 1 }})
     }
   end
 
   describe "sorting by unknown sort field" do
     before  { get("/v3/repo/#{repo.id}/branches?sort_by=name:desc,foo&limit=1") }
     example { expect(last_response).to be_ok }
-    example { expect(parsed_body["@warnings"]).to be == [{
+    example { expect(parsed_body["@warnings"]).to eql_json([{
       "@type"       => "warning",
       "message"     => "query value foo for sort_by not a valid sort mode, ignored",
       "warning_type"=> "ignored_value",
       "parameter"   => "sort_by",
       "value"       => "foo"
-    }]}
+    }])}
   end
 end

--- a/spec/v3/services/build/find_spec.rb
+++ b/spec/v3/services/build/find_spec.rb
@@ -21,19 +21,19 @@ describe Travis::API::V3::Services::Build::Find, set_app: true do
   describe "fetching a non-existing build" do
     before     { get("/v3/build/1231987129387218")  }
     example { expect(last_response).to be_not_found }
-    example { expect(parsed_body).to be == {
+    example { expect(parsed_body).to eql_json({
       "@type"         => "error",
       "error_type"    => "not_found",
       "error_message" => "build not found (or insufficient access)",
       "resource_type" => "build"
-    }}
+    })}
   end
 
   describe "build on public repository, no pull access" do
     before     { Travis::API::V3::Models::Permission.create(repository: repo, user: repo.owner, pull: false) }
     before     { get("/v3/build/#{build.id}") }
     example    { expect(last_response).to be_ok }
-    example    { expect(parsed_body).to be == {
+    example    { expect(parsed_body).to eql_json({
       "@type"               => "build",
       "@href"               => "/v3/build/#{build.id}",
       "@representation"     => "standard",
@@ -117,7 +117,7 @@ describe Travis::API::V3::Services::Build::Find, set_app: true do
         "@representation"   => "minimal",
         "id"                => 1,
         "login"             => "svenfuchs"}
-    }}
+    })}
   end
 
   describe "build private repository, private API, authenticated as user with access" do
@@ -128,7 +128,7 @@ describe Travis::API::V3::Services::Build::Find, set_app: true do
     before        { get("/v3/build/#{build.id}", {}, headers) }
     after         { repo.update_attribute(:private, false) }
     example       { expect(last_response).to be_ok  }
-    example    { expect(parsed_body).to be == {
+    example    { expect(parsed_body).to eql_json({
       "@type"               => "build",
       "@href"               => "/v3/build/#{build.id}",
       "@representation"     => "standard",
@@ -208,14 +208,14 @@ describe Travis::API::V3::Services::Build::Find, set_app: true do
         "@representation"   => "minimal",
         "id"                => 1,
         "login"             => "svenfuchs"}
-    }}
+    })}
   end
 
   describe "build on public repository, no pull access" do
     before     { Travis::API::V3::Models::Permission.create(repository: repo, user: repo.owner, pull: false) }
     before     { get("/v3/build/#{build.id}") }
     example    { expect(last_response).to be_ok }
-    example    { expect(parsed_body).to be == {
+    example    { expect(parsed_body).to eql_json({
       "@type"               => "build",
       "@href"               => "/v3/build/#{build.id}",
       "@representation"     => "standard",
@@ -299,7 +299,7 @@ describe Travis::API::V3::Services::Build::Find, set_app: true do
         "@representation"   => "minimal",
         "id"                => 1,
         "login"             => "svenfuchs"}
-    }}
+    })}
   end
 
   describe "build for a tag push event" do
@@ -308,12 +308,12 @@ describe Travis::API::V3::Services::Build::Find, set_app: true do
     before  { get("/v3/build/#{build.id}") }
 
     example { expect(last_response).to be_ok  }
-    example { expect(parsed_body['tag']).to be == {
+    example { expect(parsed_body['tag']).to eql_json({
       "@type"           => "tag",
       "@representation" => "minimal",
       "repository_id"   => 1,
       "name"            => "v1.0.0",
       "last_build_id"   => nil
-    }}
+    })}
   end
 end

--- a/spec/v3/services/builds/find_spec.rb
+++ b/spec/v3/services/builds/find_spec.rb
@@ -22,18 +22,18 @@ describe Travis::API::V3::Services::Builds::Find, set_app: true do
   describe "fetching builds on a non-existing repository by slug" do
     before     { get("/v3/repo/svenfuchs%2Fminimal1/builds")     }
     example { expect(last_response).to be_not_found }
-    example { expect(parsed_body).to be == {
+    example { expect(parsed_body).to eql_json({
       "@type"         => "error",
       "error_type"    => "not_found",
       "error_message" => "repository not found (or insufficient access)",
       "resource_type" => "repository"
-    }}
+    })}
   end
 
   describe "builds on public repository" do
     before     { get("/v3/repo/#{repo.id}/builds?limit=1") }
     example    { expect(last_response).to be_ok }
-    example    { expect(parsed_body).to be == {
+    example    { expect(parsed_body).to eql_json({
       "@type"                 => "builds",
       "@href"                 => "/v3/repo/#{repo.id}/builds?limit=1",
       "@representation"       => "standard",
@@ -141,7 +141,7 @@ describe Travis::API::V3::Services::Builds::Find, set_app: true do
           "id"                => 1,
           "login"             => "svenfuchs"}
       }]
-    }}
+    })}
   end
 
   describe "builds private repository, private API, authenticated as user with access" do
@@ -152,7 +152,7 @@ describe Travis::API::V3::Services::Builds::Find, set_app: true do
     before        { get("/v3/repo/#{repo.id}/builds?limit=1", {}, headers)                           }
     after         { repo.update_attribute(:private, false)                            }
     example       { expect(last_response).to be_ok                                    }
-    example    { expect(parsed_body).to be == {
+    example    { expect(parsed_body).to eql_json({
       "@type"                 => "builds",
       "@href"                 => "/v3/repo/#{repo.id}/builds?limit=1",
       "@representation"       => "standard",
@@ -260,7 +260,7 @@ describe Travis::API::V3::Services::Builds::Find, set_app: true do
           "id"                => 1,
           "login"             => "svenfuchs"}
       }]
-    }}
+    })}
   end
 
   describe "including branch.name params on existing branch" do
@@ -300,12 +300,12 @@ describe Travis::API::V3::Services::Builds::Find, set_app: true do
     before  { get("/v3/repo/svenfuchs%2Fminimal/builds")     }
 
     example { expect(last_response).to be_ok  }
-    example { expect(parsed_body['builds'][0]['tag']).to be == {
+    example { expect(parsed_body['builds'][0]['tag']).to eql_json({
       "@type"           => "tag",
       "@representation" => "minimal",
       "repository_id"   => 1,
       "name"            => "v1.0.0",
       "last_build_id"   => nil
-    }}
+    })}
   end
 end

--- a/spec/v3/services/builds/for_current_user.rb
+++ b/spec/v3/services/builds/for_current_user.rb
@@ -20,7 +20,7 @@ describe Travis::API::V3::Services::Builds::Find, set_app: true do
     let(:headers) {{ 'HTTP_AUTHORIZATION' => "token #{token}"                        }}
     before        { get("/v3/builds", {}, headers)                           }
     example       { expect(last_response).to be_ok                                    }
-    example    { expect(parsed_body).to be == {
+    example    { expect(parsed_body).to eql_json({
       "@type"                 => "builds",
       "@href"                 => "/v3/builds",
       "@representation"       => "standard",
@@ -124,6 +124,6 @@ describe Travis::API::V3::Services::Builds::Find, set_app: true do
           "id"                => 1,
           "login"             => "svenfuchs"}
       }]
-    }}
+    })}
   end
 end

--- a/spec/v3/services/cron/create_spec.rb
+++ b/spec/v3/services/cron/create_spec.rb
@@ -17,7 +17,7 @@ describe Travis::API::V3::Services::Cron::Create, set_app: true do
     before     { post("/v3/repo/#{repo.id}/branch/#{branch.name}/cron", options, headers) }
     example    { expect(current_cron == last_cron).to be_falsey }
     example    { expect(last_response).to be_ok }
-    example    { expect(parsed_body).to be == {
+    example    { expect(parsed_body).to eql_json({
         "@type"               => "cron",
         "@href"               => "/v3/cron/#{current_cron.id}",
         "@representation"     => "standard",
@@ -43,7 +43,7 @@ describe Travis::API::V3::Services::Cron::Create, set_app: true do
         "last_run"            => current_cron.last_run,
         "next_run"      => current_cron.next_run.strftime('%Y-%m-%dT%H:%M:%SZ'),
         "created_at"          => current_cron.created_at.strftime('%Y-%m-%dT%H:%M:%SZ')
-    }}
+    })}
     example { expect(current_cron.next_run).to_not be nil }
   end
 
@@ -53,7 +53,7 @@ describe Travis::API::V3::Services::Cron::Create, set_app: true do
     before     { post("/v3/repo/#{repo.id}/branch/#{branch.name}/cron", options2, headers) }
     example    { expect(current_cron == last_cron).to be_falsey }
     example    { expect(last_response).to be_ok }
-    example    { expect(parsed_body).to be == {
+    example    { expect(parsed_body).to eql_json({
         "@type"               => "cron",
         "@href"               => "/v3/cron/#{current_cron.id}",
         "@representation"     => "standard",
@@ -79,7 +79,7 @@ describe Travis::API::V3::Services::Cron::Create, set_app: true do
         "last_run"            => current_cron.last_run,
         "next_run"      => current_cron.next_run.strftime('%Y-%m-%dT%H:%M:%SZ'),
         "created_at"          => current_cron.created_at.strftime('%Y-%m-%dT%H:%M:%SZ')
-    }}
+    })}
     example { expect(current_cron.next_run).to_not be nil }
   end
 
@@ -96,36 +96,36 @@ describe Travis::API::V3::Services::Cron::Create, set_app: true do
     before     { last_cron }
     before     { Travis::API::V3::Models::Permission.create(repository: repo, user: repo.owner, push: true) }
     before     { post("/v3/repo/#{repo.id}/branch/#{branch.name}/cron", wrong_options, headers) }
-    example    { expect(parsed_body).to be == {
+    example    { expect(parsed_body).to eql_json({
       "@type"         => "error",
       "error_type"    => "error",
       "error_message" => "Invalid value for interval. Interval must be \"daily\", \"weekly\" or \"monthly\"!"
-    }}
+    })}
   end
 
   describe "creating a cron job on a branch not existing on GitHub" do
     before     { Travis::API::V3::Models::Permission.create(repository: repo, user: repo.owner, push: true) }
     before     { post("/v3/repo/#{repo.id}/branch/#{non_existing_branch.name}/cron", options, headers) }
-    example    { expect(parsed_body).to be == {
+    example    { expect(parsed_body).to eql_json({
       "@type"         => "error",
       "error_type"    => "error",
       "error_message" => "Crons can only be set up for branches existing on GitHub!"
-    }}
+    })}
   end
 
   describe "try creating a cron job without login" do
     before     { post("/v3/repo/#{repo.id}/branch/#{branch.name}/cron", options) }
-    example { expect(parsed_body).to be == {
+    example { expect(parsed_body).to eql_json({
       "@type"         => "error",
       "error_type"    => "login_required",
       "error_message" => "login required"
-    }}
+    })}
   end
 
   describe "try creating a cron job with a user without permissions" do
     before     { Travis::API::V3::Models::Permission.create(repository: repo, user: repo.owner, push: false) }
     before     { post("/v3/repo/#{repo.id}/branch/#{branch.name}/cron", options, headers) }
-    example    { expect(parsed_body).to be == {
+    example    { expect(parsed_body).to eql_json({
         "@type"               => "error",
         "error_type"          => "insufficient_access",
         "error_message"       => "operation requires create_cron access to repository",
@@ -138,31 +138,31 @@ describe Travis::API::V3::Services::Cron::Create, set_app: true do
             "id"              => repo.id,
             "name"            => "minimal",
             "slug"            => "svenfuchs/minimal" }
-    }}
+    })}
   end
 
   describe "creating cron on a non-existing repository by slug" do
     before     { Travis::API::V3::Models::Permission.create(repository: repo, user: repo.owner, push: false) }
     before     { post("/v3/repo/svenfuchs%2Fminimal1/branch/master/cron", options, headers)     }
     example { expect(last_response).to be_not_found }
-    example { expect(parsed_body).to be == {
+    example { expect(parsed_body).to eql_json({
       "@type"         => "error",
       "error_type"    => "not_found",
       "error_message" => "repository not found (or insufficient access)",
       "resource_type" => "repository"
-    }}
+    })}
   end
 
   describe "creating cron on a non-existing branch" do
     before     { Travis::API::V3::Models::Permission.create(repository: repo, user: repo.owner, push: false) }
     before     { post("/v3/repo/#{repo.id}/branch/hopefullyNonExistingBranch/cron", options, headers)     }
     example { expect(last_response).to be_not_found }
-    example { expect(parsed_body).to be == {
+    example { expect(parsed_body).to eql_json({
       "@type"         => "error",
       "error_type"    => "not_found",
       "error_message" => "branch not found (or insufficient access)",
       "resource_type" => "branch"
-    }}
+    })}
   end
 
 end

--- a/spec/v3/services/cron/delete_spec.rb
+++ b/spec/v3/services/cron/delete_spec.rb
@@ -17,18 +17,18 @@ describe Travis::API::V3::Services::Cron::Delete, set_app: true do
   describe "try deleting a cron job without login" do
     before     { delete("/v3/cron/#{cron.id}") }
     example    { expect(Travis::API::V3::Models::Cron.where(id: cron.id)).to exist }
-    example { expect(parsed_body).to be == {
+    example { expect(parsed_body).to eql_json({
       "@type"         => "error",
       "error_type"    => "login_required",
       "error_message" => "login required"
-    }}
+    })}
   end
 
   describe "try deleting a cron job with a user without permissions" do
     before     { Travis::API::V3::Models::Permission.create(repository: repo, user: repo.owner, push: false) }
     before     { delete("/v3/cron/#{cron.id}", {}, headers) }
     example    { expect(Travis::API::V3::Models::Cron.where(id: cron.id)).to exist }
-    example    { expect(parsed_body).to be == {
+    example    { expect(parsed_body).to eql_json({
         "@type"               => "error",
         "error_type"          => "insufficient_access",
         "error_message"       => "operation requires delete access to cron",
@@ -39,18 +39,18 @@ describe Travis::API::V3::Services::Cron::Delete, set_app: true do
             "@href"           => "/v3/cron/#{cron.id}",
             "@representation" => "minimal",
             "id"              => cron.id }
-    }}
+    })}
   end
 
   describe "try deleting a non-existing cron job" do
     before  { Travis::API::V3::Models::Permission.create(repository: repo, user: repo.owner, push: false) }
     before  { delete("/v3/cron/999999999999999", {}, headers) }
-    example { expect(parsed_body).to be == {
+    example { expect(parsed_body).to eql_json({
       "@type"         => "error",
       "error_type"    => "not_found",
       "error_message" => "cron not found (or insufficient access)",
       "resource_type" => "cron"
-    }}
+    })}
   end
 
 end

--- a/spec/v3/services/cron/find_spec.rb
+++ b/spec/v3/services/cron/find_spec.rb
@@ -7,7 +7,7 @@ describe Travis::API::V3::Services::Cron::Find, set_app: true do
   describe "fetching a cron job by id" do
     before     { get("/v3/cron/#{cron.id}") }
     example    { expect(last_response).to be_ok }
-    example    { expect(parsed_body).to be == {
+    example    { expect(parsed_body).to eql_json({
         "@type"               => "cron",
         "@href"               => "/v3/cron/#{cron.id}",
         "@representation"     => "standard",
@@ -33,18 +33,18 @@ describe Travis::API::V3::Services::Cron::Find, set_app: true do
         "last_run"            => cron.last_run,
         "next_run"            => cron.next_run.strftime('%Y-%m-%dT%H:%M:%SZ'),
         "created_at"          => cron.created_at.strftime('%Y-%m-%dT%H:%M:%SZ')
-    }}
+    })}
   end
 
   describe "fetching a non-existing cron job by id" do
     before     { get("/v3/cron/999999999999999")     }
     example { expect(last_response).to be_not_found }
-    example { expect(parsed_body).to be == {
+    example { expect(parsed_body).to eql_json({
       "@type"         => "error",
       "error_type"    => "not_found",
       "error_message" => "cron not found (or insufficient access)",
       "resource_type" => "cron"
-    }}
+    })}
   end
 
   describe "private cron, not authenticated" do
@@ -52,12 +52,12 @@ describe Travis::API::V3::Services::Cron::Find, set_app: true do
     before  { get("/v3/cron/#{cron.id}")             }
     after   { repo.update_attribute(:private, false) }
     example { expect(last_response).to be_not_found  }
-    example { expect(parsed_body).to be == {
+    example { expect(parsed_body).to eql_json({
       "@type"         => "error",
       "error_type"    => "not_found",
       "error_message" => "cron not found (or insufficient access)",
       "resource_type" => "cron"
-    }}
+    })}
   end
 
   describe "private cron, authenticated as user with access" do
@@ -68,7 +68,7 @@ describe Travis::API::V3::Services::Cron::Find, set_app: true do
     before        { get("/v3/cron/#{cron.id}", {}, headers)                           }
     after         { repo.update_attribute(:private, false)                            }
     example       { expect(last_response).to be_ok                                    }
-    example       { expect(parsed_body).to be == {
+    example       { expect(parsed_body).to eql_json({
       "@type"               => "cron",
       "@href"               => "/v3/cron/#{cron.id}",
       "@representation"     => "standard",
@@ -94,7 +94,7 @@ describe Travis::API::V3::Services::Cron::Find, set_app: true do
       "last_run"            => cron.last_run,
       "next_run"            => cron.next_run.strftime('%Y-%m-%dT%H:%M:%SZ'),
       "created_at"          => cron.created_at.strftime('%Y-%m-%dT%H:%M:%SZ')
-    }}
+    })}
   end
 
 end

--- a/spec/v3/services/cron/for_branch_spec.rb
+++ b/spec/v3/services/cron/for_branch_spec.rb
@@ -8,7 +8,7 @@ describe Travis::API::V3::Services::Cron::ForBranch, set_app: true do
     before     { cron }
     before     { get("/v3/repo/#{repo.id}/branch/#{branch.name}/cron")     }
     example    { expect(last_response).to be_ok }
-    example    { expect(parsed_body).to be == {
+    example    { expect(parsed_body).to eql_json({
       "@type"               => "cron",
       "@href"               => "/v3/cron/#{cron.id}",
       "@representation"     => "standard",
@@ -34,29 +34,29 @@ describe Travis::API::V3::Services::Cron::ForBranch, set_app: true do
       "last_run"            => cron.last_run,
       "next_run"            => cron.next_run.strftime('%Y-%m-%dT%H:%M:%SZ'),
       "created_at"          => cron.created_at.strftime('%Y-%m-%dT%H:%M:%SZ')
-    }}
+    })}
   end
 
   describe "fetching crons on a non-existing repository by slug" do
     before  { get("/v3/repo/svenfuchs%2Fminimal1/branch/master/cron") }
     example { expect(last_response).to be_not_found }
-    example { expect(parsed_body).to be == {
+    example { expect(parsed_body).to eql_json({
       "@type"         => "error",
       "error_type"    => "not_found",
       "error_message" => "repository not found (or insufficient access)",
       "resource_type" => "repository"
-    }}
+    })}
   end
 
   describe "fetching crons on a non-existing branch" do
     before  { get("/v3/repo/#{repo.id}/branch/hopefullyNonExistingBranch/cron") }
     example { expect(last_response).to be_not_found }
-    example { expect(parsed_body).to be == {
+    example { expect(parsed_body).to eql_json({
       "@type"         => "error",
       "error_type"    => "not_found",
       "error_message" => "branch not found (or insufficient access)",
       "resource_type" => "branch"
-    }}
+    })}
   end
 
   describe "fetching crons from private repo, not authenticated" do
@@ -64,12 +64,12 @@ describe Travis::API::V3::Services::Cron::ForBranch, set_app: true do
     before  { get("/v3/repo/#{repo.id}/branch/#{branch.name}/cron") }
     after   { repo.update_attribute(:private, false) }
     example { expect(last_response).to be_not_found  }
-    example { expect(parsed_body).to be == {
+    example { expect(parsed_body).to eql_json({
       "@type"         => "error",
       "error_type"    => "not_found",
       "error_message" => "repository not found (or insufficient access)",
       "resource_type" => "repository"
-    }}
+    })}
   end
 
 end

--- a/spec/v3/services/crons/for_repository_spec.rb
+++ b/spec/v3/services/crons/for_repository_spec.rb
@@ -8,7 +8,7 @@ describe Travis::API::V3::Services::Crons::ForRepository, set_app: true do
     before     { cron }
     before     { get("/v3/repo/#{repo.id}/crons")     }
     example    { expect(last_response).to be_ok }
-    example    { expect(parsed_body).to be == {
+    example    { expect(parsed_body).to eql_json({
       "@type"              => "crons",
         "@href"             => "/v3/repo/#{repo.id}/crons",
         "@representation"   => "standard",
@@ -57,18 +57,18 @@ describe Travis::API::V3::Services::Crons::ForRepository, set_app: true do
                 "created_at"          => cron.created_at.strftime('%Y-%m-%dT%H:%M:%SZ')
             }
           ]
-    }}
+    })}
   end
 
   describe "fetching crons on a non-existing repository by slug" do
     before     { get("/v3/repo/svenfuchs%2Fminimal1/crons")     }
     example { expect(last_response).to be_not_found }
-    example { expect(parsed_body).to be == {
+    example { expect(parsed_body).to eql_json({
       "@type"         => "error",
       "error_type"    => "not_found",
       "error_message" => "repository not found (or insufficient access)",
       "resource_type" => "repository"
-    }}
+    })}
   end
 
   describe "fetching crons from private repo, not authenticated" do
@@ -76,12 +76,12 @@ describe Travis::API::V3::Services::Crons::ForRepository, set_app: true do
     before  { get("/v3/repo/#{repo.id}/crons")             }
     after   { repo.update_attribute(:private, false) }
     example { expect(last_response).to be_not_found  }
-    example { expect(parsed_body).to be == {
+    example { expect(parsed_body).to eql_json({
       "@type"         => "error",
       "error_type"    => "not_found",
       "error_message" => "repository not found (or insufficient access)",
       "resource_type" => "repository"
-    }}
+    })}
   end
 
 end

--- a/spec/v3/services/job/find_spec.rb
+++ b/spec/v3/services/job/find_spec.rb
@@ -18,7 +18,7 @@ describe Travis::API::V3::Services::Job::Find, set_app: true do
     before     { Travis::API::V3::Models::Permission.create(repository: repo, user: repo.owner, pull: false) }
     before     { get("/v3/job/#{job.id}")     }
     example    { expect(last_response).to be_ok }
-    example    { expect(parsed_body).to be == {
+    example    { expect(parsed_body).to eql_json({
       "@type"                 => "job",
       "@href"                 => "/v3/job/#{job.id}",
       "@representation"       => "standard",
@@ -80,18 +80,18 @@ describe Travis::API::V3::Services::Job::Find, set_app: true do
         "@representation"     => "minimal",
         "id"                  => owner.id,
         "login"               => owner.login}
-    }}
+    })}
   end
 
   describe "fetching a non-existing job" do
     before     { get("/v3/job/1233456789")     }
     example { expect(last_response).to be_not_found }
-    example { expect(parsed_body).to be == {
+    example { expect(parsed_body).to eql_json({
       "@type"         =>  "error",
       "error_type"    =>  "not_found",
       "error_message" =>  "job not found (or insufficient access)",
       "resource_type" =>  "job"
-    }}
+    })}
   end
 
   describe "fetching job on private repository, private API, authenticated as user with access" do
@@ -103,7 +103,7 @@ describe Travis::API::V3::Services::Job::Find, set_app: true do
     before        { get("/v3/job/#{job.id}", {}, headers)                             }
     after         { repo.update_attribute(:private, false)                            }
     example       { expect(last_response).to be_ok                                    }
-    example       { expect(parsed_body).to be == {
+    example       { expect(parsed_body).to eql_json({
       "@type"                 => "job",
       "@href"                 => "/v3/job/#{job.id}",
       "@representation"       => "standard",
@@ -165,6 +165,6 @@ describe Travis::API::V3::Services::Job::Find, set_app: true do
         "@representation"     => "minimal",
         "id"                  => owner.id,
         "login"               => owner.login}
-    }}
+    })}
   end
 end

--- a/spec/v3/services/jobs/find_spec.rb
+++ b/spec/v3/services/jobs/find_spec.rb
@@ -17,7 +17,7 @@ describe Travis::API::V3::Services::Jobs::Find, set_app: true do
   describe "jobs on public repository" do
     before     { get("/v3/build/#{build.id}/jobs") }
     example    { expect(last_response).to be_ok }
-    example    { expect(parsed_body).to be == {
+    example    { expect(parsed_body).to eql_json({
       "@type"                   => "jobs",
       "@href"                   => "/v3/build/#{build.id}/jobs",
       "@representation"         => "standard",
@@ -270,7 +270,7 @@ describe Travis::API::V3::Services::Jobs::Find, set_app: true do
           "id"                  => 1,
           "login"               => "svenfuchs"}}
         ]
-      }
+      })
     }
   end
 
@@ -282,7 +282,7 @@ describe Travis::API::V3::Services::Jobs::Find, set_app: true do
     before        { get("/v3/build/#{build.id}/jobs", {}, headers)                           }
     after         { repo.update_attribute(:private, false)                            }
     example       { expect(last_response).to be_ok                                    }
-    example    { expect(parsed_body).to be == {
+    example    { expect(parsed_body).to eql_json({
       "@type"                   => "jobs",
       "@href"                   => "/v3/build/#{build.id}/jobs",
       "@representation"         => "standard",
@@ -532,7 +532,7 @@ describe Travis::API::V3::Services::Jobs::Find, set_app: true do
           "id"                  => 1,
           "login"               => "svenfuchs"}}
         ]
-      }
+      })
     }
   end
 
@@ -546,7 +546,7 @@ describe "jobs private repository, private API, authenticated as user with push 
     before        { get("/v3/build/#{build.id}/jobs", {}, headers)                           }
     after         { repo.update_attribute(:private, false)                            }
     example       { expect(last_response).to be_ok                                    }
-    example    { expect(parsed_body).to be == {
+    example    { expect(parsed_body).to eql_json({
       "@type"              => "jobs",
       "@href"              => "/v3/build/#{build.id}/jobs",
       "@representation"    => "standard",
@@ -796,7 +796,7 @@ describe "jobs private repository, private API, authenticated as user with push 
           "id"             =>  1,
           "login"          => "svenfuchs"}}
         ]
-      }
+      })
     }
   end
 end

--- a/spec/v3/services/lint/lint_spec.rb
+++ b/spec/v3/services/lint/lint_spec.rb
@@ -7,26 +7,26 @@ describe Travis::API::V3::Services::Lint::Lint, set_app: true do
   describe "accepts content in parameter" do
     before        { post("v3/lint", content: content )  }
     example       { expect(last_response).to be_ok }
-    example       { expect(parsed_body).to be == {
+    example       { expect(parsed_body).to eql_json({
                     "@type"             =>  "lint",
                     "warnings"          => [{
                       "key"             => [],
                       "message"         => "unexpected key \"foo\", dropping"}, {
                       "key"             => [],
-                      "message"         => "missing key \"language\", defaulting to \"ruby\""}]}
+                      "message"         => "missing key \"language\", defaulting to \"ruby\""}]})
                   }
   end
 
   describe "accepts content as body" do
     before        { post("/v3/lint", content, headers)  }
     example       { expect(last_response).to be_ok }
-    example       { expect(parsed_body).to be == {
+    example       { expect(parsed_body).to eql_json({
                     "@type"             =>  "lint",
                     "warnings"          => [{
                       "key"             => [],
                       "message"         => "unexpected key \"foo\", dropping"}, {
                       "key"             => [],
-                      "message"         => "missing key \"language\", defaulting to \"ruby\""}]}
+                      "message"         => "missing key \"language\", defaulting to \"ruby\""}]})
                   }
   end
 end

--- a/spec/v3/services/repository/find_spec.rb
+++ b/spec/v3/services/repository/find_spec.rb
@@ -64,7 +64,7 @@ describe Travis::API::V3::Services::Repository::Find, set_app: true do
 
   shared_examples '200 standard representation' do |opts|
     example { expect(last_response).to be_ok }
-    example { expect(parsed_body).to be == {
+    example { expect(parsed_body).to eql_json({
       "@type"              => "repository",
       "@href"              => "/v3/repo/#{repo.id}",
       "@representation"    => "standard",
@@ -87,26 +87,26 @@ describe Travis::API::V3::Services::Repository::Find, set_app: true do
         "@representation"  => "minimal",
         "name"             => "master"},
       "starred"            => false,
-    }}
+    })}
   end
 
   shared_examples '404 not found' do
     example { expect(last_response).to be_not_found }
-    example { expect(parsed_body).to be == {
+    example { expect(parsed_body).to eql_json({
       "@type"         => "error",
       "error_type"    => "not_found",
       "error_message" => "repository not found (or insufficient access)",
       "resource_type" => "repository"
-    }}
+    })}
   end
 
   shared_examples '400 wrong params' do |message|
     example { expect(last_response.status).to be == 400 }
-    example { expect(parsed_body).to be == {
+    example { expect(parsed_body).to eql_json({
       "@type"         => "error",
       "error_type"    => "wrong_params",
       "error_message" => message
-    }}
+    })}
   end
 
   describe "fetching a non-existing repository by slug" do

--- a/spec/v3/services/stages/find_spec.rb
+++ b/spec/v3/services/stages/find_spec.rb
@@ -17,7 +17,7 @@ describe Travis::API::V3::Services::Stages::Find, set_app: true do
   describe "stages on public repository" do
     before     { get("/v3/build/#{build.id}/stages") }
     example    { expect(last_response).to be_ok }
-    example       { expect(parsed_body).to be == {
+    example       { expect(parsed_body).to eql_json({
       "@type"=>"stages",
       "@href"=>"/v3/build/#{build.id}/stages",
       "@representation"=>"standard",
@@ -58,7 +58,7 @@ describe Travis::API::V3::Services::Stages::Find, set_app: true do
           "@representation"=>"minimal",
           "id"=>stages[1].jobs[1].id}
         ]}
-      ]}
+      ]})
     }
   end
 
@@ -70,7 +70,7 @@ describe Travis::API::V3::Services::Stages::Find, set_app: true do
     before        { get("/v3/build/#{build.id}/stages", {}, headers)                           }
     after         { repo.update_attribute(:private, false)                            }
     example       { expect(last_response).to be_ok                                    }
-    example       { expect(parsed_body).to be == {
+    example       { expect(parsed_body).to eql_json({
       "@type"=>"stages",
       "@href"=>"/v3/build/#{build.id}/stages",
       "@representation"=>"standard",
@@ -111,7 +111,7 @@ describe Travis::API::V3::Services::Stages::Find, set_app: true do
           "@representation"=>"minimal",
           "id"=>stages[1].jobs[1].id}
         ]}
-      ]}
+      ]})
     }
   end
 
@@ -125,7 +125,7 @@ describe "stages private repository, private API, authenticated as user with pus
     before        { get("/v3/build/#{build.id}/stages", {}, headers)                           }
     after         { repo.update_attribute(:private, false)                            }
     example       { expect(last_response).to be_ok                                    }
-    example       { expect(parsed_body).to be == {
+    example       { expect(parsed_body).to eql_json({
       "@type"=>"stages",
       "@href"=>"/v3/build/#{build.id}/stages",
       "@representation"=>"standard",
@@ -166,7 +166,7 @@ describe "stages private repository, private API, authenticated as user with pus
           "@representation"=>"minimal",
           "id"=>stages[1].jobs[1].id}
         ]}
-      ]}
+      ]})
     }
   end
 end


### PR DESCRIPTION
From the commit message:

```
In API V3 specs we often compare big JSON objects and when 2 objects
don't match, we get a message that's not very helpful: expected (...big
pile of JSON here...) to be equal to (...another big pile of JSON
here...).

This commit introduces eql_json matcher that will return a better
message. For example given the following expectation:

    actual = {
      'job' => {
        'id' => 1,
        'number': '10.1',
        'repository_id': 1
      }
    }

    expect(actual).to eql_json({
      'job' => {
        'id' => 1,
        'number': '11.1',
        'state': 'passed'
      }
    })

The message will be:

    Failure/Error: expect(actual).to eql_json({
      expected to match JSON:
        missing job.state == passed
        entries @job.number do not match, expected: 11.1, actual: 10.1
        extra entry job.repository_id == 1

This makes it much easier to fix any potential problems.
```