### PR TITLE
Add `hidden_resources` method

### DIFF
--- a/lib/travis/api/v3/routes/dsl.rb
+++ b/lib/travis/api/v3/routes/dsl.rb
@@ -28,6 +28,10 @@ module Travis::API::V3
       resources << resource
     end
 
+    def hidden_resource(identifier, **args, &block)
+      resource(identifier, **args.merge(hidden: true), &block)
+    end
+
     def with_resource(resource)
       resource_was, @current_resource = current_resource, resource
       prefix_was, @prefix             = @prefix, resource_was.route if resource_was

--- a/lib/travis/api/v3/service_index.rb
+++ b/lib/travis/api/v3/service_index.rb
@@ -83,6 +83,7 @@ module Travis::API::V3
     def render_json
       resources = { }
       all_resources.each do |resource|
+        next if resource.meta_data[:hidden]
         data = resources[resource.display_identifier] ||= { :@type => :resource, :actions => {} }
         data.merge! resource.meta_data
 


### PR DESCRIPTION
@tyranja and @porras were working on it in their branch `billing-v2`, but I'd like to use it too, so I'm porting it to master.

This basically adds ability to add resources hidden from the service index - useful if we work on features that are not ready for publishing to API users.