### PR TITLE
Fix decrypting env vars with non-ascii characters

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -73,7 +73,7 @@ GIT
 
 GIT
   remote: https://github.com/travis-ci/travis-settings
-  revision: d510e63b6c6f059cccae141c265e7a0c7236d1fd
+  revision: debef595a6a54b082176edba630fdb5ee9d705af
   specs:
     travis-settings (0.0.1)
       activemodel

--- a/lib/travis/model/encrypted_column.rb
+++ b/lib/travis/model/encrypted_column.rb
@@ -62,6 +62,9 @@ class Travis::Model::EncryptedColumn
     aes = create_aes :decrypt, key.to_s, iv
 
     result = aes.update(data) + aes.final
+    if result
+      result.force_encoding('UTF-8')
+    end
   end
 
   def encrypt(data)

--- a/spec/integration/v2/settings/env_vars_spec.rb
+++ b/spec/integration/v2/settings/env_vars_spec.rb
@@ -37,7 +37,7 @@ describe Travis::Api::App::SettingsEndpoint, set_app: true do
     describe 'GET /settings/env_vars' do
       it 'returns a list of env vars' do
         settings = repo.settings
-        record = settings.env_vars.create(name: 'FOO', value: 'bar')
+        record = settings.env_vars.create(name: 'FOO', value: 'zażółć gęślą jaźń', public: true)
         settings.save
 
         response = get '/settings/env_vars', { repository_id: repo.id }, headers
@@ -49,9 +49,8 @@ describe Travis::Api::App::SettingsEndpoint, set_app: true do
         key['id'].should == record.id
         key['repository_id'].should == repo.id
 
-        key['public'].should == false
-        # key.should_not have_key('value')
-        key['value'].should be_nil
+        key['public'].should == true
+        key['value'].should == 'zażółć gęślą jaźń'
       end
     end
 

--- a/spec/v3/services/env_var/find_spec.rb
+++ b/spec/v3/services/env_var/find_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe Travis::API::V3::Services::EnvVar::Find, set_app: true do
   let(:repo)  { Travis::API::V3::Models::Repository.where(owner_name: 'svenfuchs', name: 'minimal').first_or_create }
   let(:token) { Travis::Api::App::AccessToken.create(user: repo.owner, app_id: 1) }
-  let(:env_var) { { id: 'abc', name: 'FOO', value: Travis::Settings::EncryptedValue.new('bar'), public: true, repository_id: repo.id } }
+  let(:env_var) { { id: 'abc', name: 'FOO', value: Travis::Settings::EncryptedValue.new('zażółć gęślą jaźń'), public: true, repository_id: repo.id } }
   let(:auth_headers) { { 'HTTP_AUTHORIZATION' => "token #{token}" } }
 
   describe 'not authenticated' do


### PR DESCRIPTION
When we decrypt a string using OpenSSL it gives it ASCII-8BIT encoding
by default. We need to encode it in UTF-8 in order to not raise errors
with UTF-8 characters.