### PR TITLE
Fix some V2 endpoints to not include public stuff on .com

### DIFF
--- a/lib/travis/services/find_builds.rb
+++ b/lib/travis/services/find_builds.rb
@@ -26,7 +26,7 @@ module Travis
         end
 
         def by_params
-          if repo
+          scope = if repo
             # TODO :after_number seems like a bizarre api why not just pass an id? pagination style?
             builds = repo.builds
             builds = builds.by_event_type(params[:event_type]) if params[:event_type]
@@ -36,11 +36,21 @@ module Travis
               builds.older_than(params[:after_number])
             end
           elsif params[:running]
-            scope(:build).running.limit(25)
+            scope_with_current_user(scope(:build).running.limit(25))
           elsif params.nil? || params == {} || params.keys.map(&:to_s) == ['access_token']
-            scope(:build).recent
+            scope_with_current_user(scope(:build).recent)
           else
             scope(:build).none
+          end
+
+          scope
+        end
+
+        def scope_with_current_user(scope)
+          if !Travis.config.org? && current_user
+            scope.where(repository_id: current_user.repository_ids)
+          else
+            scope
           end
         end
 

--- a/lib/travis/services/find_jobs.rb
+++ b/lib/travis/services/find_jobs.rb
@@ -31,6 +31,11 @@ module Travis
             jobs = jobs.where(queue: params[:queue]) if params[:queue]
             jobs
           end
+
+          if !Travis.config.org? && current_user
+            jobs = jobs.where(repository_id: current_user.repository_ids)
+          end
+
           jobs.includes(:commit).limit(250)
         end
     end

--- a/lib/travis/services/find_repos.rb
+++ b/lib/travis/services/find_repos.rb
@@ -30,6 +30,11 @@ module Travis
           if params[:search].present?
             scope = scope.search(params[:search]).order('last_build_started_at DESC NULLS LAST')
           end
+
+          if !Travis.config.org? && current_user && timeline?
+            scope = scope.where(id: current_user.repository_ids)
+          end
+
           scope = scope.limit(limit) if limit
           scope
         end

--- a/spec/auth/v1/builds_spec.rb
+++ b/spec/auth/v1/builds_spec.rb
@@ -44,7 +44,7 @@ describe 'v1 builds', auth_helpers: true, api_version: :v1, set_app: true do
   describe 'in public mode, with a public repo', mode: :public, repo: :public do
     describe 'GET /builds' do
       it(:with_permission)    { should auth status: 200, type: :json, empty: false }
-      it(:without_permission) { should auth status: 200, type: :json, empty: false }
+      it(:without_permission) { should auth status: 200, type: :json, empty: true }
       it(:invalid_token)      { should auth status: 403 }
       it(:unauthenticated)    { should auth status: 401 }
     end
@@ -52,7 +52,7 @@ describe 'v1 builds', auth_helpers: true, api_version: :v1, set_app: true do
     describe 'GET /builds?running=true' do
       before { build.update_attributes(state: :started) }
       it(:with_permission)    { should auth status: 200, type: :json, empty: false }
-      it(:without_permission) { should auth status: 200, type: :json, empty: false }
+      it(:without_permission) { should auth status: 200, type: :json, empty: true }
       it(:invalid_token)      { should auth status: 403 }
       it(:unauthenticated)    { should auth status: 401 }
     end

--- a/spec/auth/v1/jobs_spec.rb
+++ b/spec/auth/v1/jobs_spec.rb
@@ -39,7 +39,7 @@ describe 'v1 jobs', auth_helpers: true, api_version: :v1, set_app: true do
   describe 'in public mode, with a public repo', mode: :public, repo: :public do
     describe 'GET /jobs' do
       it(:with_permission)    { should auth status: [200, 307], type: :json, empty: false }
-      it(:without_permission) { should auth status: [200, 307], type: :json, empty: false }
+      it(:without_permission) { should auth status: [200, 307], type: :json, empty: true  }
       it(:invalid_token)      { should auth status: 403 }
       it(:unauthenticated)    { should auth status: 401 }
     end

--- a/spec/auth/v1/repos_spec.rb
+++ b/spec/auth/v1/repos_spec.rb
@@ -130,7 +130,7 @@ describe 'v1 repos', auth_helpers: true, api_version: :v1, set_app: true do
   describe 'in public mode, with a public repo', mode: :public, repo: :public do
     describe 'GET /repos' do
       it(:with_permission)    { should auth status: 200, type: :json, empty: false }
-      it(:without_permission) { should auth status: 200, type: :json, empty: false }
+      it(:without_permission) { should auth status: 200, type: :json, empty: true }
       it(:invalid_token)      { should auth status: 403 }
       it(:unauthenticated)    { should auth status: 401 }
     end

--- a/spec/auth/v2.1/builds_spec.rb
+++ b/spec/auth/v2.1/builds_spec.rb
@@ -48,7 +48,7 @@ describe 'v2.1 builds', auth_helpers: true, api_version: :'v2.1', set_app: true 
   describe 'in public mode, with a public repo', mode: :public, repo: :public do
     describe 'GET /builds' do
       it(:with_permission)    { should auth status: 200, type: :json, empty: false }
-      it(:without_permission) { should auth status: 200, type: :json, empty: false }
+      it(:without_permission) { should auth status: 200, type: :json, empty: true }
       it(:invalid_token)      { should auth status: 403 }
       it(:unauthenticated)    { should auth status: 200, type: :json, empty: false }
     end
