### PR TITLE
add additional attributes to V3 repo payload

### DIFF
--- a/lib/travis/api/v3/renderer/repository.rb
+++ b/lib/travis/api/v3/renderer/repository.rb
@@ -1,7 +1,7 @@
 module Travis::API::V3
   class Renderer::Repository < ModelRenderer
     representation(:minimal,  :id, :name, :slug)
-    representation(:standard, :id, :name, :slug, :description, :github_language, :active, :private, :owner, :default_branch, :starred)
+    representation(:standard, :id, :name, :slug, :description, :github_language, :active, :private, :owner, :default_branch, :starred, :last_build_number, :last_build_started_at, :last_build_finished_at)
     representation(:experimental, :id, :name, :slug, :description, :github_language, :active, :private, :owner, :default_branch, :starred, :current_build)
 
     hidden_representations(:experimental)

--- a/spec/v3/services/owner/find_spec.rb
+++ b/spec/v3/services/owner/find_spec.rb
@@ -84,7 +84,10 @@ describe Travis::API::V3::Services::Owner::Find, set_app: true do
             "@href"           => "/v3/repo/#{repo.id}/branch/master",
             "@representation" => "minimal",
             "name"            => "master"},
-          "starred"           => false
+          "starred"           => false,
+          "last_build_number" =>nil,
+          "last_build_started_at"=>nil,
+          "last_build_finished_at"=>nil
         }]
       }}
     end
@@ -137,7 +140,10 @@ describe Travis::API::V3::Services::Owner::Find, set_app: true do
             "@href"         => "/v3/repo/#{repo.id}/branch/master",
             "@representation"=> "minimal",
             "name"          => "master"},
-          "starred"         => false
+          "starred"         => false,
+          "last_build_number"=>nil,
+          "last_build_started_at"=>nil,
+          "last_build_finished_at"=>nil
         }]
       }}
     end

--- a/spec/v3/services/repositories/for_current_user_spec.rb
+++ b/spec/v3/services/repositories/for_current_user_spec.rb
@@ -67,6 +67,9 @@ describe Travis::API::V3::Services::Repositories::ForCurrentUser, set_app: true 
           "@representation"  => "minimal",
           "name"             => "master"},
         "starred"            => false,
+        "last_build_number"  => repo.last_build_number,
+        "last_build_started_at"=>repo.last_build_started_at.iso8601,
+        "last_build_finished_at"=>repo.last_build_finished_at.iso8601
         }]
     }}
   end

--- a/spec/v3/services/repositories/for_owner_spec.rb
+++ b/spec/v3/services/repositories/for_owner_spec.rb
@@ -68,6 +68,9 @@ describe Travis::API::V3::Services::Repositories::ForOwner, set_app: true do
           "@representation"  => "minimal",
           "name"             => "master"},
           "starred"          => false,
+          "last_build_number"  => repo.last_build_number,
+        "last_build_started_at"=>repo.last_build_started_at.iso8601,
+        "last_build_finished_at"=>repo.last_build_finished_at.iso8601
         }]}}
   end
 
@@ -149,7 +152,10 @@ describe Travis::API::V3::Services::Repositories::ForOwner, set_app: true do
           "@href"         => "/v3/repo/1/branch/master",
           "@representation"=>"minimal",
           "name"          => "master" },
-        "starred"         => false }, {
+        "starred"         => false,
+        "last_build_number"  => repo.last_build_number,
+        "last_build_started_at"=>repo.last_build_started_at.iso8601,
+        "last_build_finished_at"=>repo.last_build_finished_at.iso8601 }, {
         "@type"           => "repository",
         "@href"           => "/v3/repo/#{repo2.id}",
         "@representation" => "standard",
@@ -183,6 +189,9 @@ describe Travis::API::V3::Services::Repositories::ForOwner, set_app: true do
           "@href"         => "/v3/repo/#{repo2.id}/branch/master",
           "@representation"=>"minimal",
           "name"           =>"master" },
-          "starred"        => false}]}
+          "starred"        => false,
+          "last_build_number"=>nil,
+          "last_build_started_at"=>nil,
+          "last_build_finished_at"=>nil}]}
   end
 end

--- a/spec/v3/services/repository/find_spec.rb
+++ b/spec/v3/services/repository/find_spec.rb
@@ -87,6 +87,9 @@ describe Travis::API::V3::Services::Repository::Find, set_app: true do
         "@representation"  => "minimal",
         "name"             => "master"},
       "starred"            => false,
+      "last_build_number" => repo.last_build_number,
+      "last_build_started_at" => repo.last_build_started_at.iso8601,
+      "last_build_finished_at" => repo.last_build_finished_at.iso8601,
     })}
   end
 
@@ -326,8 +329,8 @@ describe Travis::API::V3::Services::Repository::Find, set_app: true do
   end
 
   describe "including non-existing field" do
-    before { get("/v3/repo/#{repo.id}?include=repository.owner,repository.last_build_number") }
-    include_examples '400 wrong params', 'no field "repository.last_build_number" to include'
+    before { get("/v3/repo/#{repo.id}?include=repository.owner,repository.last_build_state") }
+    include_examples '400 wrong params', 'no field "repository.last_build_state" to include'
   end
 
   describe "wrong include format" do


### PR DESCRIPTION
This was requested by Schibsted in this ticket: https://secure.helpscout.net/conversation/455214628/61801?folderId=304690

It adds `last_build_number`, `last_build_started_at` and `last_build_finished_at` to the standard representation for a repository.

