### PR TITLE
[Enterprise 2.2 Backport] Include base URL in Faraday.new so it honors no_proxy (#684)

### DIFF
--- a/lib/travis/api/app/endpoint/authorization.rb
+++ b/lib/travis/api/app/endpoint/authorization.rb
@@ -301,7 +301,12 @@ class Travis::Api::App
         end
 
         def get_token(endpoint, values)
-          conn = Faraday.new(ssl: Travis.config.ssl.to_h.merge(Travis.config.github.ssl || {}).compact) do |conn|
+          # Get base URL for when we setup Faraday since otherwise it'll ignore no_proxy
+          url = URI.parse(endpoint)
+          base_url = "#{url.scheme}://#{url.host}"
+          http_options = {url: base_url, ssl: Travis.config.ssl.to_h.merge(Travis.config.github.ssl || {}).compact} 
+
+          conn = Faraday.new(http_options) do |conn|
             conn.request :json
             conn.use :instrumentation
             conn.adapter :net_http_persistent

--- a/lib/travis/api/v3/services/enterprise_license/find.rb
+++ b/lib/travis/api/v3/services/enterprise_license/find.rb
@@ -2,7 +2,8 @@ module Travis::API::V3
   class Services::EnterpriseLicense::Find < Service
     def run!
       if replicated_endpoint
-        response = Faraday.new(ssl: Travis.config.ssl.to_h || {}).get("#{replicated_endpoint}/license/v1/license")
+        http_options = {url: replicated_endpoint, ssl: Travis.config.ssl.to_h}.compact
+        response = Faraday.new(http_options).get("license/v1/license")
         replicated_response = JSON.parse(response.body)
         license_id = replicated_response["license_id"]
         license_type = replicated_response["license_type"]


### PR DESCRIPTION
Backports #684 

We'll also need to do this with 2.1 so that github auth works with proxying/no_proxy. 