### PR TITLE
postgres query comments via marginalia

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -38,7 +38,7 @@ gem 'metriks-librato_metrics', git: 'https://github.com/eric/metriks-librato_met
 gem 'simplecov'
 gem 'stackprof'
 gem 'netaddr'
-gem 'marginalia'
+gem 'marginalia', git: 'https://github.com/travis-ci/marginalia'
 
 gem 'jemalloc'
 gem 'customerio'

--- a/Gemfile
+++ b/Gemfile
@@ -38,6 +38,7 @@ gem 'metriks-librato_metrics', git: 'https://github.com/eric/metriks-librato_met
 gem 'simplecov'
 gem 'stackprof'
 gem 'netaddr'
+gem 'marginalia'
 
 gem 'jemalloc'
 gem 'customerio'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -124,6 +124,19 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
+    actionpack (4.2.10)
+      actionview (= 4.2.10)
+      activesupport (= 4.2.10)
+      rack (~> 1.6)
+      rack-test (~> 0.6.2)
+      rails-dom-testing (~> 1.0, >= 1.0.5)
+      rails-html-sanitizer (~> 1.0, >= 1.0.2)
+    actionview (4.2.10)
+      activesupport (= 4.2.10)
+      builder (~> 3.1)
+      erubis (~> 2.7.0)
+      rails-dom-testing (~> 1.0, >= 1.0.5)
+      rails-html-sanitizer (~> 1.0, >= 1.0.3)
     active_model_serializers (0.9.5)
       activemodel (>= 3.2)
     activemodel (4.2.10)
@@ -163,6 +176,7 @@ GEM
     connection_pool (2.2.1)
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
+    crass (1.0.3)
     customerio (1.0.0)
       multi_json (~> 1.0)
     dalli (2.7.6)
@@ -174,6 +188,7 @@ GEM
     domain_name (0.5.20170404)
       unf (>= 0.0.5, < 1.0.0)
     equalizer (0.0.11)
+    erubis (2.7.0)
     excon (0.59.0)
     factory_girl (2.4.2)
       activesupport
@@ -256,6 +271,12 @@ GEM
     logging (2.2.2)
       little-plugger (~> 1.1)
       multi_json (~> 1.10)
+    loofah (2.1.1)
+      crass (~> 1.0.2)
+      nokogiri (>= 1.5.9)
+    marginalia (1.5.0)
+      actionpack (>= 2.3)
+      activerecord (>= 2.3)
     memcachier (0.0.2)
     memoist (0.16.0)
     metaclass (0.0.4)
@@ -304,6 +325,14 @@ GEM
       rack
     rack-test (0.6.3)
       rack (>= 1.0)
+    rails-deprecated_sanitizer (1.0.3)
+      activesupport (>= 4.2.0.alpha)
+    rails-dom-testing (1.0.8)
+      activesupport (>= 4.2.0.beta, < 5.0)
+      nokogiri (~> 1.6)
+      rails-deprecated_sanitizer (>= 1.0.1)
+    rails-html-sanitizer (1.0.3)
+      loofah (~> 2.0)
     raindrops (0.17.0)
     rake (0.9.6)
     rb-fsevent (0.9.8)
@@ -411,6 +440,7 @@ DEPENDENCIES
   jemalloc
   knapsack
   libhoney
+  marginalia
   metriks (= 0.9.9.6)
   metriks-librato_metrics!
   mime-types

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -32,6 +32,13 @@ GIT
       net-http-pipeline
 
 GIT
+  remote: https://github.com/travis-ci/marginalia
+  revision: 42542d7769723e2846da163c9b3f1c55013d68f0
+  specs:
+    marginalia (1.5.0)
+      activerecord (>= 2.3)
+
+GIT
   remote: https://github.com/travis-ci/s3
   revision: 386361c1b0ede19cde0ddaf86e41a16308575f5d
   specs:
