### PR TITLE
Fix filtering by slug with uppercase letters

### DIFF
--- a/lib/travis/api/v3/queries/repositories.rb
+++ b/lib/travis/api/v3/queries/repositories.rb
@@ -47,7 +47,7 @@ module Travis::API::V3
       end
 
       if slug_filter
-        query = slug_filter.strip
+        query = slug_filter.strip.downcase
         sql_phrase = query.empty? ? '%' : "%#{query.split('').join('%')}%"
 
         query = ActiveRecord::Base.sanitize(query)

--- a/spec/v3/services/repositories/filter_spec.rb
+++ b/spec/v3/services/repositories/filter_spec.rb
@@ -12,7 +12,7 @@ describe Travis::API::V3::Services::Repositories::ForCurrentUser, set_app: true 
   before        { Travis::API::V3::Models::Permission.create(repository: long_name, user: user, pull: true, push: true, admin: true) }
 
   it "filters by query" do
-    get("/v3/repos?slug_filter=trvs&sort_by=slug_filter:desc,id:desc", {}, headers)
+    get("/v3/repos?slug_filter=Trvs&sort_by=slug_filter:desc,id:desc", {}, headers)
 
     slugs = parsed_body['repositories'].map { |repo_data| repo_data['slug'] }
 


### PR DESCRIPTION
When we were searching by slug we were querying the database for an
owner name and a repo name with all characters converted to lower case.
But the filter string was not converted, which means that it needed to
be in all lower case letters already. This commit fixes the problem by
converting a filter string to lower case as well.