### PR TITLE
Add `/owner/<login>/import` route

### DIFF
--- a/lib/travis/api/v3/access_control/generic.rb
+++ b/lib/travis/api/v3/access_control/generic.rb
@@ -119,6 +119,10 @@ module Travis::API::V3
       full_access? or public_mode?(organization)
     end
 
+    def organization_adminable?(organization)
+      full_access? or organization.memberships.where(user: self.user, role: 'admin').exists?
+    end
+
     def ssl_key_visible?(ssl_key)
       visible? ssl_key.repository
     end

--- a/lib/travis/api/v3/model_renderer.rb
+++ b/lib/travis/api/v3/model_renderer.rb
@@ -94,7 +94,14 @@ module Travis::API::V3
       modes                    = {}
 
       if permissions = access_control.permissions(model) and (representation != :minimal or include? :@permissions)
-        result[:@permissions] = permissions.to_h
+        hash = permissions.to_h
+
+        if (model.is_a?(Models::User) || model.is_a?(Models::Organization)) &&
+            !Travis::Features.owner_active?(:import_owner, model)
+          hash.delete(:import)
+        end
+
+        result[:@permissions] = hash
       end
 
       if include.any?

--- a/lib/travis/api/v3/models/import.rb
+++ b/lib/travis/api/v3/models/import.rb
@@ -1,0 +1,42 @@
+require 'faraday'
+
+module Travis::API::V3::Models
+  class Import
+    class ImportDisabledError < StandardError; end
+    class ImportRequestFailed < StandardError; end
+    attr_accessor :owner, :current_user
+
+    def initialize(owner, current_user)
+      self.owner = owner
+      self.current_user = current_user
+    end
+
+    def import!
+      if !Travis::Features.owner_active?(:import_owner, owner)
+        raise ImportDisabledError
+      end
+
+      token = Travis.config.merge.auth_token
+      url   = Travis.config.merge.api_url
+      connection = Faraday.new(url: url) do |c|
+        c.request :json
+        c.use Faraday::Request::Authorization, 'Token', token
+        c.adapter Faraday.default_adapter
+      end
+      response = connection.put("/api/#{type}/#{owner.id}") do |request|
+        request.body = { user_id: current_user.id }
+      end
+
+      unless response.success?
+        raise ImportRequestFailed
+      end
+    end
+
+    def type
+      case owner
+      when User         then :user
+      when Organization then :org
+      end
+    end
+  end
+end

--- a/lib/travis/api/v3/permissions/generic.rb
+++ b/lib/travis/api/v3/permissions/generic.rb
@@ -71,5 +71,9 @@ module Travis::API::V3
       access_control.starable? object
     end
 
+    def adminable?
+      access_control.adminable? object
+    end
+
   end
 end

--- a/lib/travis/api/v3/permissions/organization.rb
+++ b/lib/travis/api/v3/permissions/organization.rb
@@ -5,5 +5,9 @@ module Travis::API::V3
     def sync?
       write?
     end
+
+    def import?
+      adminable?
+    end
   end
 end

--- a/lib/travis/api/v3/permissions/user.rb
+++ b/lib/travis/api/v3/permissions/user.rb
@@ -2,6 +2,10 @@ require 'travis/api/v3/permissions/generic'
 
 module Travis::API::V3
   class Permissions::User < Permissions::Generic
+    def import?
+      write?
+    end
+
     def sync?
       write?
     end

--- a/lib/travis/api/v3/routes.rb
+++ b/lib/travis/api/v3/routes.rb
@@ -98,6 +98,8 @@ module Travis::API::V3
         route '/active'
         get :for_owner
       end
+
+      hide(post :import, '/import')
     end
 
     resource :repositories do

--- a/lib/travis/api/v3/services/owner/import.rb
+++ b/lib/travis/api/v3/services/owner/import.rb
@@ -1,0 +1,29 @@
+require 'travis/api/v3/models/import'
+
+module Travis::API::V3
+  class Services::Owner::Import < Service
+    def result_type
+      @result_type ||= super
+    end
+
+    def run!
+      owner = check_login_and_find
+      access_control.permissions(owner).import!
+
+      Models::Import.new(owner, access_control.user).import!
+
+      result(owner, status: 202, result_type: type_for(owner))
+    rescue Models::Import::ImportDisabledError
+      raise Error.new("Import is disabled for #{owner.login}. Please contact Travis CI support for more information", status: 403)
+    rescue Models::Import::ImportRequestFailed
+      raise Error.new('There was a problem with starting an import', status: 500)
+    end
+
+    private def type_for(owner)
+      case owner
+      when Models::User         then :user
+      when Models::Organization then :organization
+      end
+    end
+  end
+end

