### PR TITLE
Enable logging and dumping errors in Enterprise for easier debugging

### DIFF
--- a/lib/travis/api/app/base.rb
+++ b/lib/travis/api/app/base.rb
@@ -39,10 +39,17 @@ class Travis::Api::App
       # Being token based makes us invulnerable to common
       # CSRF attack.
       #
-      # Logging is set up by custom middleware
-      disable  :protection, :logging, :setup
+      
+      disable  :protection, :setup
       enable   :raise_errors
-      disable  :dump_errors
+      
+      # Logging is set up by custom middleware in hosted, but in Enterprise we need to dump them
+      if Travis.config.enterprise
+        enable   :logging, :dump_errors
+      else
+        disable  :logging, :dump_errors
+      end 
+      
       register :subclass_tracker, :expose_pattern
       helpers  :respond_with, :mime_types
     end


### PR DESCRIPTION
One of the things we've noticed in Enterprise is that logging is off so it can be difficult to see when things are hitting the API without looking at `nginx.log`. Additionally we've noticed that errors are not dumped properly, causing Sentry to swallow them. This is something that may be in how Sentry is configured (or logging) in `travis-api` vs the rest of the apps. 

This PR attempts to solve this issue by enabling logging and dumping errors in Enterprise only. 

This way we can see more of what's happening and hopefully get to roots of problems sooner. 