### PR TITLE
Allow to hide routes from the index

### DIFF
--- a/lib/travis/api/v3/routes/dsl.rb
+++ b/lib/travis/api/v3/routes/dsl.rb
@@ -60,6 +60,10 @@ module Travis::API::V3
       end
     end
 
+    def hide(service)
+      current_resource.hide_service(service)
+    end
+
     def get(*args)
       current_resource.add_service('GET'.freeze, *args)
     end

--- a/lib/travis/api/v3/routes/resource.rb
+++ b/lib/travis/api/v3/routes/resource.rb
@@ -2,13 +2,22 @@ require 'mustermann'
 
 module Travis::API::V3
   class Routes::Resource
-    attr_accessor :identifier, :route, :services, :meta_data
+    attr_accessor :identifier, :route, :services, :meta_data, :hidden_services
 
     def initialize(identifier, as: nil, **meta_data)
       @identifier         = identifier
       @display_identifier = as
       @services           = {}
       @meta_data          = meta_data
+      @hidden_services    = []
+    end
+
+    def hide_service(service)
+      hidden_services.push(service)
+    end
+
+    def service_hidden?(service)
+      hidden_services.include?(service)
     end
 
     def add_service(request_method, service, sub_route = nil)

--- a/lib/travis/api/v3/service_index.rb
+++ b/lib/travis/api/v3/service_index.rb
@@ -105,6 +105,7 @@ module Travis::API::V3
         end
 
         resource.services.each do |(request_method, sub_route), service|
+          next if resource.service_hidden?(service)
           list    = resources[resource.display_identifier][:actions][service] ||= []
           pattern = sub_route ? resource.route + sub_route : resource.route
           factory = Services[resource.identifier][service]

--- a/spec/v3/service_index_spec.rb
+++ b/spec/v3/service_index_spec.rb
@@ -5,18 +5,23 @@ describe Travis::API::V3::ServiceIndex, set_app: true do
   let(:response)  { get(path, {}, headers)   }
   let(:resources) { json.fetch('resources')  }
 
-  describe 'hidden_resource' do
+  describe 'hiding resources and routes' do
     let(:headers) { { 'HTTP_ACCEPT' => 'application/vnd.travis-ci.3+json' } }
 
     it 'hides a resource from the service index' do
       Travis::API::V3::Services.const_set('Foo', Module.new { extend Travis::API::V3::Services })
       Travis::API::V3::Services::Foo.const_set('Find', Class.new(Travis::API::V3::Service))
+      Travis::API::V3::Services::Foo.const_set('DoSomething', Class.new(Travis::API::V3::Service))
+      Travis::API::V3::Services::Foo.const_set('DoSomethingSecret', Class.new(Travis::API::V3::Service))
       Travis::API::V3::Services.const_set('Bar', Module.new { extend Travis::API::V3::Services })
       Travis::API::V3::Services::Bar.const_set('Find', Class.new(Travis::API::V3::Service))
       Travis::API::V3::Routes.module_eval do
         resource :foo do
           route '/foo'
           get :find
+
+          hide(post :do_something_secret, '/do_something_secret')
+          post :do_something, '/do_something'
         end
 
         hidden_resource :bar do
@@ -27,6 +32,8 @@ describe Travis::API::V3::ServiceIndex, set_app: true do
 
       expect(json['resources']).to have_key('foo')
       expect(json['resources']).to_not have_key('bar')
+      expect(json['resources']['foo']['actions']).to have_key('do_something')
+      expect(json['resources']['foo']['actions']).to_not have_key('do_something_secret')
 
       #TODO: it would be nice to remove extra routes after finishing this spec
     end


### PR DESCRIPTION
Sometimes it may be necessary to hide routes from the index, for example
when working on an experimental features. This commit adds a `hide`
method that let's you hide a route.

I went with a kind of a functional approach of `hide(get(:foo))`,
because I didn't want to change too many signatures (ie. adding options
to routes would be more complicated).