### PR TITLE
Always add deploy keys when using travis Enterprise

### DIFF
--- a/lib/travis/api/v3/services/repository/activate.rb
+++ b/lib/travis/api/v3/services/repository/activate.rb
@@ -5,7 +5,7 @@ module Travis::API::V3
     def run!
       repository = super(true).resource
 
-      if repository.private?
+      if repository.private? || access_control.enterprise?
         admin = access_control.admin_for(repository)
         github(admin).upload_key(repository)
       end

--- a/lib/travis/services/update_hook.rb
+++ b/lib/travis/services/update_hook.rb
@@ -10,7 +10,7 @@ module Travis
 
       def run
         run_service(:github_set_hook, id: repo.id, active: active?)
-        run_service(:github_set_key, params) if repo.private?
+        run_service(:github_set_key, params) if repo.private? || Travis.config.enterprise
         repo.update_column(:active, active?)
         sync_repo if active?
         true


### PR DESCRIPTION
When Enterprise used `travis-pro-api` it always would add keys, even to public repositories. This was because `travis-pro-api` didn't have a concept of public repos. Now that we use `travis-api` we're running into issues where the `source_url` getting passed to the worker is using the non-anonymous GitHub clone URL when we use GitHub Enterprise (https://github.com/travis-ci/travis-api/blob/master/lib/travis/model/repository.rb#L109-L119).

The proper way of fixing this would be to detect if we're using GitHub Enterprise and adjust accordingly. However this has the additional wrinkle of needing to accommodate `Private Mode` on GHE which makes even "Public" repositories require authentication. 

So my approach in this PR is to restore the old behavior of _always_ placing a deploy key when activating a repository if we're on Travis Enterprise. 