### PR TITLE
Run each test in config_spec in a fresh environment

### DIFF
--- a/spec/lib/travis/config_spec.rb
+++ b/spec/lib/travis/config_spec.rb
@@ -2,6 +2,14 @@ require 'spec_helper'
 require 'active_support/core_ext/hash/slice'
 
 describe Travis::Config do
+  # Run examples with a fresh ENV and restore original afterwards
+  around do |example|
+    old_env = ENV.to_h
+    ENV.replace({})
+    example.run
+    ENV.replace(old_env)
+  end
+
   let(:config) { Travis::Config.load(:files, :env, :heroku, :docker) }
   let(:statement_timeout) { Travis::Config::Heroku::Database::VARIABLES[:statement_timeout] }
 
@@ -89,7 +97,6 @@ describe Travis::Config do
   describe 'resource urls' do
     describe 'with a TRAVIS_DATABASE_URL set' do
       before { ENV['TRAVIS_DATABASE_URL'] = 'postgres://username:password@host:1234/database' }
-      after  { ENV.delete('TRAVIS_DATABASE_URL') }
 
       it { config.database.username.should == 'username' }
       it { config.database.password.should == 'password' }
@@ -103,7 +110,6 @@ describe Travis::Config do
 
     describe 'with a DATABASE_URL set' do
       before { ENV['DATABASE_URL'] = 'postgres://username:password@host:1234/database' }
-      after  { ENV.delete('DATABASE_URL') }
 
       it { config.database.username.should == 'username' }
       it { config.database.password.should == 'password' }
@@ -117,7 +123,6 @@ describe Travis::Config do
 
     describe 'with a TRAVIS_LOGS_DATABASE_URL set' do
       before { ENV['TRAVIS_LOGS_DATABASE_URL'] = 'postgres://username:password@host:1234/database' }
-      after  { ENV.delete('TRAVIS_LOGS_DATABASE_URL') }
 
       it { config.logs_database.username.should == 'username' }
       it { config.logs_database.password.should == 'password' }
@@ -131,7 +136,6 @@ describe Travis::Config do
 
     describe 'with a LOGS_DATABASE_URL set' do
       before { ENV['LOGS_DATABASE_URL'] = 'postgres://username:password@host:1234/database' }
-      after  { ENV.delete('LOGS_DATABASE_URL') }
 
       it { config.logs_database.username.should == 'username' }
       it { config.logs_database.password.should == 'password' }
@@ -145,7 +149,6 @@ describe Travis::Config do
 
     describe 'with a TRAVIS_RABBITMQ_URL set' do
       before { ENV['TRAVIS_RABBITMQ_URL'] = 'amqp://username:password@host:1234/vhost' }
-      after  { ENV.delete('TRAVIS_RABBITMQ_URL') }
 
       it { config.amqp.username.should == 'username' }
       it { config.amqp.password.should == 'password' }
@@ -156,7 +159,6 @@ describe Travis::Config do
 
     describe 'with a RABBITMQ_URL set' do
       before { ENV['RABBITMQ_URL'] = 'amqp://username:password@host:1234/vhost' }
-      after  { ENV.delete('RABBITMQ_URL') }
 
       it { config.amqp.username.should == 'username' }
       it { config.amqp.password.should == 'password' }
@@ -167,14 +169,12 @@ describe Travis::Config do
 
     describe 'with a TRAVIS_REDIS_URL set' do
       before { ENV['TRAVIS_REDIS_URL'] = 'redis://username:password@host:1234' }
-      after  { ENV.delete('TRAVIS_REDIS_URL') }
 
       it { config.redis.url.should == 'redis://username:password@host:1234' }
     end
 
     describe 'with a REDIS_URL set' do
       before { ENV['REDIS_URL'] = 'redis://username:password@host:1234' }
-      after  { ENV.delete('REDIS_URL') }
 
       it { config.redis.url.should == 'redis://username:password@host:1234' }
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -97,7 +97,7 @@ RSpec.configure do |c|
 
   c.before :each do
     DatabaseCleaner.start
-    Redis.new.flushall
+    Redis.new(Travis.config.redis.to_h).flushall
     Travis.config.public_mode = true
     Travis.config.host = 'travis-ci.org'
     Travis.config.oauth2.scope = "user:email,public_repo"


### PR DESCRIPTION
(and restore the old one afterwards)

All these tests don't play very nicely if you are setting environment variables for setting up, for example, a database or Redis server which are not the default.

* On one hand, they assume the default configuration and an empty environment, so they break if you set something
* On the other hand, some of them overwrite values, which can break your setup for the rest of the tests

The implementation is not super clean, but I couldn't find a way for stubbing the `ENV` constant in mocha, and stubbing the `[]` method won't work because the data could be accessed using other methods like `fetch` (e.g. `Travis::Config` uses `values_at`). I guess using the real environment, as long as we take care of restoring it afterwards, is fine (after all, we were using it before, without doing any setup or restoration).

### Possible improvement

We could hide this implementation behind a helper with [this API](https://github.com/travis-ci/travis-config/blob/master/spec/travis/config/env_spec.rb#L22-L33). Is it worth it?