### PR TITLE
include queued and received builds in "active" list

### DIFF
--- a/lib/travis/api/v3/queries/builds.rb
+++ b/lib/travis/api/v3/queries/builds.rb
@@ -12,7 +12,7 @@ module Travis::API::V3
     def active_from(repositories)
       V3::Models::Build.where(
         repository_id: repositories.pluck(:id),
-        state: ['created'.freeze, 'started'.freeze]
+        state: ['created'.freeze, 'queued'.freeze, 'received'.freeze, 'started'.freeze]
       ).includes(:active_jobs)
     end
 


### PR DESCRIPTION
the `Travis::API::V3::Services::Active::ForOwner` endpoint currently only considers `created` and `started` jobs. we probably want to expand that to include `queued` and `received` too.

refs travis-ci/reliability#16