### PR TITLE
Allow build response to contain request

### DIFF
--- a/lib/travis/api/v3/renderer/build.rb
+++ b/lib/travis/api/v3/renderer/build.rb
@@ -6,6 +6,14 @@ module Travis::API::V3
 
     hidden_representations(:active)
 
+    def self.available_attributes
+      super + ['request']
+    end
+
+    def request
+      Renderer.render_model(model.request, mode: :minimal)
+    end
+
     def jobs
       return model.active_jobs if include_full_jobs? && representation?(:active)
       return model.jobs if include_full_jobs?

--- a/spec/v3/services/build/find_spec.rb
+++ b/spec/v3/services/build/find_spec.rb
@@ -321,4 +321,21 @@ describe Travis::API::V3::Services::Build::Find, set_app: true do
       "last_build_id"   => nil
     })}
   end
+
+  describe 'including a request' do
+    before { get("/v3/build/#{build.id}?include=build.request") }
+
+    example { expect(last_response).to be_ok }
+    example do
+      expect(parsed_body['request']).to include(
+        '@type',
+        '@href',
+        '@representation',
+        'id',
+        'state',
+        'result',
+        'message'
+      )
+    end
+  end
 end


### PR DESCRIPTION
/v3/build/123?include=build.request

The minimal representation of a request is included in the build
response, but only when using the include param as above.