### PR TITLE
[Enterprise] Backport: Always add deploy keys when using travis Enterprise (#688)

### DIFF
--- a/lib/travis/api/v3/services/repository/activate.rb
+++ b/lib/travis/api/v3/services/repository/activate.rb
@@ -5,7 +5,7 @@ module Travis::API::V3
     def run!
       repository = super(true).resource
 
-      if repository.private?
+      if repository.private? || access_control.enterprise?
         admin = access_control.admin_for(repository)
         github(admin).upload_key(repository)
       end

--- a/lib/travis/services/update_hook.rb
+++ b/lib/travis/services/update_hook.rb
@@ -10,7 +10,7 @@ module Travis
 
       def run
         run_service(:github_set_hook, id: repo.id, active: active?)
-        run_service(:github_set_key, params) if repo.private?
+        run_service(:github_set_key, params) if repo.private? || Travis.config.enterprise
         repo.update_column(:active, active?)
         sync_repo if active?
         true


### PR DESCRIPTION
Backports #688 to `enterprise-2.2`. 