@@ -124,19 +131,6 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    actionpack (4.2.10)
-      actionview (= 4.2.10)
-      activesupport (= 4.2.10)
-      rack (~> 1.6)
-      rack-test (~> 0.6.2)
-      rails-dom-testing (~> 1.0, >= 1.0.5)
-      rails-html-sanitizer (~> 1.0, >= 1.0.2)
-    actionview (4.2.10)
-      activesupport (= 4.2.10)
-      builder (~> 3.1)
-      erubis (~> 2.7.0)
-      rails-dom-testing (~> 1.0, >= 1.0.5)
-      rails-html-sanitizer (~> 1.0, >= 1.0.3)
     active_model_serializers (0.9.5)
       activemodel (>= 3.2)
     activemodel (4.2.10)
@@ -176,7 +170,6 @@ GEM
     connection_pool (2.2.1)
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
-    crass (1.0.3)
     customerio (1.0.0)
       multi_json (~> 1.0)
     dalli (2.7.6)
@@ -188,7 +181,6 @@ GEM
     domain_name (0.5.20170404)
       unf (>= 0.0.5, < 1.0.0)
     equalizer (0.0.11)
-    erubis (2.7.0)
     excon (0.59.0)
     factory_girl (2.4.2)
       activesupport
@@ -271,12 +263,6 @@ GEM
     logging (2.2.2)
       little-plugger (~> 1.1)
       multi_json (~> 1.10)
-    loofah (2.1.1)
-      crass (~> 1.0.2)
-      nokogiri (>= 1.5.9)
-    marginalia (1.5.0)
-      actionpack (>= 2.3)
-      activerecord (>= 2.3)
     memcachier (0.0.2)
     memoist (0.16.0)
     metaclass (0.0.4)
@@ -325,14 +311,6 @@ GEM
       rack
     rack-test (0.6.3)
       rack (>= 1.0)
-    rails-deprecated_sanitizer (1.0.3)
-      activesupport (>= 4.2.0.alpha)
-    rails-dom-testing (1.0.8)
-      activesupport (>= 4.2.0.beta, < 5.0)
-      nokogiri (~> 1.6)
-      rails-deprecated_sanitizer (>= 1.0.1)
-    rails-html-sanitizer (1.0.3)
-      loofah (~> 2.0)
     raindrops (0.17.0)
     rake (0.9.6)
     rb-fsevent (0.9.8)
@@ -440,7 +418,7 @@ DEPENDENCIES
   jemalloc
   knapsack
   libhoney
-  marginalia
+  marginalia!
   metriks (= 0.9.9.6)
   metriks-librato_metrics!
   mime-types

--- a/lib/travis/api/app.rb
+++ b/lib/travis/api/app.rb
@@ -101,7 +101,7 @@ module Travis::Api
           Travis::Honeycomb.clear
           Travis::Honeycomb.context.add('x_request_id', env['HTTP_X_REQUEST_ID'])
 
-          ::Marginalia.clear
+          ::Marginalia.clear!
           ::Marginalia.set('app', 'api')
           ::Marginalia.set('request_id', env['HTTP_X_REQUEST_ID'])
         end

--- a/lib/travis/api/app.rb
+++ b/lib/travis/api/app.rb
@@ -102,7 +102,7 @@ module Travis::Api
           Travis::Honeycomb.context.add('x_request_id', env['HTTP_X_REQUEST_ID'])
 
           Travis::Marginalia.clear
-          Travis::Marginalia.request_id = env['HTTP_X_REQUEST_ID']
+          Travis::Marginalia::Comment.request_id = env['HTTP_X_REQUEST_ID']
         end
 
         use Travis::Api::App::Middleware::RequestId

--- a/lib/travis/api/app.rb
+++ b/lib/travis/api/app.rb
@@ -101,8 +101,9 @@ module Travis::Api
           Travis::Honeycomb.clear
           Travis::Honeycomb.context.add('x_request_id', env['HTTP_X_REQUEST_ID'])
 
-          Travis::Marginalia.clear
-          Travis::Marginalia.request_id = env['HTTP_X_REQUEST_ID']
+          ::Marginalia.clear
+          ::Marginalia.set('app', 'api')
+          ::Marginalia.set('request_id', env['HTTP_X_REQUEST_ID'])
         end
 
         use Travis::Api::App::Middleware::RequestId
@@ -227,7 +228,9 @@ module Travis::Api
       end
 
       def self.setup_database_connections
