### PR TITLE
Remove multi_os feature flag, multi_os is now the default

### DIFF
--- a/lib/travis/model/build.rb
+++ b/lib/travis/model/build.rb
@@ -197,7 +197,7 @@ class Build < Travis::Model
   end
 
   def config
-    @config ||= Config.new(super, multi_os: repository.try(:multi_os_enabled?)).normalize
+    @config ||= Config.new(super).normalize
   end
 
   def obfuscated_config

--- a/lib/travis/model/build/config.rb
+++ b/lib/travis/model/build/config.rb
@@ -10,7 +10,7 @@ require 'travis/model/build/config/yaml'
 
 class Build
   class Config
-    NORMALIZERS = [Features, Yaml, Env, Language, Group, Dist]
+    NORMALIZERS = [Features, Yaml, Env, Language, Group, Dist, OS]
 
     DEFAULT_LANG = 'ruby'
 
@@ -48,8 +48,6 @@ class Build
       :xcode_sdk
     ]
 
-    EXPANSION_KEYS_FEATURE = [:os]
-
     EXPANSION_KEYS_LANGUAGE = {
       'c'           => [:compiler],
       'c++'         => [:compiler],
@@ -82,7 +80,7 @@ class Build
       'visualbasic' => [:visualbasic, :mono]
     }
 
-    EXPANSION_KEYS_UNIVERSAL = [:env, :branch]
+    EXPANSION_KEYS_UNIVERSAL = [:env, :branch, :os]
 
     def self.matrix_keys_for(config, options = {})
       keys = matrix_keys(config, options)
@@ -93,7 +91,6 @@ class Build
       lang = Array(config.symbolize_keys[:language]).first
       keys = ENV_KEYS
       keys &= EXPANSION_KEYS_LANGUAGE.fetch(lang, EXPANSION_KEYS_LANGUAGE[DEFAULT_LANG])
-      keys << :os if options[:multi_os]
       keys += [:dist, :group] if options[:dist_group_expansion]
       keys | EXPANSION_KEYS_UNIVERSAL
     end
@@ -106,8 +103,7 @@ class Build
     end
 
     def normalize
-      normalizers = options[:multi_os] ? NORMALIZERS : NORMALIZERS + [OS]
-      normalizers.inject(config) do |config, normalizer|
+      NORMALIZERS.inject(config) do |config, normalizer|
         normalizer.new(config, options).run
       end
     end

--- a/lib/travis/model/build/config/dist.rb
+++ b/lib/travis/model/build/config/dist.rb
@@ -51,8 +51,7 @@ class Build
         (Array(h[:services]) || []).each do |service|
           return DIST_SERVICES_MAP[service] if DIST_SERVICES_MAP.key?(service)
         end
-        return DEFAULT_DIST if options[:multi_os]
-        DIST_OS_MAP.fetch(Array(h[:os]).first, DEFAULT_DIST)
+        return DEFAULT_DIST
       end
     end
   end

--- a/lib/travis/model/build/config/features.rb
+++ b/lib/travis/model/build/config/features.rb
@@ -5,16 +5,6 @@ class Build
     class Features < Struct.new(:config, :options)
       def run
         config = self.config
-        config = remove_multi_os(config) unless options[:multi_os]
-        config
-      end
-
-      def remove_multi_os(config)
-        config.delete(:os)
-        includes = config[:matrix].is_a?(Hash) && config[:matrix][:include]
-        return config unless includes.is_a?(Array)
-        includes = includes.each { |c| c.delete(:os) if c.is_a?(Hash) }.uniq
-        config[:matrix][:include] = includes
         config
       end
     end

--- a/lib/travis/model/build/config/language.rb
+++ b/lib/travis/model/build/config/language.rb
@@ -20,7 +20,7 @@ class Build
       end
 
       def known_env_key?(key)
-        (ENV_KEYS | EXPANSION_KEYS_FEATURE).include?(key)
+        ENV_KEYS.include?(key)
       end
     end
   end

