### PR TITLE
POST /v3/subscriptions (creation) endpoint

### DIFF
--- a/lib/travis/api/v3/billing.rb
+++ b/lib/travis/api/v3/billing.rb
@@ -35,6 +35,15 @@ module Travis::API::V3
       connection.patch("/subscriptions/#{subscription_id}/creditcard", creditcard_data)
     end
 
+    def create_subscription(subscription_data)
+      response = connection.post('/subscriptions', subscription_data)
+      if response.success?
+        Travis::API::V3::Models::Subscription.new(response.body)
+      else
+        raise Error, "TODO: Different errors according to status messages"
+      end
+    end
+
     private
 
     def connection

--- a/lib/travis/api/v3/billing.rb
+++ b/lib/travis/api/v3/billing.rb
@@ -11,7 +11,7 @@ module Travis::API::V3
     def get_subscription(id)
       response = connection.get("/subscriptions/#{id}")
       if response.success?
-        Subscription.new(response.body)
+        Travis::API::V3::Models::Subscription.new(response.body)
       else
         raise NotFoundError, "Subscription ##{id} not found (HTTP Status: #{response.status})"
       end
@@ -19,7 +19,7 @@ module Travis::API::V3
 
     def all
       connection.get('/subscriptions').body.map do |subscription_data|
-        Subscription.new(subscription_data)
+        Travis::API::V3::Models::Subscription.new(subscription_data)
       end
     end
 
@@ -30,7 +30,7 @@ module Travis::API::V3
     def cancel_subscription(id)
       connection.post("/subscriptions/#{id}/cancel")
     end
-    
+
     def update_creditcard(subscription_id, creditcard_data)
       connection.patch("/subscriptions/#{subscription_id}/creditcard", creditcard_data)
     end
@@ -54,12 +54,6 @@ module Travis::API::V3
 
     def billing_auth_key
       Travis.config.billing.auth_key || raise(ConfigurationError, 'No billing auth key configured')
-    end
-
-    class Subscription < Struct.new(:id)
-      def initialize(attributes = {})
-        super(attributes.fetch('id'))
-      end
     end
   end
 end

--- a/lib/travis/api/v3/models/subscription.rb
+++ b/lib/travis/api/v3/models/subscription.rb
@@ -1,0 +1,7 @@
+module Travis::API::V3
+  class Models::Subscription < Struct.new(:id)
+    def initialize(attributes = {})
+      super(attributes.fetch('id'))
+    end
+  end
+end

--- a/lib/travis/api/v3/queries/subscriptions.rb
+++ b/lib/travis/api/v3/queries/subscriptions.rb
@@ -4,5 +4,10 @@ module Travis::API::V3
       client = Billing.new(user_id)
       client.all
     end
+
+    def create(user_id)
+      client = Billing.new(user_id)
+      client.create_subscription(params)
+    end
   end
 end

--- a/lib/travis/api/v3/routes.rb
+++ b/lib/travis/api/v3/routes.rb
@@ -232,6 +232,7 @@ module Travis::API::V3
     resource :subscriptions do
       route '/subscriptions'
       get :all
+      post :create
     end
 
     resource :subscription do

--- a/lib/travis/api/v3/services/subscriptions/create.rb
+++ b/lib/travis/api/v3/services/subscriptions/create.rb
@@ -1,0 +1,12 @@
+module Travis::API::V3
+  class Services::Subscriptions::Create < Service
+    result_type :subscription
+    # TODO: required attributes
+    params :street
+
+    def run!
+      raise LoginRequired unless access_control.full_access_or_logged_in?
+      result query(:subscriptions).create(access_control.user.id)
+    end
+  end
+end

--- a/spec/v3/billing_spec.rb
+++ b/spec/v3/billing_spec.rb
@@ -62,6 +62,18 @@ describe Travis::API::V3::Billing do
     end
   end
 
+  describe '#create_subscription' do
+    let(:subscription_data) {{ 'street' => 'Rigaer' }}
+    subject { billing.create_subscription(subscription_data) }
+
+    it 'requests the creation and returns the representation' do
+      stubbed_request = stub_billing_request(:post, "/subscriptions").with(body: JSON.dump(subscription_data)).to_return(status: 202, body: JSON.dump('id' => 456))
+
+      expect(subject).to eq(Travis::API::V3::Models::Subscription.new('id' => 456))
+      expect(stubbed_request).to have_been_made
+    end
+  end
+
   def stub_billing_request(method, path)
     url = URI(billing_url).tap do |url|
       url.path = path

