### PR TITLE
Add .../repo/id/request/id/messages endpoint for display of travis-yml messages

### DIFF
--- a/lib/travis/api/v3/models/message.rb
+++ b/lib/travis/api/v3/models/message.rb
@@ -1,0 +1,5 @@
+module Travis::API::V3
+  class Models::Message < Model
+    belongs_to :subject, polymorphic: true  
+  end
+end

--- a/lib/travis/api/v3/models/request.rb
+++ b/lib/travis/api/v3/models/request.rb
@@ -7,6 +7,7 @@ module Travis::API::V3
     has_many   :builds
     serialize  :config
     serialize  :payload
+    has_many   :messages, as: :subject
 
     def branch_name
       commit.branch if commit

--- a/lib/travis/api/v3/queries/messages.rb
+++ b/lib/travis/api/v3/queries/messages.rb
@@ -1,7 +1,7 @@
 module Travis::API::V3
   class Queries::Messages < Query
   	def for_request(request)
-  		Models::Message.where(subject_type: "Request", subject_id: request.id)
+			Models::Message.where(subject_type: "Request", subject_id: request.id)
   	end
   end
 end

--- a/lib/travis/api/v3/queries/messages.rb
+++ b/lib/travis/api/v3/queries/messages.rb
@@ -1,0 +1,7 @@
+module Travis::API::V3
+  class Queries::Messages < Query
+  	def for_request(request)
+  		Models::Message.where(subject_type: "Request", subject_id: request.id)
+  	end
+  end
+end

--- a/lib/travis/api/v3/queries/messages.rb
+++ b/lib/travis/api/v3/queries/messages.rb
@@ -1,7 +1,7 @@
 module Travis::API::V3
   class Queries::Messages < Query
-  	def for_request(request)
-			Models::Message.where(subject_type: "Request", subject_id: request.id)
-  	end
+    def for_request(request)
+      Models::Message.where(subject_type: "Request", subject_id: request.id)
+    end
   end
 end

--- a/lib/travis/api/v3/renderer/build.rb
+++ b/lib/travis/api/v3/renderer/build.rb
@@ -1,6 +1,6 @@
 module Travis::API::V3
   class Renderer::Build < ModelRenderer
-    representation(:minimal,  :id, :number, :state, :duration, :event_type, :previous_state, :pull_request_title, :pull_request_number, :started_at, :finished_at, :request_id)
+    representation(:minimal,  :id, :number, :state, :duration, :event_type, :previous_state, :pull_request_title, :pull_request_number, :started_at, :finished_at)
     representation(:standard, *representations[:minimal], :repository, :branch, :tag, :commit, :jobs, :stages, :created_by, :updated_at)
     representation(:active, *representations[:standard])
 

--- a/lib/travis/api/v3/renderer/build.rb
+++ b/lib/travis/api/v3/renderer/build.rb
@@ -1,6 +1,6 @@
 module Travis::API::V3
   class Renderer::Build < ModelRenderer
-    representation(:minimal,  :id, :number, :state, :duration, :event_type, :previous_state, :pull_request_title, :pull_request_number, :started_at, :finished_at)
+    representation(:minimal,  :id, :number, :state, :duration, :event_type, :previous_state, :pull_request_title, :pull_request_number, :started_at, :finished_at, :request_id)
     representation(:standard, *representations[:minimal], :repository, :branch, :tag, :commit, :jobs, :stages, :created_by, :updated_at)
     representation(:active, *representations[:standard])
 

--- a/lib/travis/api/v3/renderer/message.rb
+++ b/lib/travis/api/v3/renderer/message.rb
@@ -1,0 +1,5 @@
+module Travis::API::V3
+  class Renderer::Message < ModelRenderer
+    representation(:standard, :id, :level, :key, :code, :args)
+  end
+end

--- a/lib/travis/api/v3/renderer/messages.rb
+++ b/lib/travis/api/v3/renderer/messages.rb
@@ -1,0 +1,6 @@
+module Travis::API::V3
+  class Renderer::Messages < CollectionRenderer
+    type            :messages
+    collection_key  :messages
+  end
+end

--- a/lib/travis/api/v3/routes.rb
+++ b/lib/travis/api/v3/routes.rb
@@ -149,6 +149,11 @@ module Travis::API::V3
       resource :request do
         route '/request/{request.id}'
         get  :find
