### PR TITLE
/v3/subscriptions endpoint

### DIFF
--- a/lib/travis/api/v3/billing.rb
+++ b/lib/travis/api/v3/billing.rb
@@ -17,6 +17,12 @@ module Travis::API::V3
       end
     end
 
+    def all
+      connection.get('/subscriptions').body.map do |subscription_data|
+        Subscription.new(subscription_data)
+      end
+    end
+
     private
 
     def connection

--- a/lib/travis/api/v3/queries/subscriptions.rb
+++ b/lib/travis/api/v3/queries/subscriptions.rb
@@ -1,0 +1,8 @@
+module Travis::API::V3
+  class Queries::Subscriptions < Query
+    def all(user_id)
+      client = Billing.new(user_id)
+      client.all
+    end
+  end
+end

--- a/lib/travis/api/v3/renderer/subscription.rb
+++ b/lib/travis/api/v3/renderer/subscription.rb
@@ -1,0 +1,5 @@
+module Travis::API::V3
+  class Renderer::Subscription < ModelRenderer
+    representation(:standard, :id)
+  end
+end

--- a/lib/travis/api/v3/renderer/subscriptions.rb
+++ b/lib/travis/api/v3/renderer/subscriptions.rb
@@ -1,0 +1,6 @@
+module Travis::API::V3
+  class Renderer::Subscriptions < CollectionRenderer
+    type           :subscriptions
+    collection_key :subscriptions
+  end
+end

--- a/lib/travis/api/v3/routes.rb
+++ b/lib/travis/api/v3/routes.rb
@@ -228,5 +228,10 @@ module Travis::API::V3
       route '/user'
       get :current
     end
+
+    resource :subscriptions do
+      route '/subscriptions'
+      get :all
+    end
   end
 end

--- a/lib/travis/api/v3/services.rb
+++ b/lib/travis/api/v3/services.rb
@@ -33,6 +33,7 @@ module Travis::API::V3
     Requests            = Module.new { extend Services }
     SslKey              = Module.new { extend Services }
     Stages              = Module.new { extend Services }
+    Subscriptions       = Module.new { extend Services }
     User                = Module.new { extend Services }
     UserSetting         = Module.new { extend Services }
     UserSettings        = Module.new { extend Services }

--- a/lib/travis/api/v3/services/subscriptions/all.rb
+++ b/lib/travis/api/v3/services/subscriptions/all.rb
@@ -1,0 +1,8 @@
+module Travis::API::V3
+  class Services::Subscriptions::All < Service
+    def run!
+      raise LoginRequired unless access_control.full_access_or_logged_in?
+      result query(:subscriptions).all(access_control.user.id)
+    end
+  end
+end

--- a/spec/v3/billing_spec.rb
+++ b/spec/v3/billing_spec.rb
@@ -9,15 +9,15 @@ describe Travis::API::V3::Billing do
     Travis.config.billing.auth_key = auth_key
   end
 
+  let(:subscription_id) { rand(999) }
+
   describe '#get_subscription' do
     subject { billing.get_subscription(subscription_id) }
 
-    let(:subscription_id) { rand(999) }
-
     it 'returns the subscription' do
       stub_billing_request(:get, "/subscriptions/#{subscription_id}").to_return(body: JSON.dump(id: subscription_id))
-      subject.should be_a(described_class::Subscription)
-      subject.id.should == subscription_id
+      expect(subject).to be_a(described_class::Subscription)
+      expect(subject.id).to eq(subscription_id)
       # TODO: More attributes
     end
 
@@ -25,6 +25,16 @@ describe Travis::API::V3::Billing do
       stub_billing_request(:get, "/subscriptions/#{subscription_id}").to_return(status: 404)
 
       expect { subject }.to raise_error(described_class::NotFoundError)
+    end
+  end
+
+  describe '#all' do
+    subject { billing.all }
+
+    it 'returns the list of subscriptions' do
+      stub_billing_request(:get, '/subscriptions').to_return(body: JSON.dump([{id: subscription_id}]))
+
+      expect(subject).to eq([described_class::Subscription.new('id' => subscription_id)])
     end
   end
 

--- a/spec/v3/services/subscriptions/all_spec.rb
+++ b/spec/v3/services/subscriptions/all_spec.rb
@@ -1,0 +1,48 @@
+describe Travis::API::V3::Services::Subscriptions::All, set_app: true do
+  let(:parsed_body) { JSON.load(last_response.body) }
+  let(:billing_url) { 'http://billingfake.travis-ci.com' }
+  let(:billing_auth_key) { 'secret' }
+
+  before do
+    Travis.config.billing.url = billing_url
+    Travis.config.billing.auth_key = billing_auth_key
+  end
+
+  context 'unauthenticated' do
+    it 'responds 403' do
+      get('/v3/subscriptions')
+
+      expect(last_response.status).to eq(403)
+    end
+  end
+
+  context 'authenticated' do
+    let(:user) { Factory(:user) }
+    let(:token) { Travis::Api::App::AccessToken.create(user: user, app_id: 1) }
+    let(:headers) {{ 'HTTP_AUTHORIZATION' => "token #{token}" }}
+    let(:response_json) { JSON.dump([{"id" => 1234}]) }
+
+    it 'responds with list of subscriptions' do
+      stub_request(:get, billing_url + '/subscriptions').
+        with(
+          basic_auth: ['_', billing_auth_key],
+          headers: {
+            'Content-Type' => 'application/json',
+            'X-Travis-User-Id' => user.id.to_s
+          }).
+          to_return(status: 200, body: response_json)
+
+      get('/v3/subscriptions', {}, headers)
+
+      expect(last_response.status).to eq(200)
+      expect(parsed_body).to eql_json({
+        '@type' => 'subscriptions',
+        '@representation' => 'standard',
+        '@href' => '/v3/subscriptions',
+        'subscriptions' => [{
+          'id' => 1234
+        }]
+      })
+    end
+  end
+end


### PR DESCRIPTION
@tyranja and I paired on this.

This is the endpoint the frontend would request to get all the subscriptions of a user (own and from organizations they belong to), to render the equivalent of this page:

![img-2018-03-12-152146](https://user-images.githubusercontent.com/3830/37289209-69cc1424-2609-11e8-828b-9fda96a70701.png)

It's work in progress (e.g. we still need to define the attributes that will be in the response) but can be merged if correct.