--- a/lib/travis/config/defaults.rb
+++ b/lib/travis/config/defaults.rb
@@ -66,7 +66,8 @@ module Travis
             endpoints:     {},
             oauth2:        {},
             webhook:       { public_key: nil },
-            cache_options: {}
+            cache_options: {},
+            merge:         { auth_token: 'merge-auth-token', api_url: 'https://merge.localhost' }
 
     default :_access => [:key]
 

--- a/spec/v3/services/owner/import_spec.rb
+++ b/spec/v3/services/owner/import_spec.rb
@@ -1,0 +1,105 @@
+describe Travis::API::V3::Services::Owner::Import, set_app: true do
+  describe "importing organization" do
+    let(:user) { Factory.create(:user, login: 'merge-user') }
+    let(:org) { Travis::API::V3::Models::Organization.new(login: 'example-org', github_id: 1234) }
+    before    { org.save!  }
+    after     { org.delete }
+    before    { Travis::Features.activate_owner(:import_owner, org) }
+
+    context "logged in" do
+      let(:token)   { Travis::Api::App::AccessToken.create(user: user, app_id: 1) }
+      let(:headers) {{ 'HTTP_AUTHORIZATION' => "token #{token}" }}
+
+      context "has admin permissions to an org" do
+        before { Travis::API::V3::Models::Membership.create!(user: user, organization: org, role: "admin") }
+        before do
+          stub_request(:put, "https://merge.localhost/api/org/#{org.id}")
+            .with { |request| request.body == {user_id: user.id}.to_json }
+        end
+
+        it "makes a request to the merge app" do
+          response = post("/v3/owner/example-org/import", {}, headers)
+          response.status.should == 202
+          JSON.parse(response.body)['@href'].should == "/v3/org/#{org.id}"
+        end
+
+        context "when a :import_owner feature is disabled" do
+          before { Travis::Features.deactivate_owner(:import_owner, org) }
+          it "returns 403" do
+            response = post("/v3/owner/example-org/import", {}, headers)
+            response.status.should == 403
+          end
+        end
+      end
+
+      context "doesn't have admin permissions to an org" do
+        before { Travis::API::V3::Models::Membership.create!(user: user, organization: org, role: "other") }
+
+        it "returns a 403 response" do
+          response = post("/v3/owner/example-org/import", {}, headers)
+          response.status.should == 403
+          JSON.parse(response.body)['@type'].should == "error"
+        end
+      end
+
+      context "isn't the organization member" do
+        it "returns a 403 response" do
+          response = post("/v3/owner/example-org/import", {}, headers)
+          response.status.should == 403
+          JSON.parse(response.body)['@type'].should == "error"
+        end
+      end
+
+    end
+  end
+
+  describe "importing user" do
+    let!(:user) { Factory.create(:user, login: 'merge-user') }
+    let!(:other_user) { Factory.create(:user, login: 'other-user') }
+    before { Travis::Features.activate_owner(:import_owner, user) }
+
+    context "logged in" do
+      let(:token)   { Travis::Api::App::AccessToken.create(user: user, app_id: 1) }
+      let(:headers) {{ 'HTTP_AUTHORIZATION' => "token #{token}" }}
+
+      context "when switching themselves" do
+        before do
+          stub_request(:put, "https://merge.localhost/api/user/#{user.id}")
+            .with { |request| request.body == {user_id: user.id}.to_json }
+        end
+
+        it "makes a request to the merge app" do
+          response = post("/v3/owner/merge-user/import", {}, headers)
+          response.status.should == 202
+          JSON.parse(response.body)['@href'].should == "/v3/user/#{user.id}"
+        end
+
+        context "when a :import_owner feature is disabled" do
+          before { Travis::Features.deactivate_owner(:import_owner, user) }
+          it "returns 403" do
+            response = post("/v3/owner/merge-user/import", {}, headers)
+            response.status.should == 403
+          end
+        end
+
+      end
+
+      context "when switching someone else" do
+        it "returns a 403 response" do
+          response = post("/v3/owner/other-user/import", {}, headers)
+          response.status.should == 403
+          JSON.parse(response.body)['@type'].should == "error"
+        end
+      end
+
+      context "inexistent user" do
+        it "returns a 403 response" do
+          response = post("/v3/owner/foo-bar-baz-user/import", {}, headers)
+          response.status.should == 404
+          JSON.parse(response.body)['@type'].should == "error"
+        end
+      end
+
+    end
+  end
+end


### PR DESCRIPTION
This is the interface for the merge app. In the merge app itself we don't do any checks or authentication, so we need to have an API endpoint that will pass the request to the merge app.

The `import` route and a new permission are hidden from the index, so for now it won't be announced in the docs.