### PR TITLE
Preload stages and jobs when full jobs included

### DIFF
--- a/lib/travis/api/v3/queries/builds.rb
+++ b/lib/travis/api/v3/queries/builds.rb
@@ -25,6 +25,7 @@ module Travis::API::V3
 
       relation = relation.includes(:commit).includes(branch: :last_build).includes(:tag).includes(:repository)
       relation = relation.includes(branch: { last_build: :commit }) if includes? 'build.commit'.freeze
+      relation = relation.includes(:stages, jobs: [:build, :commit]) if includes? 'build.jobs'.freeze
       relation
     end
 


### PR DESCRIPTION
This is an attempt to fix the slow behaviour for customers with
a large amount of builds/jobs per repo.

https://github.com/travis-pro/team-teal/issues/2418