### PR TITLE
[Proposal-V3] Add a way to hide endpoints from service index

### DIFF
--- a/lib/travis/api/v3/routes.rb
+++ b/lib/travis/api/v3/routes.rb
@@ -229,13 +229,13 @@ module Travis::API::V3
       get :current
     end
 
-    resource :subscriptions do
+    hidden_resource :subscriptions do
       route '/subscriptions'
       get :all
       post :create
     end
 
-    resource :subscription do
+    hidden_resource :subscription do
       route '/subscription/{subscription.id}'
       patch :update_address, '/address'
       patch :update_creditcard, '/creditcard'

--- a/lib/travis/api/v3/routes/dsl.rb
+++ b/lib/travis/api/v3/routes/dsl.rb
@@ -28,6 +28,10 @@ module Travis::API::V3
       resources << resource
     end
 
+    def hidden_resource(identifier, **args, &block)
+      resource(identifier, **args.merge(hidden: true), &block)
+    end
+
     def with_resource(resource)
       resource_was, @current_resource = current_resource, resource
       prefix_was, @prefix             = @prefix, resource_was.route if resource_was

--- a/lib/travis/api/v3/service_index.rb
+++ b/lib/travis/api/v3/service_index.rb
@@ -83,6 +83,7 @@ module Travis::API::V3
     def render_json
       resources = { }
       all_resources.each do |resource|
+        next if resource.meta_data[:hidden]
         data = resources[resource.display_identifier] ||= { :@type => :resource, :actions => {} }
         data.merge! resource.meta_data
 

--- a/spec/v3/service_index_spec.rb
+++ b/spec/v3/service_index_spec.rb
@@ -292,6 +292,18 @@ describe Travis::API::V3::ServiceIndex, set_app: true do
           specify { expect(action).to include("@type"=>"template", "request_method"=>"GET", "uri_template"=>"#{path}user/{user.id}{?include}") }
         end
       end
+
+      describe "subscriptions resource" do
+        it 'is hidden' do
+          expect(resources).to_not have_key('subscriptions')
+        end
+      end
+
+      describe "subscription resource" do
+        it 'is hidden' do
+          expect(resources).to_not have_key('subscription')
+        end
+      end
     end
 
     describe 'with /v3 prefix' do


### PR DESCRIPTION
Following the discussion in #690 and a couple of in person conversations too, this PR adds a `hidden_resource` method to the v3 routing DSL, which does the same as `resource` but doesn't show in the service index served at `/`.

The case that this tries to solve is that you can't/shouldn't merge any unfinished API work because it ends up in the generated documentation, and since that's public that makes it difficult to change (because someone might be using it). That's reasonable but leads to long lived branches, late integration, etc.

We are having this problem with `billing-v2` but it seems (according to those conversations) that it's not a new problem.

In some cases (billing can be one) it might even make sense that this is not temporary, and they stay out of the public API (as private endpoints subject to change) for ever (is there a use case for third party tools to use them?). That's a different discussion though, and it involves having an alternative way of documenting the API, internally or whatever. 

About the implementation, I guess we don't even need to define a `hidden_resource` method, and one could use the `hidden: true` option directly when calling `resource`. What API do you think is better?

For other use cases, it might make sense to have this also at the service level (e.g. the endpoint shows up, but only the GET operation, not the PATCH one). For our current use case, the whole resource is what makes sense.

Also, is *hidden* good naming? Alternatives I can think of: private, experimental.