### PR TITLE
change to correct job

### DIFF
--- a/spec/v3/services/job/find_spec.rb
+++ b/spec/v3/services/job/find_spec.rb
@@ -212,8 +212,8 @@ describe Travis::API::V3::Services::Job::Find, set_app: true do
       "state"                 => job2.state,
       "started_at"            => "2010-11-12T12:00:00Z",
       "finished_at"           => "2010-11-12T12:00:10Z",
-      "created_at"            => json_format_time_with_ms(job.created_at),
-      "updated_at"            => json_format_time_with_ms(job.updated_at),
+      "created_at"            => json_format_time_with_ms(job2.created_at),
+      "updated_at"            => json_format_time_with_ms(job2.updated_at),
       "build"                 => {
         "@type"               => "build",
         "@href"               => "/v3/build/#{build.id}",


### PR DESCRIPTION
When I ran tests locally I noticed one for v3/services/job/find_spec.rb was using the wrong job object. For some reason it wasn't failing on Travis, but this fix now passes locally and on Travis...