### PR TITLE
change sentry tag from x_request_id to request_id

### DIFF
--- a/lib/travis/api/app.rb
+++ b/lib/travis/api/app.rb
@@ -127,7 +127,7 @@ module Travis::Api
         if Travis::Api::App.use_monitoring?
           use Rack::Config do |env|
             if env['HTTP_X_REQUEST_ID']
-              Raven.tags_context(x_request_id: env['HTTP_X_REQUEST_ID'])
+              Raven.tags_context(request_id: env['HTTP_X_REQUEST_ID'])
             end
           end
           use Raven::Rack

--- a/lib/travis/api/app.rb
+++ b/lib/travis/api/app.rb
@@ -99,7 +99,7 @@ module Travis::Api
           env['metriks.request.start'] ||= Time.now.utc
 
           Travis::Honeycomb.clear
-          Travis::Honeycomb.context.add('x_request_id', env['HTTP_X_REQUEST_ID'])
+          Travis::Honeycomb.context.add('request_id', env['HTTP_X_REQUEST_ID'])
 
           ::Marginalia.clear!
           ::Marginalia.set('app', 'api')

--- a/lib/travis/api/app/middleware/error_handler.rb
+++ b/lib/travis/api/app/middleware/error_handler.rb
@@ -13,7 +13,7 @@ class Travis::Api::App
         body = "Sorry, we experienced an error.\n"
         if env['HTTP_X_REQUEST_ID']
           body += "\n"
-          body += "request_id=#{env['HTTP_X_REQUEST_ID']}\n"
+          body += "request_id:#{env['HTTP_X_REQUEST_ID']}\n"
         end
         [500, {'Content-Type' => 'text/plain'}, [body]]
       end

--- a/spec/integration/error_handling_spec.rb
+++ b/spec/integration/error_handling_spec.rb
@@ -62,7 +62,7 @@ describe 'Exception', set_app: true do
     Raven.stubs(:send_event)
     res = get '/repos/1', nil, 'HTTP_X_REQUEST_ID' => '235dd08f-10d5-4fcc-9a4d-6b8e6a24f975'
     expect(res.status).to eq(500)
-    expect(res.body).to eq("Sorry, we experienced an error.\n\nrequest_id=235dd08f-10d5-4fcc-9a4d-6b8e6a24f975\n")
+    expect(res.body).to eq("Sorry, we experienced an error.\n\nrequest_id:235dd08f-10d5-4fcc-9a4d-6b8e6a24f975\n")
     expect(res.headers).to eq({
       'Content-Type' => 'text/plain',
       'Content-Length' => '81',


### PR DESCRIPTION
this will make the error codes from api directly copy-pasteable into sentry, allowing for faster correlation.