### PR TITLE
pagination count cache

### DIFF
--- a/lib/travis/api/v3/paginator/count_cache.rb
+++ b/lib/travis/api/v3/paginator/count_cache.rb
@@ -1,0 +1,54 @@
+require 'digest'
+require 'travis/honeycomb'
+
+module Travis::API::V3
+  class Paginator
+    class CountCache
+      attr_accessor :result
+
+      def initialize(result)
+        @result = result
+      end
+
+      def count
+        count = Travis.redis.get(cache_key)&.to_i
+
+        if count
+          Travis::Honeycomb.context.add('pagination.count_cache.hit', 1)
+        else
+          count = count_upstream
+          if count >= threshold
+            Travis.redis.setex(cache_key, ttl, count)
+            Travis::Honeycomb.context.add('pagination.count_cache.miss', 1)
+          else
+            Travis::Honeycomb.context.add('pagination.count_cache.bypass', 1)
+          end
+        end
+
+        Travis::Honeycomb.context.add('pagination.count_cache.count', count)
+
+        count
+      end
+
+      def count_upstream
+        result.resource.count(:all)
+      end
+
+      def cache_key
+        "api:count_query:#{query_hash}"
+      end
+
+      def query_hash
+        Digest::SHA1.hexdigest(result.resource.to_sql)
+      end
+
+      def ttl
+        ENV['PAGINATION_COUNT_CACHE_TTL']&.to_i || 60*60*24
+      end
+
+      def threshold
+        ENV['PAGINATION_COUNT_CACHE_THRESHOLD']&.to_i || 100
+      end
+    end
+  end
+end


### PR DESCRIPTION
For a lot of endpoints, the pagination count query is the biggest performance bottleneck. The fundamental issue is that counts are expensive. If there are many records, a count essentially means we need to do a full scan of all those records.

As a long-term solution we should probably move away from count-based pagination in the case of large tables (builds and jobs). There are faster pagination approaches described in [Pagination Done the Right Way](https://use-the-index-luke.com/blog/2013-07/pagination-done-the-postgresql-way).

This patch is essentially a hack that caches the count, with the assumption that it does not need to be that accurate anyway. Possible optimizations to this patch include:

* [x] Guesstimate the number of records using explain and only use the cache if we expect there to be many rows returned. Or even better: only set the cache key if the value exceeds a threshold (say 1k).
* [x] ~The query hash currently still includes limit/offset -- we should drop those so that we don't have to cache one key per page.~