### PR TITLE
Fix fetching accounts when account names are duplicated in the DB

### DIFF
--- a/lib/travis/model/repository.rb
+++ b/lib/travis/model/repository.rb
@@ -83,11 +83,11 @@ class Repository < Travis::Model
     Hash[*all.map { |repository| [repository.name, repository] }.flatten]
   end
 
-  def self.counts_by_owner_names(owner_names)
-    query = %(SELECT owner_name, count(*) FROM repositories WHERE owner_name IN (?) AND invalidated_at IS NULL GROUP BY owner_name)
-    query = sanitize_sql([query, owner_names])
-    rows = connection.select_all(query, owner_names)
-    Hash[*rows.map { |row| [row['owner_name'], row['count'].to_i] }.flatten]
+  def self.counts_by_owner_ids(owner_ids)
+    query = %(SELECT owner_id, count(*) FROM repositories WHERE owner_id IN (?) AND invalidated_at IS NULL GROUP BY owner_id)
+    query = sanitize_sql([query, owner_ids])
+    rows = connection.select_all(query, owner_ids)
+    Hash[*rows.map { |row| [row['owner_id'].to_i, row['count'].to_i] }.flatten]
   end
 
   delegate :builds_only_with_travis_yml?, to: :settings

--- a/spec/lib/model/repository_spec.rb
+++ b/spec/lib/model/repository_spec.rb
@@ -164,16 +164,16 @@ describe Repository do
       end
     end
 
-    describe 'counts_by_owner_names' do
+    describe 'counts_by_owner_ids' do
       let!(:repositories) do
-        Factory(:repository, owner_name: 'svenfuchs', name: 'minimal')
-        Factory(:repository, owner_name: 'travis-ci', name: 'travis-ci')
-        Factory(:repository, owner_name: 'travis-ci', name: 'invalidated', invalidated_at: Time.now)
+        Factory(:repository, owner_id: 1, owner_name: 'svenfuchs', name: 'minimal')
+        Factory(:repository, owner_id: 2, owner_name: 'travis-ci', name: 'travis-ci')
+        Factory(:repository, owner_id: 2, owner_name: 'travis-ci', name: 'invalidated', invalidated_at: Time.now)
       end
 
-      it 'returns repository counts per owner_name for the given owner_names' do
-        counts = Repository.counts_by_owner_names(%w(svenfuchs travis-ci))
-        counts.should == { 'svenfuchs' => 1, 'travis-ci' => 1 }
+      it 'returns repository counts per owner_id for the given owner_ids' do
+        counts = Repository.counts_by_owner_ids([1, 2])
+        counts.should == { 1 => 1, 2 => 1 }
       end
     end
   end

--- a/spec/lib/services/find_user_accounts_spec.rb
+++ b/spec/lib/services/find_user_accounts_spec.rb
@@ -2,6 +2,7 @@ describe Travis::Services::FindUserAccounts do
   let!(:sven)    { Factory(:user, :login => 'sven') }
   let!(:travis)  { Factory(:org, :login => 'travis-ci') }
   let!(:sinatra) { Factory(:org, :login => 'sinatra') }
+  let!(:non_user_org) { Factory(:org, :login => 'travis-ci') }
 
   let!(:repos) do
     Factory(:repository, :owner => sven, :owner_name => 'sven', :name => 'minimal')
@@ -38,6 +39,10 @@ describe Travis::Services::FindUserAccounts do
 
   it 'does not include accounts where the user does not have admin access' do
     service.run.should_not include(Account.from(sinatra))
+  end
+
+  it 'does not include account of organizations that do not belong to the user, even though they match by name' do
+    service.run.should_not include(Account.from(non_user_org))
   end
 
   it 'includes repository counts' do

--- a/spec/unit/endpoint/accounts_spec.rb
+++ b/spec/unit/endpoint/accounts_spec.rb
@@ -5,7 +5,7 @@ describe Travis::Api::App::Endpoint::Accounts, set_app: true do
   before do
     User.stubs(:find_by_github_id).returns(user)
     User.stubs(:find).returns(user)
-    user.stubs(:repositories).returns(stub(administrable: stub(select: [repository])))
+    Travis::Services::FindUserAccounts.any_instance.stubs(:account_ids).returns([user.id])
     user.stubs(:attributes).returns(:id => user.id, :login => user.login, :name => user.name)
   end
 


### PR DESCRIPTION
From the commit:

```
find_user_accounts service that we use to fetch accounts and
repositories names was querying accounts by getting a list of user
repositories and then using an owner_name attribute to fetch
organizations. This method will work only if we don't have any
duplicates in the database. Duplicates can happen in multiple scenarios,
for example when an organization is deleted from GitHub and a new one is
created. We don't delete old organizations at the moment, so fetching by
name will get both records.

This commit changes the code to fetch organizations by ids rather than
by names.

In theory we could use memberships to fetch organizations (so basically
do `SELECT organization_id FROM memberships WHERE user_id = ?`), but I'm
not sure if this change would have any side effects, so I would have to
check how we store memberships and how exactly memberships work on GitHub.
So for now I prefer to leave the way this code works unchanged, and only
fix the main issue with it.
```