-        Travis::Marginalia.setup
+        if ENV['QUERY_COMMENTS_ENABLED'] == 'true'
+          Travis::Marginalia.setup
+        end
 
         Travis.config.database.variables                    ||= {}
         Travis.config.database.variables[:application_name] ||= ["api", Travis.env, ENV['DYNO']].compact.join(?-)

--- a/lib/travis/api/app.rb
+++ b/lib/travis/api/app.rb
@@ -4,6 +4,7 @@ require 'travis/amqp'
 require 'travis/model'
 require 'travis/states_cache'
 require 'travis/honeycomb'
+require 'travis/marginalia'
 require 'rack'
 require 'rack/protection'
 require 'rack/contrib/config'
@@ -223,6 +224,8 @@ module Travis::Api
       end
 
       def self.setup_database_connections
+        Travis::Marginalia.setup
+
         Travis.config.database.variables                    ||= {}
         Travis.config.database.variables[:application_name] ||= ["api", Travis.env, ENV['DYNO']].compact.join(?-)
         Travis::Database.connect

--- a/lib/travis/api/app.rb
+++ b/lib/travis/api/app.rb
@@ -100,6 +100,9 @@ module Travis::Api
 
           Travis::Honeycomb.clear
           Travis::Honeycomb.context.add('x_request_id', env['HTTP_X_REQUEST_ID'])
+
+          Travis::Marginalia.clear
+          Travis::Marginalia.request_id = env['HTTP_X_REQUEST_ID']
         end
 
         use Travis::Api::App::Middleware::RequestId

--- a/lib/travis/api/app.rb
+++ b/lib/travis/api/app.rb
@@ -102,7 +102,7 @@ module Travis::Api
           Travis::Honeycomb.context.add('x_request_id', env['HTTP_X_REQUEST_ID'])
 
           Travis::Marginalia.clear
-          Travis::Marginalia::Comment.request_id = env['HTTP_X_REQUEST_ID']
+          Travis::Marginalia.request_id = env['HTTP_X_REQUEST_ID']
         end
 
         use Travis::Api::App::Middleware::RequestId

--- a/lib/travis/api/v3/router.rb
+++ b/lib/travis/api/v3/router.rb
@@ -34,7 +34,7 @@ module Travis::API::V3
       filtered = factory.filter_params(env_params)
       service  = factory.new(access_control, filtered.merge(params), env['rack.input'.freeze])
 
-      Travis::Marginalia.endpoint = factory.name
+      ::Marginalia.set('endpoint', factory.name)
 
       metrics.tick(:prepare)
       result   = service.run

--- a/lib/travis/api/v3/router.rb
+++ b/lib/travis/api/v3/router.rb
@@ -1,4 +1,5 @@
 require 'metriks'
+require 'marginalia'
 
 module Travis::API::V3
   class Router
@@ -32,6 +33,8 @@ module Travis::API::V3
 
       filtered = factory.filter_params(env_params)
       service  = factory.new(access_control, filtered.merge(params), env['rack.input'.freeze])
+
+      Marginalia::Comment.endpoint = factory.name
 
       metrics.tick(:prepare)
       result   = service.run

--- a/lib/travis/api/v3/router.rb
+++ b/lib/travis/api/v3/router.rb
@@ -34,7 +34,7 @@ module Travis::API::V3
       filtered = factory.filter_params(env_params)
       service  = factory.new(access_control, filtered.merge(params), env['rack.input'.freeze])
 
-      Marginalia::Comment.endpoint = factory.name
+      Travis::Marginalia.endpoint = factory.name
 
       metrics.tick(:prepare)
       result   = service.run

--- a/lib/travis/marginalia.rb
+++ b/lib/travis/marginalia.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require 'marginalia'
+require 'active_record/connection_adapters/postgresql_adapter'
+require 'thread'
+
+module Marginalia
+  module Comment
+    def self.reset!
+      @endpoint = nil
+    end
+
+    def self.endpoint=(endpoint)
+      @endpoint = endpoint
+    end
+
+    def self.endpoint
+      @endpoint
+    end
+  end
+end
+
+module Travis
+  class Marginalia
+    class << self
+      def setup
+        ActiveRecord::ConnectionAdapters::PostgreSQLAdapter.module_eval do
+          include ::Marginalia::ActiveRecordInstrumentation
+        end
+
+        ::Marginalia.application_name = 'api'
+        ::Marginalia::Comment.components = [:application, :endpoint]
+
+        # todo do this before every request
+        ::Marginalia::Comment.reset!
+      end
+    end
+  end
+end

