### PR TITLE
handle potentially encrypted float values

### DIFF
--- a/lib/travis/model/job.rb
+++ b/lib/travis/model/job.rb
@@ -205,6 +205,7 @@ class Job < Travis::Model
     end
 
     def process_env(env)
+      env = env.to_s if env.is_a?(Float)
       env = [env] unless env.is_a?(Array)
       env = normalize_env(env)
       env = if secure_env_enabled?

--- a/lib/travis/secure_config.rb
+++ b/lib/travis/secure_config.rb
@@ -17,6 +17,7 @@ module Travis
 
     def decrypt(config)
       return config if config.is_a?(String)
+      return config if config.is_a?(Float)
 
       config.inject(config.class.new) do |result, element|
         key, element = element if result.is_a?(Hash)

--- a/lib/travis/secure_config.rb
+++ b/lib/travis/secure_config.rb
@@ -17,7 +17,6 @@ module Travis
 
     def decrypt(config)
       return config if config.is_a?(String)
-      return config if config.is_a?(Float)
 
       config.inject(config.class.new) do |result, element|
         key, element = element if result.is_a?(Hash)

--- a/spec/lib/model/job_spec.rb
+++ b/spec/lib/model/job_spec.rb
@@ -226,6 +226,19 @@ describe Job do
       }
     end
 
+    it 'handles float env' do
+      job = Job.new(repository: repo)
+      job.expects(:secure_env_enabled?).at_least_once.returns(true)
+
+      job.config = { rvm: '1.8.7', env: 2.0, global_env: nil }
+
+      job.decrypted_config.should == {
+        rvm: '1.8.7',
+        env: ['2.0'],
+        global_env: nil
+      }
+    end
+
     it 'normalizes env vars which are hashes to strings' do
       job = Job.new(repository: repo)
       job.expects(:secure_env_enabled?).at_least_once.returns(true)


### PR DESCRIPTION
if somebody sets an env var that has a float value in yml, we currently pass it all the way through to the decryptor, which errors out, because it expects a string or an array.

this has produced a very high error volume.