+
+        resource :messages do
+          route '/messages'
+          get :for_request
+        end
       end
 
       resource :user_settings, as: :settings do

--- a/lib/travis/api/v3/services.rb
+++ b/lib/travis/api/v3/services.rb
@@ -22,6 +22,7 @@ module Travis::API::V3
     KeyPair       = Module.new { extend Services }
     Lint          = Module.new { extend Services }
     Log           = Module.new { extend Services }
+    Messages      = Module.new { extend Services }
     Organization  = Module.new { extend Services }
     Organizations = Module.new { extend Services }
     Owner         = Module.new { extend Services }

--- a/lib/travis/api/v3/services/messages/for_request.rb
+++ b/lib/travis/api/v3/services/messages/for_request.rb
@@ -1,0 +1,10 @@
+module Travis::API::V3
+  class Services::Messages::ForRequest < Service
+    paginate
+
+    def run!
+      request = query(:request).find
+      result query.for_request(request)
+    end
+  end
+end

--- a/spec/v3/services/messages/for_request_spec.rb
+++ b/spec/v3/services/messages/for_request_spec.rb
@@ -1,0 +1,49 @@
+describe Travis::API::V3::Services::Messages::ForRequest, set_app: true do
+
+  let(:repo) { Travis::API::V3::Models::Repository.where(owner_name: 'svenfuchs', name: 'minimal').first }
+  let(:request) { repo.requests.first }
+  let!(:message) { Travis::API::V3::Models::Message.create!(subject_id: request.id, subject_type: 'Request')}
+
+  describe "retrieve request messages on a public repository" do
+    before { puts message.inspect }
+    before { puts request.id}
+    before     { get("/v3/repo/#{repo.id}/request/#{request.id}/messages")     }
+    example    { expect(last_response).to be_ok }
+    example    { expect(JSON.load(body).to_s).to include(
+                  "@type",
+                  "messages",
+                  "/v3/repo/#{repo.id}/request/#{request.id}/messages",
+                  "id",
+                  "level",
+                  "key",
+                  "code",
+                  "args",
+                  "representation",
+                  "@pagination")
+    }
+  end
+
+  describe "retrieve request messages on private repository, private API, authenticated as user with access" do
+    let(:token)   { Travis::Api::App::AccessToken.create(user: repo.owner, app_id: 1) }
+    let(:headers) {{ 'HTTP_AUTHORIZATION' => "token #{token}"                        }}
+    before        { Travis::API::V3::Models::Permission.create(repository: repo, user: repo.owner, pull: true) }
+    before        { repo.update_attribute(:private, true)                             }
+    before        { get("/v3/repo/#{repo.id}/request/#{request.id}/messages", {}, headers)                             }
+    after         { repo.update_attribute(:private, false)                            }
+    example       { expect(last_response).to be_ok                                    }
+    example       { expect(JSON.load(body).to_s).to include( 
+                    "@type",
+                    "messages",
+                    "/v3/repo/#{repo.id}/request/#{request.id}/messages",
+                    "id",
+                    "level",
+                    "key",
+                    "code",
+                    "args",
+                    "representation",
+                    "@pagination"
+                      )
+    }
+
+  end
+end

--- a/spec/v3/services/messages/for_request_spec.rb
+++ b/spec/v3/services/messages/for_request_spec.rb
@@ -5,8 +5,6 @@ describe Travis::API::V3::Services::Messages::ForRequest, set_app: true do
   let!(:message) { Travis::API::V3::Models::Message.create!(subject_id: request.id, subject_type: 'Request')}
 
   describe "retrieve request messages on a public repository" do
-    before { puts message.inspect }
-    before { puts request.id}
     before     { get("/v3/repo/#{repo.id}/request/#{request.id}/messages")     }
     example    { expect(last_response).to be_ok }
     example    { expect(JSON.load(body).to_s).to include(


### PR DESCRIPTION
This PR addresses https://github.com/travis-pro/team-teal/issues/2285, which is part of the `travis-yml` project.

It adds a v3 api endpoint to find any `messages` that may have been created for a `request` by `travis-yml`.

All tests are passing, and the branch has been deployed and tested on staging with test data. See here for sample payload: https://api-staging.travis-ci.org/v3/repo/travis-repos%2Fchirp-org-staging/request/247096/messages
