### PR TITLE
Fix find_user_accounts service when user doesn't have any repos

### DIFF
--- a/lib/travis/services/find_user_accounts.rb
+++ b/lib/travis/services/find_user_accounts.rb
@@ -46,7 +46,7 @@ module Travis
             r['owner_type'] == 'User' && r['owner_id'].to_i == current_user.id
           }
 
-          ::Account.from(current_user, repos_count: user['repos_count'])
+          ::Account.from(current_user, repos_count: user ? user['repos_count'] : 0)
         end
     end
   end

--- a/spec/lib/services/find_user_accounts_spec.rb
+++ b/spec/lib/services/find_user_accounts_spec.rb
@@ -60,4 +60,10 @@ describe Travis::Services::FindUserAccounts do
   it 'includes repository counts' do
     service.run.map(&:repos_count).should == [1, 2]
   end
+
+  it 'works when user doesn\'t have any repos' do
+    Permission.destroy_all
+
+    service.run.should include(Account.from(sven))
+  end
 end


### PR DESCRIPTION
When a user doesn't have any repos, it will not be fetched with a new
SQL query that we use, so we can't get reppsitories count and in this
case we need to just return 0.