### PR TITLE
Fetch the newest organization and user

### DIFF
--- a/lib/travis/api/v3/queries/organization.rb
+++ b/lib/travis/api/v3/queries/organization.rb
@@ -5,7 +5,7 @@ module Travis::API::V3
     def find
       return Models::Organization.find_by_id(id) if id
       return Models::Organization.find_by_github_id(github_id) if github_id
-      return Models::Organization.where('lower(login) = ?'.freeze, login.downcase).first if login
+      return Models::Organization.where('lower(login) = ?'.freeze, login.downcase).order("id DESC").first if login
       raise WrongParams, 'missing organization.id or organization.login'.freeze
     end
   end

--- a/lib/travis/api/v3/queries/user.rb
+++ b/lib/travis/api/v3/queries/user.rb
@@ -6,7 +6,7 @@ module Travis::API::V3
     def find
       return Models::User.find_by_id(id) if id
       return Models::User.find_by_github_id(github_id) if github_id
-      return Models::User.where('lower(login) = ?'.freeze, login.downcase).first if login
+      return Models::User.where('lower(login) = ?'.freeze, login.downcase).order("id DESC").first if login
       return find_by_email(email) if email
       raise WrongParams, 'missing user.id or user.login'.freeze
     end

--- a/spec/v3/queries/organization_spec.rb
+++ b/spec/v3/queries/organization_spec.rb
@@ -1,0 +1,8 @@
+describe Travis::API::V3::Queries::Organization do
+  it 'fetches the newest user if multiple users exist with the same login' do
+    Factory(:org, login: 'travisbot')
+    newer = Factory(:org, login: 'travisbot')
+
+    described_class.new({ 'organization.login' => 'travisbot' }, 'Organization').find.id.should == newer.id
+  end
+end

--- a/spec/v3/queries/user_spec.rb
+++ b/spec/v3/queries/user_spec.rb
@@ -1,0 +1,8 @@
+describe Travis::API::V3::Queries::User do
+  it 'fetches the newest user if multiple users exist with the same login' do
+    Factory(:user, login: 'travisbot')
+    newer = Factory(:user, login: 'travisbot')
+
+    described_class.new({ 'user.login' => 'travisbot' }, 'User').find.id.should == newer.id
+  end
+end


### PR DESCRIPTION
From the commit:

```
We sometimes might have more than one User or Organization record with
the same login in the DB. At the moment we don't invalidate them, which
means that there's a possibility that a user will get repositories from
an older organization. This doesn't really pose any security threat,
because we filter the repositories with a data from permissions table,
but it can result in confusing bugs for the users.

This commit changes queries used to fetch user and organization records
by logins to fetch records with the newest ids. This might not be 100%
accurate, so in the long run we should start invalidating old records,
but it should work in majority of cases (if not all cases).
```