### PR TITLE
Make cron enqueue messages only show when there's something to enqueue in Enterprise

### DIFF
--- a/lib/travis/api/app/schedulers/schedule_cron_jobs.rb
+++ b/lib/travis/api/app/schedulers/schedule_cron_jobs.rb
@@ -32,10 +32,7 @@ class Travis::Api::App
         scheduled = Travis::API::V3::Models::Cron.scheduled
         count = scheduled.count
 
-        if count > 0 || !Travis.config.enterprise
-          Travis.logger.info "Found #{count} cron jobs to enqueue"
-        end
-
+        Travis.logger.info "Found #{count} cron jobs to enqueue" if count > 0
         Metriks.gauge("api.v3.cron_scheduler.upcoming_jobs").set(count)
 
         scheduled.each do |cron|

--- a/lib/travis/api/app/schedulers/schedule_cron_jobs.rb
+++ b/lib/travis/api/app/schedulers/schedule_cron_jobs.rb
@@ -32,12 +32,10 @@ class Travis::Api::App
         scheduled = Travis::API::V3::Models::Cron.scheduled
         count = scheduled.count
 
-        if Travis.config.enterprise
-          Travis.logger.debug "Found #{count} cron jobs to enqueue"
-        else
+        if count > 0 || !Travis.config.enterprise
           Travis.logger.info "Found #{count} cron jobs to enqueue"
         end
-        
+
         Metriks.gauge("api.v3.cron_scheduler.upcoming_jobs").set(count)
 
         scheduled.each do |cron|

--- a/lib/travis/api/app/schedulers/schedule_cron_jobs.rb
+++ b/lib/travis/api/app/schedulers/schedule_cron_jobs.rb
@@ -32,8 +32,12 @@ class Travis::Api::App
         scheduled = Travis::API::V3::Models::Cron.scheduled
         count = scheduled.count
 
-        Travis.logger.info "Found #{count} cron jobs to enqueue"
-
+        if Travis.config.enterprise
+          Travis.logger.debug "Found #{count} cron jobs to enqueue"
+        else
+          Travis.logger.info "Found #{count} cron jobs to enqueue"
+        end
+        
         Metriks.gauge("api.v3.cron_scheduler.upcoming_jobs").set(count)
 
         scheduled.each do |cron|


### PR DESCRIPTION
This is part of the making logs less chatty in Enterprise effort where even when there's no activity on the instance the logs still generate a lot of chatter which can make diagnosing problems difficult (as we only grab recent logs). 

The approach I went with here was to only show the log message when there was something to enqueue in Enterprise. In hosted it'll still show the log entry when there's nothing to enqueue (so no change). I could see making them behave the same, but since I don't know how these messages are used in hosted I did the safest approach.  