--- a/lib/travis/model/build/config/matrix.rb
+++ b/lib/travis/model/build/config/matrix.rb
@@ -101,7 +101,7 @@ class Build
         end
 
         def known_env_key?(key)
-          (ENV_KEYS | EXPANSION_KEYS_FEATURE).include?(key)
+          ENV_KEYS.include?(key)
         end
     end
   end

--- a/lib/travis/model/build/matrix.rb
+++ b/lib/travis/model/build/matrix.rb
@@ -77,7 +77,7 @@ class Build
     private
 
       def matrix_config
-        @matrix_config ||= Config::Matrix.new(config, multi_os: repository.multi_os_enabled?, dist_group_expansion: repository.dist_group_expansion_enabled?)
+        @matrix_config ||= Config::Matrix.new(config, dist_group_expansion: repository.dist_group_expansion_enabled?)
       end
 
       def matrix_allow_failures

--- a/lib/travis/model/repository.rb
+++ b/lib/travis/model/repository.rb
@@ -187,10 +187,6 @@ class Repository < Travis::Model
     super
   end
 
-  def multi_os_enabled?
-    Travis::Features.enabled_for_all?(:multi_os) || Travis::Features.active?(:multi_os, self)
-  end
-
   def dist_group_expansion_enabled?
     Travis::Features.enabled_for_all?(:dist_group_expansion) || Travis::Features.active?(:dist_group_expansion, self)
   end

--- a/lib/travis/model/request.rb
+++ b/lib/travis/model/request.rb
@@ -108,7 +108,7 @@ class Request < Travis::Model
 
   def creates_jobs?
     Build::Config::Matrix.new(
-      Build::Config.new(config).normalize, multi_os: repository.multi_os_enabled?, dist_group_expansion: repository.dist_group_expansion_enabled?
+      Build::Config.new(config).normalize, dist_group_expansion: repository.dist_group_expansion_enabled?
     ).expand.size > 0
   end
 

--- a/spec/lib/model/build/config/dist_spec.rb
+++ b/spec/lib/model/build/config/dist_spec.rb
@@ -57,9 +57,8 @@ describe Build::Config::Dist do
     end
   end
 
-  context 'with multi_os option and override language set' do
+  context 'with an override language set' do
     let(:config) { { language: language } }
-    let(:options) { { multi_os: true } }
     let(:language) { described_class::DIST_LANGUAGE_MAP.keys.sample }
 
     it 'sets the override for that language' do
@@ -69,28 +68,9 @@ describe Build::Config::Dist do
     end
   end
 
-  context 'with multi_os option and non-override language set' do
+  context 'with a non-override language set' do
     let(:config) { { language: 'goober' } }
-    let(:options) { { multi_os: true } }
     let(:language) { described_class::DIST_LANGUAGE_MAP.keys.sample }
-
-    it 'sets dist to the default' do
-      subject.run[:dist].should eql(described_class::DEFAULT_DIST)
-    end
-  end
-
-  context 'without multi_os and os array with override first entry' do
-    let(:config) { { os: %w(osx linux) } }
-    let(:options) { { multi_os: false } }
-
-    it 'sets the override for that os' do
-      subject.run[:dist].should eql(described_class::DIST_OS_MAP['osx'])
-    end
-  end
-
-  context 'without multi_os and os array without override first entry' do
-    let(:config) { { os: %w(freebsd osx linux) } }
-    let(:options) { { multi_os: false } }
 
     it 'sets dist to the default' do
       subject.run[:dist].should eql(described_class::DEFAULT_DIST)

--- a/spec/lib/model/build/matrix_spec.rb
+++ b/spec/lib/model/build/matrix_spec.rb
@@ -750,20 +750,11 @@ describe Build, 'matrix' do
     let(:build)      { Factory(:build, repository: repository, config: matrix_with_includes_os_ruby) }
 
     it 'expands on :os if the feature is active' do
