### PR TITLE
Allow to filter organizations by role

### DIFF
--- a/lib/travis/api/v3/queries/organizations.rb
+++ b/lib/travis/api/v3/queries/organizations.rb
@@ -1,9 +1,12 @@
 module Travis::API::V3
   class Queries::Organizations < Query
     sortable_by :id, :login, :name, :github_id
+    params :role, prefix: :organization
 
     def for_member(user)
-      sort Models::Organization.joins(:users).where(users: user_condition(user))
+      orgs =  Models::Organization.joins(:users).where(users: user_condition(user))
+      orgs = orgs.where(memberships: { role: role }) if role
+      sort orgs
     end
   end
 end

--- a/lib/travis/api/v3/services/organizations/for_current_user.rb
+++ b/lib/travis/api/v3/services/organizations/for_current_user.rb
@@ -1,5 +1,6 @@
 module Travis::API::V3
   class Services::Organizations::ForCurrentUser < Service
+    params :role, prefix: :organization
     paginate(default_limit: 100)
 
     def run!

--- a/spec/v3/service_index_spec.rb
+++ b/spec/v3/service_index_spec.rb
@@ -273,7 +273,7 @@ describe Travis::API::V3::ServiceIndex, set_app: true do
 
         describe "for_current_user action" do
           let(:action) { resource.fetch("actions").fetch("for_current_user") }
-          specify { expect(action).to include("@type"=>"template", "request_method"=>"GET", "uri_template"=>"#{path}orgs{?include,limit,offset,sort_by}") }
+          specify { expect(action).to include("@type"=>"template", "request_method"=>"GET", "uri_template"=>"#{path}orgs{?include,limit,offset,organization.role,role,sort_by}") }
         end
       end
 

--- a/spec/v3/services/organizations/for_current_user_spec.rb
+++ b/spec/v3/services/organizations/for_current_user_spec.rb
@@ -9,8 +9,18 @@ describe Travis::API::V3::Services::Organizations::ForCurrentUser, set_app: true
 
   let(:org) { Travis::API::V3::Models::Organization.new(login: 'example-org')   }
   before    { org.save!                                }
-  before    { org.memberships.create(user: repo.owner) }
+  before    { org.memberships.create(user: repo.owner, role: 'admin') }
   after     { org.delete                               }
+
+  context "with role query param" do
+    it "filters by role" do
+      another_org = Travis::API::V3::Models::Organization.create(login: 'another-org')
+      another_org.memberships.create(user: repo.owner, role: 'member')
+
+      get("/v3/orgs", {role: 'admin'}, headers)
+      JSON.load(body)['organizations'].map { |o| o['id'] }.should == [org.id]
+    end
+  end
 
   describe "authenticated as user with access" do
     before  { get("/v3/orgs", {}, headers)     }


### PR DESCRIPTION
This commit adds ability to pass a role query param to /orgs requests in
order to filter by role.