### PR TITLE
Update Faraday to fix issue where it ignores no_proxy in certain cases

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -184,7 +184,7 @@ GEM
     excon (0.60.0)
     factory_girl (2.4.2)
       activesupport
-    faraday (0.12.2)
+    faraday (0.14.0)
       multipart-post (>= 1.2, < 3)
     faraday_middleware (0.12.2)
       faraday (>= 0.7.4, < 1.0)


### PR DESCRIPTION
While testing http_proxy on Enterprise I noticed that the License endpoint in API kept ignoring `no_proxy` and trying to proxy the private address. 

Looking around I found the issue was with Faraday and fixed in 0.13 (https://github.com/lostisland/faraday/pull/712). 

Essentially any code that went `Faraday.new(options).get` would skip setting up the proxy envs correctly. The license code is the only code that I've seen so far that does it. And updating Faraday fixes that in case there are others. 

