### PR TITLE
updated POST rate limit from 10 retries to 20

### DIFF
--- a/lib/travis/api/attack.rb
+++ b/lib/travis/api/attack.rb
@@ -86,9 +86,9 @@ class Rack::Attack
   ####
   # Ban based on: IP address or access token
   # Ban time:     1 hour
-  # Ban after:    10 POST requests within 30 seconds
+  # Ban after:    20 POST requests within 30 seconds
   blocklist('spamming_post_requests') do |request|
-    Rack::Attack::Allow2Ban.filter(request.identifier, maxretry: 10, findtime: 30.seconds, bantime: bantime(1.hour)) do
+    Rack::Attack::Allow2Ban.filter(request.identifier, maxretry: 20, findtime: 30.seconds, bantime: bantime(1.hour)) do
       request.post? and not POST_SAFELIST.include? request.path
     end
   end


### PR DESCRIPTION
I have over 200 open-source projects, of which maintaining them is becoming quite problematic due to this rate limit. Part of the maintenance is running `travis env set|unset` commands on the repos. I have an automated script that runs through my projects and does these updates. However, eventually, it always ends up with something like this (manual example):

```
19:21:18:/Users/balupton/Projects/websites/staticsitegenerators-list:master
> travis login
We need your GitHub login to identify you.
This information will not be sent to Travis CI, only to api.github.com.
The password will not be displayed.

Try running with --github-token or --auto if you don't want to enter your password anyway.

Username: balupton
Password for balupton: **********************
Two-factor authentication code for balupton: 989244
Successfully logged in as balupton!
19:21:52:/Users/balupton/Projects/websites/staticsitegenerators-list:master
> travis env set SURGE_LOGIN "$SURGE_LOGIN" --public --no-interactive
not logged in, please run travis login --pro
```

Hopefully this fixes it.