### PR TITLE
make nginx error log level configurable

### DIFF
--- a/config/nginx.conf.erb
+++ b/config/nginx.conf.erb
@@ -17,7 +17,7 @@ http {
 
 	log_format l2met 'measure#nginx.service=$request_time request_id=$http_x_request_id';
 	access_log logs/nginx/access.log l2met;
-	error_log logs/nginx/error.log;
+	error_log logs/nginx/error.log <%= ENV["NGINX_ERROR_LOG_LEVEL"] %>;
 
 	include mime.types;
 	default_type application/octet-stream;


### PR DESCRIPTION
This allows us to change the log level to `info` (http://nginx.org/en/docs/ngx_core_module.html#error_log) so that we can see nginx level errors in more detail.

The level can be set via:

```
heroku config:set NGINX_ERROR_LOG_LEVEL=info -a travis-api-staging
```

The error logs can be viewed by running:

```
heroku ps:exec -a travis-api-staging 'tail -F logs/nginx/error.log'
```