-      repository.stubs(:multi_os_enabled?).returns(true)
       build.matrix.map(&:config).should == [
         { os: 'linux', language: 'ruby', group: 'stable', dist: 'precise', compiler: 'gcc' },
         { os: 'linux', language: 'ruby', group: 'stable', dist: 'precise', compiler: 'clang' },
         { os: 'osx',   language: 'ruby', group: 'stable', dist: 'precise', compiler: 'gcc' },
         { os: 'osx',   language: 'ruby', group: 'stable', dist: 'precise', compiler: 'clang' }
-      ]
-    end
-
-    it 'ignores the os key if the feature is inactive' do
-      repository.stubs(:multi_os_enabled?).returns(false)
-      build.matrix.map(&:config).should == [
-        { os: 'linux', language: 'ruby', group: 'stable', dist: 'precise', compiler: 'gcc' },
-        { os: 'linux', language: 'ruby', group: 'stable', dist: 'precise', compiler: 'clang' }
       ]
     end
   end

--- a/spec/lib/model/build/matrix_spec.rb
+++ b/spec/lib/model/build/matrix_spec.rb
@@ -718,30 +718,15 @@ describe Build, 'matrix' do
     let(:repository) { Factory(:repository)}
     let(:test) { Factory(:test, repository: repository) }
 
-    context 'the feature is active' do
-      it 'expands on :os' do
-        repository.stubs(:multi_os_enabled?).returns(true)
-        build = Factory(:build, config: matrix_with_os_ruby, repository: repository)
+    it 'expands on :os' do
+      build = Factory(:build, config: matrix_with_os_ruby, repository: repository)
 
-        build.matrix.map(&:config).should == [
-          { os: 'osx', language: 'ruby', group: 'stable', dist: 'precise', rvm: '2.0.0', gemfile: 'gemfiles/rails-4' },
-          { os: 'osx', language: 'ruby', group: 'stable', dist: 'precise', rvm: '1.9.3', gemfile: 'gemfiles/rails-4' },
-          { os: 'linux', language: 'ruby', group: 'stable', dist: 'precise', rvm: '2.0.0', gemfile: 'gemfiles/rails-4' },
-          { os: 'linux', language: 'ruby', group: 'stable', dist: 'precise', rvm: '1.9.3', gemfile: 'gemfiles/rails-4' },
-        ]
-      end
-    end
-
-    context 'the feature is inactive' do
-      it 'does not expand on :os' do
-        repository.stubs(:multi_os_enabled?).returns(false)
-        build = Factory(:build, config: matrix_with_os_ruby, repository: repository)
-
-        build.matrix.map(&:config).should == [
-          { os: 'linux', language: 'ruby', group: 'stable', dist: 'precise', rvm: '2.0.0', gemfile: 'gemfiles/rails-4' },
-          { os: 'linux', language: 'ruby', group: 'stable', dist: 'precise', rvm: '1.9.3', gemfile: 'gemfiles/rails-4' }
-        ]
-      end
+      build.matrix.map(&:config).should == [
+        { os: 'osx', language: 'ruby', group: 'stable', dist: 'precise', rvm: '2.0.0', gemfile: 'gemfiles/rails-4' },
+        { os: 'osx', language: 'ruby', group: 'stable', dist: 'precise', rvm: '1.9.3', gemfile: 'gemfiles/rails-4' },
+        { os: 'linux', language: 'ruby', group: 'stable', dist: 'precise', rvm: '2.0.0', gemfile: 'gemfiles/rails-4' },
+        { os: 'linux', language: 'ruby', group: 'stable', dist: 'precise', rvm: '1.9.3', gemfile: 'gemfiles/rails-4' },
+      ]
     end
   end
 


### PR DESCRIPTION
Since multi_os is Enabled for everyone, and we now even enable it in Enterprise, this PR is aimed at removing it from gatekeeper. This is also helpful for the upcoming Enterprise 2.2 since we don't have to write migrations that enable feature flags for everyone to enable Trusty support.

This is all part of the on going work to clean up feature flags, which we're tracking in an internal ticket in `team-teal`. I'll cross reference that ticket there. 


