### PR TITLE
Return `updated_at` column for jobs and builds

### DIFF
--- a/lib/travis/api/v3/model_renderer.rb
+++ b/lib/travis/api/v3/model_renderer.rb
@@ -128,5 +128,9 @@ module Travis::API::V3
 
       result
     end
+
+    def json_format_time_with_ms(time)
+      time.strftime('%Y-%m-%dT%H:%M:%S.%3NZ')
+    end
   end
 end

--- a/lib/travis/api/v3/renderer/build.rb
+++ b/lib/travis/api/v3/renderer/build.rb
@@ -1,7 +1,7 @@
 module Travis::API::V3
   class Renderer::Build < ModelRenderer
     representation(:minimal,  :id, :number, :state, :duration, :event_type, :previous_state, :pull_request_title, :pull_request_number, :started_at, :finished_at)
-    representation(:standard, *representations[:minimal], :repository, :branch, :tag, :commit, :jobs, :stages, :created_by)
+    representation(:standard, *representations[:minimal], :repository, :branch, :tag, :commit, :jobs, :stages, :created_by, :updated_at)
     representation(:active, *representations[:standard])
 
     hidden_representations(:active)
@@ -25,6 +25,10 @@ module Travis::API::V3
         payload['avatar_url'] = V3::Renderer::AvatarURL.avatar_url(creator) if include?('created_by.avatar_url')
         payload
       end
+    end
+
+    def updated_at
+      json_format_time_with_ms(model.updated_at)
     end
 
     private def created_by_href(creator)

--- a/lib/travis/api/v3/renderer/job.rb
+++ b/lib/travis/api/v3/renderer/job.rb
@@ -1,9 +1,13 @@
 module Travis::API::V3
   class Renderer::Job < ModelRenderer
     representation(:minimal, :id)
-    representation(:standard, *representations[:minimal], :allow_failure, :number, :state, :started_at, :finished_at, :build, :queue, :repository, :commit, :owner, :stage)
+    representation(:standard, *representations[:minimal], :allow_failure, :number, :state, :started_at, :finished_at, :build, :queue, :repository, :commit, :owner, :stage, :updated_at)
     representation(:active, *representations[:standard])
 
     hidden_representations(:active)
+
+    def updated_at
+      json_format_time_with_ms(model.updated_at)
+    end
   end
 end

--- a/spec/lib/services/find_build_spec.rb
+++ b/spec/lib/services/find_build_spec.rb
@@ -26,7 +26,7 @@ describe Travis::Services::FindBuild do
 
   describe 'updated_at' do
     it 'returns builds updated_at attribute' do
-      service.updated_at.to_s.should == build.updated_at.to_s
+      service.updated_at.to_s.should == build.reload.updated_at.to_s
     end
   end
 

--- a/spec/support/formats.rb
+++ b/spec/support/formats.rb
@@ -35,6 +35,10 @@ module Support
     def json_format_time(time)
       time.strftime('%Y-%m-%dT%H:%M:%SZ')
     end
+
+    def json_format_time_with_ms(time)
+      time.strftime('%Y-%m-%dT%H:%M:%S.%3NZ')
+    end
   end
 end
 

--- a/spec/v3/services/build/find_spec.rb
+++ b/spec/v3/services/build/find_spec.rb
@@ -1,4 +1,5 @@
 describe Travis::API::V3::Services::Build::Find, set_app: true do
+  include Support::Formats
   let(:repo)   { Travis::API::V3::Models::Repository.where(owner_name: 'svenfuchs', name: 'minimal').first }
   let(:build)  { repo.builds.first }
   let(:stages) { build.stages }
@@ -11,6 +12,7 @@ describe Travis::API::V3::Services::Build::Find, set_app: true do
     deploy = build.stages.create(number: 2, name: 'deploy')
     build.jobs[0, 2].each { |job| job.update_attributes!(stage: test) }
     build.jobs[2, 2].each { |job| job.update_attributes!(stage: deploy) }
