### PR TITLE
Revert "Fix SSL errors during Authorization against GitHub Enterprise with self signed cert"

### DIFF
--- a/lib/travis/api/app/endpoint/authorization.rb
+++ b/lib/travis/api/app/endpoint/authorization.rb
@@ -301,7 +301,7 @@ class Travis::Api::App
         end
 
         def get_token(endpoint, values)
-          conn = Faraday.new(ssl: Travis.config.github.ssl.to_h ) do |conn|
+          conn = Faraday.new(ssl: Travis.config.ssl.to_h.merge(Travis.config.github.ssl || {}).compact) do |conn|
             conn.request :json
             conn.use :instrumentation
             conn.adapter :net_http_persistent


### PR DESCRIPTION
Reverts travis-ci/travis-api#657

Ended up going a different direction with this where merging in the `ca_file` would make sense again. Now the `verify: false` setting is configurable in the interface so reverting this makes sense. 