### PR TITLE
log-tracing: introduce log-based tracing for requests

### DIFF
--- a/lib/travis/api/app.rb
+++ b/lib/travis/api/app.rb
@@ -119,6 +119,10 @@ module Travis::Api
           use Travis::Api::App::Middleware::Honeycomb
         end
 
+        if Travis::Api::App::Middleware::LogTracing.enabled?
+          use Travis::Api::App::Middleware::LogTracing
+        end
+
         use Travis::Api::App::Cors # if Travis.env == 'development' ???
         if Travis::Api::App.use_monitoring?
           use Rack::Config do |env|
@@ -230,6 +234,10 @@ module Travis::Api
       def self.setup_database_connections
         if ENV['QUERY_COMMENTS_ENABLED'] == 'true'
           Travis::Marginalia.setup
+        end
+
+        if Travis::Api::App::Middleware::LogTracing.enabled?
+          Travis::Api::App::Middleware::LogTracing.setup
         end
 
         Travis.config.database.variables                    ||= {}

--- a/lib/travis/api/app/middleware.rb
+++ b/lib/travis/api/app/middleware.rb
@@ -10,6 +10,7 @@ class Travis::Api::App
     require 'travis/api/app/middleware/request_id'
     require 'travis/api/app/middleware/scope_check'
     require 'travis/api/app/middleware/honeycomb'
+    require 'travis/api/app/middleware/log_tracing'
     require 'travis/api/app/middleware/user_agent_tracker'
   end
 end

--- a/lib/travis/api/app/middleware/log_tracing.rb
+++ b/lib/travis/api/app/middleware/log_tracing.rb
@@ -72,15 +72,15 @@ class Travis::Api::App
           event = ActiveSupport::Notifications::Event.new *args
           duration = event.duration.round(3)
 
+          if event.payload[:cached]
+            next
+          end
+
           log_line = ''
           if env['HTTP_X_REQUEST_ID']
             log_line += color("#{env['HTTP_X_REQUEST_ID']} ", YELLOW)
           end