--- a/spec/v3/billing_spec.rb
+++ b/spec/v3/billing_spec.rb
@@ -16,7 +16,7 @@ describe Travis::API::V3::Billing do
 
     it 'returns the subscription' do
       stub_billing_request(:get, "/subscriptions/#{subscription_id}").to_return(body: JSON.dump(id: subscription_id))
-      expect(subject).to be_a(described_class::Subscription)
+      expect(subject).to be_a(Travis::API::V3::Models::Subscription)
       expect(subject.id).to eq(subscription_id)
       # TODO: More attributes
     end
@@ -34,7 +34,7 @@ describe Travis::API::V3::Billing do
     it 'returns the list of subscriptions' do
       stub_billing_request(:get, '/subscriptions').to_return(body: JSON.dump([{id: subscription_id}]))
 
-      expect(subject).to eq([described_class::Subscription.new('id' => subscription_id)])
+      expect(subject).to eq([Travis::API::V3::Models::Subscription.new('id' => subscription_id)])
     end
   end
 

--- a/spec/v3/services/subscriptions/all_spec.rb
+++ b/spec/v3/services/subscriptions/all_spec.rb
@@ -21,7 +21,7 @@ describe Travis::API::V3::Services::Subscriptions::All, set_app: true do
     let(:token) { Travis::Api::App::AccessToken.create(user: user, app_id: 1) }
     let(:headers) {{ 'HTTP_AUTHORIZATION' => "token #{token}" }}
     let(:client) { stub(:billing_client) }
-    let(:subscriptions) { [Travis::API::V3::Billing::Subscription.new('id' => 1234)]}
+    let(:subscriptions) { [Travis::API::V3::Models::Subscription.new('id' => 1234)]}
 
     before do
       Travis::API::V3::Billing.stubs(:new).with(user.id).returns(client)
@@ -38,6 +38,8 @@ describe Travis::API::V3::Services::Subscriptions::All, set_app: true do
         '@representation' => 'standard',
         '@href' => '/v3/subscriptions',
         'subscriptions' => [{
+          '@type' => 'subscription',
+          '@representation' => 'standard',
           'id' => 1234
         }]
       })

--- a/spec/v3/services/subscriptions/create_spec.rb
+++ b/spec/v3/services/subscriptions/create_spec.rb
@@ -1,0 +1,45 @@
+describe Travis::API::V3::Services::Subscriptions::Create, set_app: true do
+  let(:parsed_body) { JSON.load(last_response.body) }
+  let(:billing_url) { 'http://billingfake.travis-ci.com' }
+  let(:billing_auth_key) { 'secret' }
+
+  before do
+    Travis.config.billing.url = billing_url
+    Travis.config.billing.auth_key = billing_auth_key
+  end
+
+  context 'unauthenticated' do
+    it 'responds 403' do
+      get('/v3/subscriptions')
+
+      expect(last_response.status).to eq(403)
+    end
+  end
+
+  context 'authenticated' do
+    let(:user) { Factory(:user) }
+    let(:token) { Travis::Api::App::AccessToken.create(user: user, app_id: 1) }
+    let(:headers) {{ 'HTTP_AUTHORIZATION' => "token #{token}",
+                     'CONTENT_TYPE' => 'application/json' }}
+    let(:subscription_data) {{ 'street'=> 'Rigaer' }}
+    let(:client) { stub(:billing_client) }
+    let(:subscription) { Travis::API::V3::Models::Subscription.new('id' => 1234)}
+
+    before do
+      Travis::API::V3::Billing.stubs(:new).with(user.id).returns(client)
+    end
+
+    it 'Creates the subscription and responds with its representation' do
+      client.expects(:create_subscription).with(subscription_data).returns(subscription)
+
+      post('/v3/subscriptions', JSON.dump(subscription_data), headers)
+
+      expect(last_response.status).to eq(200)
+      expect(parsed_body).to eql_json({
+        '@type' => 'subscription',
+        '@representation' => 'standard',
+        'id' => 1234
+      })
+    end
+  end
+end


### PR DESCRIPTION
(pairing with @tyranja)

This PR reintroduces the `Subscription` model removed in #697 but now as a plain ruby object instead of `ActiveRecord` subclass (no longer database backed). All the implicit stuff query -> service -> renderer seems to be happy with the replacement.