### PR TITLE
Fix finding builds later than the given number

### DIFF
--- a/lib/travis/model/build.rb
+++ b/lib/travis/model/build.rb
@@ -136,6 +136,12 @@ class Build < Travis::Model
       scope
     end
 
+    def later_than(build = nil)
+      scope = order('number::integer DESC').paged({}) # TODO in which case we'd call older_than without an argument?
+      scope = scope.where('number::integer > ?', (build.is_a?(Build) ? build.number : build).to_i) if build
+      scope
+    end
+
     protected
 
       def normalize_to_array(object)

--- a/lib/travis/services/find_builds.rb
+++ b/lib/travis/services/find_builds.rb
@@ -31,7 +31,7 @@ module Travis
             if params[:number]
               builds.where(:number => params[:number].to_s)
             else
-              builds.older_than(params[:after_number])
+              builds.later_than(params[:after_number])
             end
           elsif params[:running]
             scope(:build).running.limit(25)

--- a/spec/lib/services/find_builds_spec.rb
+++ b/spec/lib/services/find_builds_spec.rb
@@ -25,9 +25,13 @@ describe Travis::Services::FindBuilds do
       service.run.should == [push]
     end
 
-    it 'finds builds older than the given number' do
-      @params = { :repository_id => repo.id, :after_number => 2 }
-      service.run.should == [push]
+    it 'finds builds later than the given number' do
+      a =  Factory(:build, repository: repo, event_type: 'push', state: :failed, number: 2)
+      b =  Factory(:build, repository: repo, event_type: 'push', state: :failed, number: 3)
+      c =  Factory(:build, repository: repo, event_type: 'push', state: :failed, number: 4)
+
+      @params = { :repository_id => repo.id, :after_number => 3 }
+      service.run.should == [c]
     end
 
     it 'finds builds with a given number, scoped by repository' do


### PR DESCRIPTION
Fixes https://github.com/travis-ci/travis-ci/issues/7384

At the moment, the find builds later than the given number does not work, see referenced issue above.

I have also renamed the test to better represent what we want the outcome to be.

Let me know if there is anything else you need for this.