+    build.reload
   end
 
   describe "fetching build on a public repository " do
@@ -51,6 +53,7 @@ describe Travis::API::V3::Services::Build::Find, set_app: true do
       "pull_request_title"  => build.pull_request_title,
       "started_at"          => "2010-11-12T13:00:00Z",
       "finished_at"         => nil,
+      "updated_at"          => json_format_time_with_ms(build.updated_at),
       "jobs"                => [
         {
         "@type"             => "job",
@@ -146,6 +149,7 @@ describe Travis::API::V3::Services::Build::Find, set_app: true do
       "pull_request_title"  => build.pull_request_title,
       "started_at"          => "2010-11-12T13:00:00Z",
       "finished_at"         => nil,
+      "updated_at"          => json_format_time_with_ms(build.updated_at),
       "jobs"                => [{
         "@type"             => "job",
         "@href"             => "/v3/job/#{jobs[0].id}",
@@ -233,6 +237,7 @@ describe Travis::API::V3::Services::Build::Find, set_app: true do
       "pull_request_title"  => build.pull_request_title,
       "started_at"          => "2010-11-12T13:00:00Z",
       "finished_at"         => nil,
+      "updated_at"          => json_format_time_with_ms(build.updated_at),
       "repository"          => {
         "@type"             => "repository",
         "@href"             => "/v3/repo/#{repo.id}",

--- a/spec/v3/services/builds/find_spec.rb
+++ b/spec/v3/services/builds/find_spec.rb
@@ -1,4 +1,5 @@
 describe Travis::API::V3::Services::Builds::Find, set_app: true do
+  include Support::Formats
   let(:repo)   { Travis::API::V3::Models::Repository.where(owner_name: 'svenfuchs', name: 'minimal').first }
   let(:build)  { repo.builds.first }
   let(:stages) { build.stages }
@@ -74,6 +75,7 @@ describe Travis::API::V3::Services::Builds::Find, set_app: true do
         "pull_request_title"  => build.pull_request_title,
         "started_at"          => "2010-11-12T13:00:00Z",
         "finished_at"         => nil,
+        "updated_at"          => json_format_time_with_ms(build.updated_at),
         "repository"          => {
           "@type"             => "repository",
           "@href"             => "/v3/repo/#{repo.id}",
@@ -193,6 +195,7 @@ describe Travis::API::V3::Services::Builds::Find, set_app: true do
         "pull_request_title"  => build.pull_request_title,
         "started_at"          => "2010-11-12T13:00:00Z",
         "finished_at"         => nil,
+        "updated_at"          => json_format_time_with_ms(build.updated_at),
         "repository"          => {
           "@type"             => "repository",
           "@href"             => "/v3/repo/#{repo.id}",

--- a/spec/v3/services/job/find_spec.rb
+++ b/spec/v3/services/job/find_spec.rb
@@ -1,4 +1,5 @@
 describe Travis::API::V3::Services::Job::Find, set_app: true do
+  include Support::Formats
   let(:repo) { Travis::API::V3::Models::Repository.where(owner_name: 'svenfuchs', name: 'minimal').first }
   let(:owner_href)  { repo.owner_type.downcase }
   let(:owner_type)  { repo.owner_type.constantize }
@@ -12,6 +13,10 @@ describe Travis::API::V3::Services::Job::Find, set_app: true do
   before do
     # TODO should this go into the scenario? is it ok to keep it here?
     job.update_attributes!(stage: stage)
+    # for some reason update_attributes! doesn't update updated_at
+    # and it doesn't play well with out triggers (as triggers will update
+    # updated_at and instance variable in tests will have a different value)
+    job.reload
   end
 
   describe "fetching job on a public repository, no pull access" do
@@ -34,6 +39,7 @@ describe Travis::API::V3::Services::Job::Find, set_app: true do
       "state"                 => job.state,
       "started_at"            => "2010-11-12T12:00:00Z",
       "finished_at"           => "2010-11-12T12:00:10Z",
+      "updated_at"            => json_format_time_with_ms(job.updated_at),
       "build"                 => {
         "@type"               => "build",
         "@href"               => "/v3/build/#{build.id}",
@@ -119,6 +125,7 @@ describe Travis::API::V3::Services::Job::Find, set_app: true do
       "state"                 => job.state,
       "started_at"            => "2010-11-12T12:00:00Z",
       "finished_at"           => "2010-11-12T12:00:10Z",
+      "updated_at"            => json_format_time_with_ms(job.updated_at),
       "build"                 => {
         "@type"               => "build",
         "@href"               => "/v3/build/#{build.id}",

--- a/spec/v3/services/jobs/find_spec.rb
+++ b/spec/v3/services/jobs/find_spec.rb
@@ -1,4 +1,5 @@
 describe Travis::API::V3::Services::Jobs::Find, set_app: true do
+  include Support::Formats
   let(:repo)   { Travis::API::V3::Models::Repository.where(owner_name: 'svenfuchs', name: 'minimal').first }
   let(:build)  { repo.builds.first }
   let(:stages) { build.stages }
@@ -12,6 +13,7 @@ describe Travis::API::V3::Services::Jobs::Find, set_app: true do
     deploy = build.stages.create(number: 2, name: 'deploy')
     jobs[0, 2].each { |job| job.update_attributes!(stage: test) }
     jobs[2, 2].each { |job| job.update_attributes!(stage: deploy) }
+    jobs.each(&:reload)
   end
 
   describe "jobs on public repository" do
@@ -32,12 +34,12 @@ describe Travis::API::V3::Services::Jobs::Find, set_app: true do
           "debug"               => false,
           "delete_log"          => false },
         "id"                    => jobs[0].id,
-        "allow_failure"         => jobs[0].allow_failure,
         "number"                => "#{jobs[0].number}",
         "state"                 => "configured",
         "started_at"            => "2010-11-12T13:00:00Z",
         "finished_at"           => nil,
         "allow_failure"         => jobs[0].allow_failure,
+        "updated_at"            => json_format_time_with_ms(jobs[0].updated_at),
         "build"                 => {
           "@type"               => "build",
           "@href"               => "/v3/build/#{build.id}",
@@ -94,12 +96,12 @@ describe Travis::API::V3::Services::Jobs::Find, set_app: true do
           "debug"               => false,
           "delete_log"          => false},
         "id"                    => jobs[1].id,
-        "allow_failure"         => jobs[1].allow_failure,
         "number"                => "#{jobs[1].number}",
         "state"                 => "configured",
         "started_at"            => "2010-11-12T13:00:00Z",
         "finished_at"           => nil,
         "allow_failure"         => jobs[1].allow_failure,
+        "updated_at"            => json_format_time_with_ms(jobs[1].updated_at),
         "build"                 => {
           "@type"               => "build",
           "@href"               => "/v3/build/#{build.id}",
@@ -156,12 +158,12 @@ describe Travis::API::V3::Services::Jobs::Find, set_app: true do
           "debug"               => false,
           "delete_log"          => false},
         "id"                    => jobs[2].id,
-        "allow_failure"         => jobs[2].allow_failure,
         "number"                => "#{jobs[2].number}",
         "state"                 => "configured",
         "started_at"            => "2010-11-12T13:00:00Z",
         "finished_at"           => nil,
         "allow_failure"         => jobs[2].allow_failure,
+        "updated_at"            => json_format_time_with_ms(jobs[2].updated_at),
         "build"                 => {
           "@type"               => "build",
           "@href"               => "/v3/build/#{build.id}",
@@ -223,6 +225,7 @@ describe Travis::API::V3::Services::Jobs::Find, set_app: true do
         "started_at"            => "2010-11-12T13:00:00Z",
         "finished_at"           => nil,
         "allow_failure"         => jobs[3].allow_failure,
+        "updated_at"            => json_format_time_with_ms(jobs[3].updated_at),
         "build"                 => {
           "@type"               => "build",
           "@href"               => "/v3/build/#{build.id}",
@@ -302,6 +305,7 @@ describe Travis::API::V3::Services::Jobs::Find, set_app: true do
         "started_at"            => "2010-11-12T13:00:00Z",
         "finished_at"           => nil,
         "allow_failure"         => jobs[0].allow_failure,
+        "updated_at"            => json_format_time_with_ms(jobs[0].updated_at),
         "build"                 => {
           "@type"               => "build",
           "@href"               => "/v3/build/#{build.id}",
@@ -362,6 +366,7 @@ describe Travis::API::V3::Services::Jobs::Find, set_app: true do
         "state"                 => "configured",
         "started_at"            => "2010-11-12T13:00:00Z",
         "allow_failure"         => jobs[1].allow_failure,
+        "updated_at"            => json_format_time_with_ms(jobs[1].updated_at),
         "finished_at"           => nil,
         "build"                 => {
           "@type"               => "build",
@@ -424,6 +429,7 @@ describe Travis::API::V3::Services::Jobs::Find, set_app: true do
         "started_at"            => "2010-11-12T13:00:00Z",
         "finished_at"           => nil,
         "allow_failure"         => jobs[2].allow_failure,
+        "updated_at"            => json_format_time_with_ms(jobs[2].updated_at),
         "build"                 => {
           "@type"               => "build",
           "@href"               => "/v3/build/#{build.id}",
@@ -485,6 +491,7 @@ describe Travis::API::V3::Services::Jobs::Find, set_app: true do
         "started_at"            => "2010-11-12T13:00:00Z",
         "finished_at"           => nil,
         "allow_failure"         => jobs[3].allow_failure,
+        "updated_at"            => json_format_time_with_ms(jobs[3].updated_at),
         "build"                 => {
           "@type"               => "build",
           "@href"               => "/v3/build/#{build.id}",
@@ -566,6 +573,7 @@ describe "jobs private repository, private API, authenticated as user with push 
         "started_at"       => "2010-11-12T13:00:00Z",
         "finished_at"      => nil,
         "allow_failure"    => jobs[0].allow_failure,
+        "updated_at"       => json_format_time_with_ms(jobs[0].updated_at),
         "build"            => {
           "@type"          => "build",
           "@href"          => "/v3/build/#{build.id}",
@@ -627,6 +635,7 @@ describe "jobs private repository, private API, authenticated as user with push 
         "started_at"       => "2010-11-12T13:00:00Z",
         "finished_at"      => nil,
         "allow_failure"    => jobs[1].allow_failure,
+        "updated_at"       => json_format_time_with_ms(jobs[1].updated_at),
         "build"            => {
           "@type"          => "build",
           "@href"          => "/v3/build/#{build.id}",
@@ -688,6 +697,7 @@ describe "jobs private repository, private API, authenticated as user with push 
         "started_at"       => "2010-11-12T13:00:00Z",
         "finished_at"      => nil,
         "allow_failure"    => jobs[2].allow_failure,
+        "updated_at"       => json_format_time_with_ms(jobs[2].updated_at),
         "build"            => {
           "@type"          => "build",
           "@href"          => "/v3/build/#{build.id}",
@@ -749,6 +759,7 @@ describe "jobs private repository, private API, authenticated as user with push 
         "started_at"       => "2010-11-12T13:00:00Z",
         "finished_at"      => nil,
         "allow_failure"    => jobs[3].allow_failure,
+        "updated_at"       => json_format_time_with_ms(jobs[3].updated_at),
         "build"            => {
           "@type"          => "build",
           "@href"          => "/v3/build/#{build.id}",


### PR DESCRIPTION
From the commit message:

```
API responses and live updates (delivered by Pusher) may sometimes come
to the client out of order. That's why we want to have a way to version
records to be able to compare them and apply only the newest updates.
updated_at column seems like a good way to check record's version, so
this commit adds it to job's and build's payload.

We might consider adding it to other records as well, but for now these
are two most important tables.
```