-          if event.payload[:cached]
-            log_line += color("CACHE (#{duration}ms)  ", MAGENTA, true)
-          else
-            log_line += color("#{event.payload[:name]} (#{duration}ms)  ", MAGENTA, true)
-          end
+          log_line += color("#{event.payload[:name]} (#{duration}ms)  ", MAGENTA, true)
           log_line += "#{event.payload[:sql]}  "
 
           log_line += event.payload[:binds].map {|pair|

--- a/lib/travis/api/app/middleware/log_tracing.rb
+++ b/lib/travis/api/app/middleware/log_tracing.rb
@@ -74,7 +74,7 @@ class Travis::Api::App
 
           log_line = ''
           if env['HTTP_X_REQUEST_ID']
-            log_line += "#{env['HTTP_X_REQUEST_ID']}: "
+            log_line += color("#{env['HTTP_X_REQUEST_ID']} ", YELLOW)
           end
           if event.payload[:cached]
             log_line += color("CACHE (#{duration}ms)  ", MAGENTA, true)
@@ -82,7 +82,11 @@ class Travis::Api::App
             log_line += color("#{event.payload[:name]} (#{duration}ms)  ", MAGENTA, true)
           end
           log_line += "#{event.payload[:sql]}  "
-          log_line += event.payload[:binds].map {|xs| xs.map(&:to_s)}.inspect
+
+          log_line += event.payload[:binds].map {|pair|
+            column, value = pair
+            [column.name, value]
+          }.to_h.inspect
 
           Travis.logger.info log_line
         end

--- a/lib/travis/api/app/middleware/log_tracing.rb
+++ b/lib/travis/api/app/middleware/log_tracing.rb
@@ -72,7 +72,7 @@ class Travis::Api::App
           event = ActiveSupport::Notifications::Event.new *args
           duration = event.duration.round(3)
 
-          if event.payload[:cached]
+          if event.payload[:cached] || event.payload[:name] == 'CACHE'
             next
           end
 

--- a/lib/travis/api/app/middleware/log_tracing.rb
+++ b/lib/travis/api/app/middleware/log_tracing.rb
@@ -1,0 +1,98 @@
+# frozen_string_literal: true
+
+require 'thread'
+
+class Travis::Api::App
+  class Middleware
+    class LogTracing
+      # from ActiveSupport::LogSubscriber
+      CLEAR   = "\e[0m"
+      BOLD    = "\e[1m"
+      BLACK   = "\e[30m"
+      RED     = "\e[31m"
+      GREEN   = "\e[32m"
+      YELLOW  = "\e[33m"
+      BLUE    = "\e[34m"
+      MAGENTA = "\e[35m"
+      CYAN    = "\e[36m"
+      WHITE   = "\e[37m"
+
+      attr_reader :app
+
+      class << self
+        def enabled?
+          ENV['LOG_TRACING_ENABLED'] == 'true'
+        end
+
+        def setup
+          return unless enabled?
+
+          ActiveSupport::Notifications.subscribe 'sql.active_record' do |*args|
+            queries << args
+          end
+        end
+
+        def queries
+          Thread.current[:log_tracing] ||= []
+        end
+
+        def clear!
+          Thread.current[:log_tracing] = []
+        end
+      end
+
+      def initialize(app)
+        @app = app
+      end
+
+      def call(env)
+        self.class.clear!
+        begin
+          @app.call(env)
+        ensure
+          if should_log?(env)
+            log_queries!(env)
+          end
+        end
+      end
+
+      private def should_log?(env)
+        case
+        when env['HTTP_TRACE'] == 'true'
+          true
+        when ENV['LOG_TRACING_ENABLED_FOR_LOGIN'] && env['travis.access_token']&.user&.login == ENV['LOG_TRACING_ENABLED_FOR_LOGIN']
+          true
+        else
+          false
+        end
+      end
+
+      private def log_queries!(env)
+        self.class.queries.each do |args|
+          event = ActiveSupport::Notifications::Event.new *args
+          duration = event.duration.round(3)
+
+          log_line = ''
+          if env['HTTP_X_REQUEST_ID']
+            log_line += "#{env['HTTP_X_REQUEST_ID']}: "
+          end
+          if event.payload[:cached]
+            log_line += color("CACHE (#{duration}ms)  ", MAGENTA, true)
+          else
+            log_line += color("#{event.payload[:name]} (#{duration}ms)  ", MAGENTA, true)
+          end
+          log_line += "#{event.payload[:sql]}  "
+          log_line += event.payload[:binds].map {|xs| xs.map(&:to_s)}.inspect
+
+          Travis.logger.info log_line
+        end
+      end
+
+      def color(text, color, bold = false) # :doc:
+        color = self.class.const_get(color.upcase) if color.is_a?(Symbol)
+        bold  = bold ? BOLD : ""
+        "#{bold}#{color}#{text}#{CLEAR}"
+      end
+    end
+  end
+end

--- a/lib/travis/api/app/middleware/log_tracing.rb
+++ b/lib/travis/api/app/middleware/log_tracing.rb
@@ -76,7 +76,7 @@ class Travis::Api::App
             next
           end
 
-          log_line = ''
+          log_line = '[log-tracing] '
           if env['HTTP_X_REQUEST_ID']
             log_line += color("#{env['HTTP_X_REQUEST_ID']} ", YELLOW)
           end

--- a/lib/travis/api/app/middleware/rewrite.rb
+++ b/lib/travis/api/app/middleware/rewrite.rb
@@ -72,4 +72,3 @@ class Travis::Api::App
     end
   end
 end
-


### PR DESCRIPTION
This is a simplified log-based solution that will eventually be replaced by zipkin (travis-ci/travis-api#598).

It allows us to trace SQL queries either per request (by setting the `Trace: true` request header) or per user (by setting the `LOG_TRACING_ENABLED_FOR_LOGIN` env var).

Log tracing must be enabled globally via the `LOG_TRACING_ENABLED` environment variable (must be set to `true`).