### PR TITLE
Fix fetching accounts for a user

### DIFF
--- a/lib/travis/model/repository.rb
+++ b/lib/travis/model/repository.rb
@@ -83,9 +83,9 @@ class Repository < Travis::Model
     Hash[*all.map { |repository| [repository.name, repository] }.flatten]
   end
 
-  def self.counts_by_owner_ids(owner_ids)
-    query = %(SELECT owner_id, count(*) FROM repositories WHERE owner_id IN (?) AND invalidated_at IS NULL GROUP BY owner_id)
-    query = sanitize_sql([query, owner_ids])
+  def self.counts_by_owner_ids(owner_ids, owner_type)
+    query = %(SELECT owner_id, count(*) FROM repositories WHERE owner_id IN (?) and owner_type = ? AND invalidated_at IS NULL GROUP BY owner_id)
+    query = sanitize_sql([query, owner_ids, owner_type])
     rows = connection.select_all(query, owner_ids)
     Hash[*rows.map { |row| [row['owner_id'].to_i, row['count'].to_i] }.flatten]
   end

--- a/lib/travis/services/find_user_accounts.rb
+++ b/lib/travis/services/find_user_accounts.rb
@@ -6,32 +6,37 @@ module Travis
       register :find_user_accounts
 
       def run
-        ([current_user] + orgs).map do |record|
-          ::Account.from(record, :repos_count => repos_counts[record.id])
+        user_account = ::Account.from(current_user, :repos_count => repos_count_for_user[current_user.id])
+        org_accounts = orgs.map do |record|
+          ::Account.from(record, :repos_count => repos_counts_for_orgs[record.id])
         end
+
+        [user_account] + org_accounts
       end
 
       private
 
         def orgs
-          Organization.where(id: account_ids)
+          Organization.where(id: org_ids)
         end
 
-        def repos_counts
-          @repos_counts ||= Repository.counts_by_owner_ids(account_ids)
+        def repos_counts_for_orgs
+          @repos_counts_for_orgs ||= Repository.counts_by_owner_ids(org_ids, 'Organization')
         end
 
-        def account_ids
+        def repos_count_for_user
+          @repo_count_for_user ||= Repository.counts_by_owner_ids([current_user.id], 'User')
+        end
+
+        def org_ids
           repos = current_user.repositories
           unless params[:all]
             repos = repos.administrable
           end
-          org_ids = repos
-                      .select('DISTINCT owner_id')
-                      .where("owner_type = 'Organization'")
-                      .map(&:owner_id)
-
-          [current_user.id] + org_ids
+          repos
+            .select('DISTINCT owner_id')
+            .where("owner_type = 'Organization'")
+            .map(&:owner_id)
         end
     end
   end

--- a/spec/lib/model/repository_spec.rb
+++ b/spec/lib/model/repository_spec.rb
@@ -166,13 +166,13 @@ describe Repository do
 
     describe 'counts_by_owner_ids' do
       let!(:repositories) do
-        Factory(:repository, owner_id: 1, owner_name: 'svenfuchs', name: 'minimal')
-        Factory(:repository, owner_id: 2, owner_name: 'travis-ci', name: 'travis-ci')
-        Factory(:repository, owner_id: 2, owner_name: 'travis-ci', name: 'invalidated', invalidated_at: Time.now)
+        Factory(:repository, owner_id: 1, owner_type: 'Organization', owner_name: 'svenfuchs', name: 'minimal')
+        Factory(:repository, owner_id: 2, owner_type: 'Organization', owner_name: 'travis-ci', name: 'travis-ci')
+        Factory(:repository, owner_id: 2, owner_type: 'Organization', owner_name: 'travis-ci', name: 'invalidated', invalidated_at: Time.now)
       end
 
       it 'returns repository counts per owner_id for the given owner_ids' do
-        counts = Repository.counts_by_owner_ids([1, 2])
+        counts = Repository.counts_by_owner_ids([1, 2], 'Organization')
         counts.should == { 1 => 1, 2 => 1 }
       end
     end

--- a/spec/lib/services/find_user_accounts_spec.rb
+++ b/spec/lib/services/find_user_accounts_spec.rb
@@ -1,5 +1,5 @@
 describe Travis::Services::FindUserAccounts do
-  let!(:sven)    { Factory(:user, :login => 'sven') }
+  let!(:sven)    { Factory(:user, id: 9999999, :login => 'sven') }
   let!(:travis)  { Factory(:org, :login => 'travis-ci') }
   let!(:sinatra) { Factory(:org, :login => 'sinatra') }
   let!(:non_user_org) { Factory(:org, :login => 'travis-ci') }
@@ -10,6 +10,8 @@ describe Travis::Services::FindUserAccounts do
     Factory(:repository, :owner => travis, :owner_name => 'travis-ci', :name => 'travis-core')
     Factory(:repository, :owner => sinatra, :owner_name => 'sinatra', :name => 'sinatra')
   end
+
+  let!(:org) { Factory(:org, id: sven.id) }
 
   let(:service) { described_class.new(sven, params || {}) }
 
@@ -43,6 +45,10 @@ describe Travis::Services::FindUserAccounts do
 
   it 'does not include account of organizations that do not belong to the user, even though they match by name' do
     service.run.should_not include(Account.from(non_user_org))
+  end
+
+  it 'does not include organizations with the same id as a user' do
+    service.run.should_not include(Account.from(org))
   end
 
   it 'includes repository counts' do

--- a/spec/unit/endpoint/accounts_spec.rb
+++ b/spec/unit/endpoint/accounts_spec.rb
@@ -5,7 +5,7 @@ describe Travis::Api::App::Endpoint::Accounts, set_app: true do
   before do
     User.stubs(:find_by_github_id).returns(user)
     User.stubs(:find).returns(user)
-    Travis::Services::FindUserAccounts.any_instance.stubs(:account_ids).returns([user.id])
+    Travis::Services::FindUserAccounts.any_instance.stubs(:org_ids).returns([user.id])
     user.stubs(:attributes).returns(:id => user.id, :login => user.login, :name => user.name)
   end
 


### PR DESCRIPTION
When fixing a bug in fetching accounts I actually introduced another
problem that I caught only when testing on staging. The previous code
was searching for Organizations also using a user id, which could result
in fetching an Organization with the same id as a user, even thought the
organization might not be related to the user at all. This commit fixes
the problem.