### PR TITLE
Don't include repos that user doesn't have access to in counts

### DIFF
--- a/spec/lib/services/find_user_accounts_spec.rb
+++ b/spec/lib/services/find_user_accounts_spec.rb
@@ -5,11 +5,17 @@ describe Travis::Services::FindUserAccounts do
   let!(:non_user_org) { Factory(:org, :login => 'travis-ci') }
 
   let!(:repos) do
-    Factory(:repository, :owner => sven, :owner_name => 'sven', :name => 'minimal')
-    Factory(:repository, :owner => travis, :owner_name => 'travis-ci', :name => 'travis-ci')
-    Factory(:repository, :owner => travis, :owner_name => 'travis-ci', :name => 'travis-core')
-    Factory(:repository, :owner => sinatra, :owner_name => 'sinatra', :name => 'sinatra')
+    [
+      Factory(:repository, :owner => sven, :owner_name => 'sven', :name => 'minimal'),
+      Factory(:repository, :owner => travis, :owner_name => 'travis-ci', :name => 'travis-ci'),
+      Factory(:repository, :owner => travis, :owner_name => 'travis-ci', :name => 'travis-core'),
+      Factory(:repository, :owner => sinatra, :owner_name => 'sinatra', :name => 'sinatra'),
+    ]
   end
+
+  let!(:repo_without_permissions) {
+    Factory(:repository, :owner => travis, :owner_name => 'travis-ci', :name => 'secret')
+  }
 
   let!(:org) { Factory(:org, id: sven.id) }
 
@@ -18,7 +24,7 @@ describe Travis::Services::FindUserAccounts do
   attr_reader :params
 
   before :each do
-    Repository.all.each do |repo|
+    repos.each do |repo|
       permissions = repo.name == 'sinatra' ? { :push => true } : { :admin => true }
       sven.permissions.create!(permissions.merge :repository => repo)
     end

--- a/spec/unit/endpoint/accounts_spec.rb
+++ b/spec/unit/endpoint/accounts_spec.rb
@@ -5,8 +5,9 @@ describe Travis::Api::App::Endpoint::Accounts, set_app: true do
   before do
     User.stubs(:find_by_github_id).returns(user)
     User.stubs(:find).returns(user)
-    Travis::Services::FindUserAccounts.any_instance.stubs(:org_ids).returns([user.id])
+    Travis::Services::FindUserAccounts.any_instance.stubs(:owners_with_counts).returns([{ 'owner_id' => user.id, 'owner_type' => 'User', 'repos_count' => 1}])
     user.stubs(:attributes).returns(:id => user.id, :login => user.login, :name => user.name)
+
   end
 
   it 'includes accounts' do


### PR DESCRIPTION
The method of counting repositories when fetching user accounts didn't
take permissions into account. Because of that the number could be wrong
if user doesn't have access to some of the repositories in an
organization.

This commit fixes it by combining fetching organizations and repos
counts into one query.