### PR TITLE
[Enterprise Backport] Update Faraday to fix issue where it ignores no_proxy in certain cases (#669)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -184,7 +184,7 @@ GEM
     excon (0.60.0)
     factory_girl (2.4.2)
       activesupport
-    faraday (0.12.2)
+    faraday (0.14.0)
       multipart-post (>= 1.2, < 3)
     faraday_middleware (0.12.2)
       faraday (>= 0.7.4, < 1.0)


### PR DESCRIPTION
Backport of #669 for Enterprise 2.2 