### PR TITLE
Fix always nil SSL config block in Enterprise

### DIFF
--- a/lib/travis/remote_log.rb
+++ b/lib/travis/remote_log.rb
@@ -3,7 +3,6 @@ require 'json'
 
 require 'faraday'
 require 'faraday_middleware'
-require 'core_ext/hash/compact'
 require 'virtus'
 
 module Travis
@@ -234,7 +233,7 @@ module Travis
       end
 
       private def http_options
-        { ssl: Travis.config.ssl.to_h.compact }
+        { ssl: Travis.config.ssl.to_h }
       end
     end
 

--- a/lib/travis/remote_log.rb
+++ b/lib/travis/remote_log.rb
@@ -3,6 +3,7 @@ require 'json'
 
 require 'faraday'
 require 'faraday_middleware'
+require 'core_ext/hash/compact'
 require 'virtus'
 
 module Travis

--- a/lib/travis/remote_log.rb
+++ b/lib/travis/remote_log.rb
@@ -233,7 +233,7 @@ module Travis
       end
 
       private def http_options
-        { ssl: Travis.config.ssl.compact.to_h }
+        { ssl: Travis.config.ssl.to_h.compact }
       end
     end
 

--- a/lib/travis/task.rb
+++ b/lib/travis/task.rb
@@ -85,7 +85,7 @@ module Travis
       end
 
       def http_options
-        { ssl: Travis.config.ssl.compact.to_h }
+        { ssl: Travis.config.ssl.to_h.compact }
       end
 
       def timeout(options = { after: 60 }, &block)

--- a/lib/travis/task.rb
+++ b/lib/travis/task.rb
@@ -85,7 +85,7 @@ module Travis
       end
 
       def http_options
-        { ssl: Travis.config.ssl.to_h.compact }
+        { ssl: Travis.config.ssl.to_h }
       end
 
       def timeout(options = { after: 60 }, &block)


### PR DESCRIPTION
Seeing an issue where API can't talk to the logs API when using a self signed cert. The SSL config fixes this but due to calling `compact` on `Travis.config.ssl` instead of `Travis.config.ssl.to_h` (as travis config objects are no longer a subclass of `Hash`) it will always be nil as it's looking for a config key called compact and there is none. 