### PR TITLE
model-renderer-tracing: correlate sql queries with the fields in the model they originate from

### DIFF
--- a/lib/travis/api/app.rb
+++ b/lib/travis/api/app.rb
@@ -240,6 +240,10 @@ module Travis::Api
           Travis::Api::App::Middleware::LogTracing.setup
         end
 
+        if ENV['MODEL_RENDERER_TRACING_ENABLED'] == 'true'
+          Travis::API::V3::ModelRenderer.install_tracer
+        end
+
         Travis.config.database.variables                    ||= {}
         Travis.config.database.variables[:application_name] ||= ["api", Travis.env, ENV['DYNO']].compact.join(?-)
         Travis::Database.connect

--- a/script/request
+++ b/script/request
@@ -1,0 +1,70 @@
+#!/usr/bin/env ruby
+# encoding: UTF-8
+
+require 'bundler/setup'
+require 'optparse'
+require 'pry'
+
+ENV['RACK_ENV'] ||= ENV['RAILS_ENV'] || ENV['ENV']
+ENV['RAILS_ENV']  = ENV['RACK_ENV']
+
+$stdout.sync = true
+
+options = {
+  api_version: 3,
+}
+parser = OptionParser.new do |opts|
+  opts.banner = "Usage: script/request [options] URL"
+
+  opts.on("--user LOGIN", "user login to log in as") do |u|
+    options[:user] = u
+  end
+
+  opts.on("--api-version VERSION", "api version (default 3)") do |v|
+    options[:api_version] = v
+  end
+
+  opts.on("--verbose", "output response body") do |v|
+    options[:verbose] = v
+  end
+end
+parser.parse!
+if ARGV.size != 1
+  puts parser.banner
+  exit 1
+end
+url = ARGV.shift
+
+require 'travis/api/app'
+
+app = Travis::Api::App.new
+
+headers = {
+  'HTTP_TRAVIS_API_VERSION' => "#{options[:api_version]}"
+}
+if options[:user]
+  user = User.find_by_login('igorwwwwwwwwwwwwwwwwwwww')
+  access_token = Travis::Api::App::AccessToken.new(user: user, app_id: 0)
+  token = access_token.token
+  headers['HTTP_AUTHORIZATION'] = "token #{token}"
+end
+
+env = Rack::MockRequest.env_for(
+  url,
+  headers
+)
+resp = app.call(env)
+
+# force response
+status = resp[0]
+body = resp[2].to_a.join
+
+if status != 200
+  puts "status code #{status}"
+  puts body
+  exit 1
+end
+
+if options[:verbose]
+  puts body
+end


### PR DESCRIPTION
This helps track down n+1 queries, by showing a logical backtrace for where in the rendering process the query happened.

An example output:

```
D TID=70269398153540   Travis::API::V3::Models::Organization Load (0.6ms)  SELECT  "organizations".* FROM "organizations" WHERE "organizations"."id" = $1 LIMIT 1  [["id", 1271]]
D TID=70269398153540    (0.5ms)  SELECT COUNT(*) FROM "permissions" WHERE "permissions"."user_id" = $1 AND "permissions"."user_id" = $2 AND "permissions"."pull" = $3 AND "permissions"."repository_id" = 62295  [["user_id", 4280], ["user_id", 4280], ["pull", "t"]]
D TID=70269398153540    (0.4ms)  SELECT COUNT(*) FROM "permissions" WHERE "permissions"."user_id" = $1 AND "permissions"."user_id" = $2 AND "permissions"."admin" = $3 AND "permissions"."repository_id" = 62295  [["user_id", 4280], ["user_id", 4280], ["admin", "t"]]
D TID=70269398153540    (0.4ms)  SELECT COUNT(*) FROM "permissions" WHERE "permissions"."user_id" = $1 AND "permissions"."user_id" = $2 AND "permissions"."push" = $3 AND "permissions"."repository_id" = 62295  [["user_id", 4280], ["user_id", 4280], ["push", "t"]]
D TID=70269398153540   Travis::API::V3::Models::Repository Load (1.4ms)  SELECT  "repositories".* FROM "repositories" WHERE "repositories"."id" = $1 LIMIT 1  [["id", 62295]]
  Repository.default_branch
    Branch.repository
```

In order to be able to tweak endpoints with a fast feedback-cycle, there is a `script/request` tool that will perform an api request without having to reload the server and re-issue a curl request.

Example usage:

```
$ script/request --user igorwwwwwwwwwwwwwwwwwwww '/repos?active=true&sort_by=current_build%3Adesc&offset=0&include=build.branch%2Crepository.default_branch%2Crepository.current_build'
```

This integrates nicely with tools like `rerun` or [`entr`](http://entrproject.org/), allowing you to re-run on any change:

```
$ ag -l | entr script/request --user igorwwwwwwwwwwwwwwwwwwww '/repos?active=true&sort_by=current_build%3Adesc&offset=0&include=build.branch%2Crepository.default_branch%2Crepository.current_build'
```

Or even:

```
$ ag -l | RACK_ENV=development DATABASE_URL=postgres://127.0.0.1:5432/travis_staging MODEL_RENDERER_TRACING_ENABLED=true entr script/request --user igorwwwwwwwwwwwwwwwwwwww '/repos?active=true&sort_by=current_build%3Adesc&offset=0&include=build.branch%2Crepository.default_branch%2Crepository.current_build' | grep -v CACHE
```