### PR TITLE
log-tracing: include X-Request-ID in Access-Control-Expose-Headers

### DIFF
--- a/config/nginx.conf.erb
+++ b/config/nginx.conf.erb
@@ -42,7 +42,7 @@ http {
 
 				add_header 'Access-Control-Allow-Origin' '*';
 				add_header 'Access-Control-Allow-Credentials' 'true';
-				add_header 'Access-Control-Expose-Headers' 'Content-Type, Cache-Control, Expires, Etag, Last-Modified';
+				add_header 'Access-Control-Expose-Headers' 'Content-Type, Cache-Control, Expires, Etag, Last-Modified, X-Request-Id';
 				add_header 'Access-Control-Allow-Methods' 'HEAD, GET, POST, PATCH, PUT, DELETE';
 				add_header 'Access-Control-Allow-Headers' 'Content-Type, Authorization, Accept, If-None-Match, If-Modified-Since, X-User-Agent, Travis-API-Version, Trace';
 				add_header 'Access-Control-Max-Age' 86400;

--- a/config/nginx.conf.erb
+++ b/config/nginx.conf.erb
@@ -42,7 +42,7 @@ http {
 
 				add_header 'Access-Control-Allow-Origin' '*';
 				add_header 'Access-Control-Allow-Credentials' 'true';
-				add_header 'Access-Control-Expose-Headers' 'Content-Type, Cache-Control, Expires, Etag, Last-Modified, X-Request-Id';
+				add_header 'Access-Control-Expose-Headers' 'Content-Type, Cache-Control, Expires, Etag, Last-Modified, X-Request-ID';
 				add_header 'Access-Control-Allow-Methods' 'HEAD, GET, POST, PATCH, PUT, DELETE';
 				add_header 'Access-Control-Allow-Headers' 'Content-Type, Authorization, Accept, If-None-Match, If-Modified-Since, X-User-Agent, Travis-API-Version, Trace';
 				add_header 'Access-Control-Max-Age' 86400;

--- a/lib/travis/api/app/cors.rb
+++ b/lib/travis/api/app/cors.rb
@@ -9,7 +9,7 @@ class Travis::Api::App
     before do
       headers['Access-Control-Allow-Origin']      = "*"
       headers['Access-Control-Allow-Credentials'] = "true"
-      headers['Access-Control-Expose-Headers']    = "Content-Type, Cache-Control, Expires, Etag, Last-Modified"
+      headers['Access-Control-Expose-Headers']    = "Content-Type, Cache-Control, Expires, Etag, Last-Modified, X-Request-ID"
     end
 
     options // do

--- a/spec/unit/cors_spec.rb
+++ b/spec/unit/cors_spec.rb
@@ -18,7 +18,7 @@ describe Travis::Api::App::Cors do
     end
 
     it 'sets Access-Control-Expose-Headers' do
-      headers['Access-Control-Expose-Headers'].should == "Content-Type, Cache-Control, Expires, Etag, Last-Modified"
+      headers['Access-Control-Expose-Headers'].should == "Content-Type, Cache-Control, Expires, Etag, Last-Modified, X-Request-Id"
     end
   end
 
@@ -34,7 +34,7 @@ describe Travis::Api::App::Cors do
     end
 
     it 'sets Access-Control-Expose-Headers' do
-      headers['Access-Control-Expose-Headers'].should == "Content-Type, Cache-Control, Expires, Etag, Last-Modified"
+      headers['Access-Control-Expose-Headers'].should == "Content-Type, Cache-Control, Expires, Etag, Last-Modified, X-Request-Id"
     end
 
     it 'sets Access-Control-Allow-Methods' do

--- a/spec/unit/cors_spec.rb
+++ b/spec/unit/cors_spec.rb
@@ -18,7 +18,7 @@ describe Travis::Api::App::Cors do
     end
 
     it 'sets Access-Control-Expose-Headers' do
-      headers['Access-Control-Expose-Headers'].should == "Content-Type, Cache-Control, Expires, Etag, Last-Modified, X-Request-Id"
+      headers['Access-Control-Expose-Headers'].should == "Content-Type, Cache-Control, Expires, Etag, Last-Modified, X-Request-ID"
     end
   end
 
@@ -34,7 +34,7 @@ describe Travis::Api::App::Cors do
     end
 
     it 'sets Access-Control-Expose-Headers' do
-      headers['Access-Control-Expose-Headers'].should == "Content-Type, Cache-Control, Expires, Etag, Last-Modified, X-Request-Id"
+      headers['Access-Control-Expose-Headers'].should == "Content-Type, Cache-Control, Expires, Etag, Last-Modified, X-Request-ID"
     end
 
     it 'sets Access-Control-Allow-Methods' do


### PR DESCRIPTION
refs travis-ci/travis-api#607