### PR TITLE
honeycomb: make pool size configurable

### DIFF
--- a/lib/travis/honeycomb.rb
+++ b/lib/travis/honeycomb.rb
@@ -33,7 +33,9 @@ module Travis
       end
 
       def honey
-        @honey ||= Libhoney::Client.new
+        @honey ||= Libhoney::Client.new(
+          max_concurrent_batches: ENV['HONEYCOMB_POOL_SIZE']&.to_i || 10,
+        )
       end
 
       def honey_setup


### PR DESCRIPTION
when running in unicorn, we have 50 unicorn workers per dyno. currently we are creating 10 honeycomb worker threads per unicorn worker.

this patch makes the pool size configurable, so that we can reduce it to 1 (per unicorn worker).

refs travis-ci/reliability#27