--- a/lib/travis/marginalia.rb
+++ b/lib/travis/marginalia.rb
@@ -8,6 +8,7 @@ module Marginalia
   module Comment
     def self.reset!
       @endpoint = nil
+      @request_id = nil
     end
 
     def self.endpoint=(endpoint)
@@ -16,6 +17,14 @@ module Marginalia
 
     def self.endpoint
       @endpoint
+    end
+
+    def self.request_id=(request_id)
+      @request_id = request_id
+    end
+
+    def self.request_id
+      @request_id
     end
   end
 end
@@ -29,9 +38,10 @@ module Travis
         end
 
         ::Marginalia.application_name = 'api'
-        ::Marginalia::Comment.components = [:application, :endpoint]
+        ::Marginalia::Comment.components = [:application, :endpoint, :request_id]
+      end
 
-        # todo do this before every request
+      def clear
         ::Marginalia::Comment.reset!
       end
     end

--- a/lib/travis/marginalia.rb
+++ b/lib/travis/marginalia.rb
@@ -44,6 +44,14 @@ module Travis
       def clear
         ::Marginalia::Comment.reset!
       end
+
+      def endpoint=(endpoint)
+        ::Marginalia::Comment.endpoint = endpoint
+      end
+
+      def request_id=(request_id)
+        ::Marginalia::Comment.request_id = request_id
+      end
     end
   end
 end

--- a/lib/travis/marginalia.rb
+++ b/lib/travis/marginalia.rb
@@ -2,55 +2,12 @@
 
 require 'marginalia'
 require 'active_record/connection_adapters/postgresql_adapter'
-require 'thread'
-
-module Marginalia
-  module Comment
-    def self.reset!
-      @endpoint = nil
-      @request_id = nil
-    end
-
-    def self.endpoint=(endpoint)
-      @endpoint = endpoint
-    end
-
-    def self.endpoint
-      @endpoint
-    end
-
-    def self.request_id=(request_id)
-      @request_id = request_id
-    end
-
-    def self.request_id
-      @request_id
-    end
-  end
-end
 
 module Travis
   class Marginalia
     class << self
       def setup
-        ActiveRecord::ConnectionAdapters::PostgreSQLAdapter.module_eval do
-          include ::Marginalia::ActiveRecordInstrumentation
-        end
-
-        ::Marginalia.application_name = 'api'
-        ::Marginalia::Comment.components = [:application, :endpoint, :request_id]
-      end
-
-      def clear
-        ::Marginalia::Comment.reset!
-      end
-
-      def endpoint=(endpoint)
-        ::Marginalia::Comment.endpoint = endpoint
-      end
-
-      def request_id=(request_id)
-        ::Marginalia::Comment.request_id = request_id
+        ::Marginalia.install
       end
     end
   end


### PR DESCRIPTION
The idea of this is to add comments to all queries with some context about where the query came from. This way, when it pops up in the slow query log, we can instantly correlate it with the code.

This is using the [marginalia](https://github.com/basecamp/marginalia) gem, which is a light wrapper on top of activerecord (with some additional railsy dependencies unfortunately).

This prototype already looks quite promising, I'm getting this kind of output:

```
D TID=70130997244500   Travis::API::V3::Models::Repository Load (1.6ms)  SELECT  "repositories".* FROM "repositories" INNER JOIN "permissions" ON "permissions"."repository_id" = "repositories"."id" INNER JOIN "users" ON "users"."id" = "permissions"."user_id" WHERE "repositories"."invalidated_at" IS NULL AND "users"."id" = $1 AND "repositories"."invalidated_at" IS NULL LIMIT 100 /*application:api,endpoint:Travis::API::V3::Services::Repositories::ForCurrentUser*/  [["id", 4]]
```