### PR TITLE
delete DATABASE_URL from ENV in spec_helper

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,6 +5,7 @@
 $: << 'lib'
 
 ENV['RACK_ENV'] = ENV['RAILS_ENV'] = ENV['ENV'] = 'test'
+ENV.delete('DATABASE_URL')
 
 require 'support/coverage' unless ENV['SKIP_COVERAGE']
 


### PR DESCRIPTION
extra safety net for not accidentally running specs against a remote database