### PR TITLE
Use Travis.config.redis to empty Redis before each test

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -97,7 +97,7 @@ RSpec.configure do |c|
 
   c.before :each do
     DatabaseCleaner.start
-    Redis.new.flushall
+    Redis.new(Travis.config.redis.to_h).flushall
     Travis.config.public_mode = true
     Travis.config.host = 'travis-ci.org'
     Travis.config.oauth2.scope = "user:email,public_repo"


### PR DESCRIPTION
The tests ignored `Travis.config.redis` and assumed that Redis runs on `localhost` which is not necessarily true.

There is a second assumption which is that the general Redis is also used for Gatekeeper which is also not necessarily true (they are configured separately), but more likely when running tests.