### PR TITLE
Fix SSL errors during Authorization against GitHub Enterprise with self signed cert

### DIFF
--- a/lib/travis/api/app/endpoint/authorization.rb
+++ b/lib/travis/api/app/endpoint/authorization.rb
@@ -301,7 +301,7 @@ class Travis::Api::App
         end
 
         def get_token(endpoint, values)
-          conn = Faraday.new(ssl: Travis.config.ssl.to_h.merge(Travis.config.github.ssl.to_h || {}).compact) do |conn|
+          conn = Faraday.new(ssl: Travis.config.github.ssl.to_h } do |conn|
             conn.request :json
             conn.use :instrumentation
             conn.adapter :net_http_persistent

--- a/lib/travis/api/app/endpoint/authorization.rb
+++ b/lib/travis/api/app/endpoint/authorization.rb
@@ -301,7 +301,7 @@ class Travis::Api::App
         end
 
         def get_token(endpoint, values)
-          conn = Faraday.new(ssl: Travis.config.ssl.to_h.merge(Travis.config.github.ssl || {}).compact) do |conn|
+          conn = Faraday.new(ssl: Travis.config.ssl.to_h.merge(Travis.config.github.ssl.to_h || {}).compact) do |conn|
             conn.request :json
             conn.use :instrumentation
             conn.adapter :net_http_persistent

--- a/lib/travis/api/app/endpoint/authorization.rb
+++ b/lib/travis/api/app/endpoint/authorization.rb
@@ -301,7 +301,7 @@ class Travis::Api::App
         end
 
         def get_token(endpoint, values)
-          conn = Faraday.new(ssl: Travis.config.github.ssl.to_h } do |conn|
+          conn = Faraday.new(ssl: Travis.config.github.ssl.to_h ) do |conn|
             conn.request :json
             conn.use :instrumentation
             conn.adapter :net_http_persistent


### PR DESCRIPTION
For some reason Folding together the two SSL options pieces now breaks turning off SSL verification for self signed certs. Seems that you can't set a ca bundle AND turn off verify with Faraday? Maybe some change has been shipped there. 

So let's just control this from the GitHub config block like we used to. 