@@ -56,7 +56,7 @@ describe 'v2.1 builds', auth_helpers: true, api_version: :'v2.1', set_app: true 
     describe 'GET /builds?running=true' do
       before { build.update_attributes(state: :started) }
       it(:with_permission)    { should auth status: 200, type: :json, empty: false }
-      it(:without_permission) { should auth status: 200, type: :json, empty: false }
+      it(:without_permission) { should auth status: 200, type: :json, empty: true }
       it(:invalid_token)      { should auth status: 403 }
       it(:unauthenticated)    { should auth status: 200, type: :json, empty: false }
     end

--- a/spec/auth/v2.1/jobs_spec.rb
+++ b/spec/auth/v2.1/jobs_spec.rb
@@ -39,7 +39,7 @@ describe 'v2.1 jobs', auth_helpers: true, api_version: :'v2.1', set_app: true do
   describe 'in public mode, with a public repo', mode: :public, repo: :public do
     describe 'GET /jobs' do
       it(:with_permission)    { should auth status: 200, type: :json, empty: false }
-      it(:without_permission) { should auth status: 200, type: :json, empty: false }
+      it(:without_permission) { should auth status: 200, type: :json, empty: true }
       it(:invalid_token)      { should auth status: 403 }
       it(:unauthenticated)    { should auth status: 200, type: :json, empty: false }
     end

--- a/spec/auth/v2.1/repos_spec.rb
+++ b/spec/auth/v2.1/repos_spec.rb
@@ -130,7 +130,7 @@ describe 'v2.1 repos', auth_helpers: true, api_version: :'v2.1', set_app: true d
   describe 'in public mode, with a public repo', mode: :public, repo: :public do
     describe 'GET /repos' do
       it(:with_permission)    { should auth status: 200, type: :json, empty: false }
-      it(:without_permission) { should auth status: 200, type: :json, empty: false }
+      it(:without_permission) { should auth status: 200, type: :json, empty: true }
       it(:invalid_token)      { should auth status: 403 }
       it(:unauthenticated)    { should auth status: 401 }
     end

--- a/spec/auth/v2/builds_spec.rb
+++ b/spec/auth/v2/builds_spec.rb
@@ -48,7 +48,7 @@ describe 'v2 builds', auth_helpers: true, api_version: :v2, set_app: true do
   describe 'in public mode, with a public repo', mode: :public, repo: :public do
     describe 'GET /builds' do
       it(:with_permission)    { should auth status: 200, type: :json, empty: false }
-      it(:without_permission) { should auth status: 200, type: :json, empty: false }
+      it(:without_permission) { should auth status: 200, type: :json, empty: true }
       it(:invalid_token)      { should auth status: 403 }
       it(:unauthenticated)    { should auth status: 401 }
     end
@@ -56,7 +56,7 @@ describe 'v2 builds', auth_helpers: true, api_version: :v2, set_app: true do
     describe 'GET /builds?running=true' do
       before { build.update_attributes(state: :started) }
       it(:with_permission)    { should auth status: 200, type: :json, empty: false }
-      it(:without_permission) { should auth status: 200, type: :json, empty: false }
+      it(:without_permission) { should auth status: 200, type: :json, empty: true }
       it(:invalid_token)      { should auth status: 403 }
       it(:unauthenticated)    { should auth status: 401 }
     end

--- a/spec/auth/v2/jobs_spec.rb
+++ b/spec/auth/v2/jobs_spec.rb
@@ -39,7 +39,7 @@ describe 'v2 jobs', auth_helpers: true, api_version: :v2, set_app: true do
   describe 'in public mode, with a public repo', mode: :public, repo: :public do
     describe 'GET /jobs' do
       it(:with_permission)    { should auth status: 200, type: :json, empty: false }
-      it(:without_permission) { should auth status: 200, type: :json, empty: false }
+      it(:without_permission) { should auth status: 200, type: :json, empty: true }
       it(:invalid_token)      { should auth status: 403 }
       it(:unauthenticated)    { should auth status: 401 }
     end

--- a/spec/auth/v2/repos_spec.rb
+++ b/spec/auth/v2/repos_spec.rb
@@ -130,7 +130,7 @@ describe 'v2 repos', auth_helpers: true, api_version: :v2, set_app: true do
   describe 'in public mode, with a public repo', mode: :public, repo: :public do
     describe 'GET /repos' do
       it(:with_permission)    { should auth status: 200, type: :json, empty: false }
-      it(:without_permission) { should auth status: 200, type: :json, empty: false }
+      it(:without_permission) { should auth status: 200, type: :json, empty: true }
       it(:invalid_token)      { should auth status: 403 }
       it(:unauthenticated)    { should auth status: 401 }
     end


### PR DESCRIPTION
After switching from travis-pro-api to travis-api to serve traffic on
Travis CI Pro it turned out that there're differences in how certain
endpoints return the data. In travis-pro-api we were scoping all of the
endpoints to return only the stuff that belongs to a user. In travis-api
we return records to which a user has access to *and* public data. This
makes sense in most of the places, but not for `/repos`, `/builds` or
`/jobs`. The assumption there is that you get only your data when you do
an authenticated request, not your data and some random public records.

This issue will require setting `public_repos_in_v2_root_endpoints` config option to true on .org. I went with the flag, because we want to keep the behaviour unchanged on .org, but change it for everything else (ie. .com and enterprise).