### PR TITLE
Explicity expose billing_info, credit_card_info and owner

### DIFF
--- a/lib/travis/api/v3/models/subscription.rb
+++ b/lib/travis/api/v3/models/subscription.rb
@@ -9,9 +9,49 @@ module Travis::API::V3
       @coupon = attributes['coupon']
       @status = attributes.fetch('status')
       @source = attributes.fetch('source')
-      @billing_info = attributes['billing_info']
-      @credit_card_info = attributes['credit_card_info']
-      @owner = attributes.fetch('owner')
+      @billing_info = attributes['billing_info'] && Models::BillingInfo.new(attributes['billing_info'])
+      @credit_card_info = attributes['credit_card_info'] && Models::CreditCardInfo.new(attributes['credit_card_info'])
+      @owner = fetch_owner(attributes.fetch('owner'))
+    end
+
+    private
+
+    def fetch_owner(attributes)
+      owner_class = case attributes.fetch('type')
+                    when 'User'
+                      Models::User
+                    when 'Organization'
+                      Models::Organization
+                    end
+      owner_class.find(attributes.fetch('id'))
+    end
+  end
+
+  class Models::BillingInfo
+    attr_reader :address, :address2, :billing_email, :city, :company, :country, :first_name, :last_name, :state, :vat_id, :zip_code
+
+    def initialize(attrs = {})
+      @address = attrs.fetch('address')
+      @address2 = attrs.fetch('address2')
+      @billing_email = attrs.fetch('billing_email')
+      @city = attrs.fetch('city')
+      @company = attrs.fetch('company')
+      @country = attrs.fetch('country')
+      @first_name = attrs.fetch('first_name')
+      @last_name = attrs.fetch('last_name')
+      @state = attrs.fetch('state')
+      @vat_id = attrs.fetch('vat_id')
+      @zip_code = attrs.fetch('zip_code')
+    end
+  end
+
+  class Models::CreditCardInfo
+    attr_reader :card_owner, :expiration_date, :last_digits
+
+    def initialize(attrs = {})
+      @card_owner = attrs.fetch('card_owner')
+      @expiration_date = attrs.fetch('expiration_date')
+      @last_digits = attrs.fetch('last_digits')
     end
   end
 end

--- a/lib/travis/api/v3/renderer/subscription.rb
+++ b/lib/travis/api/v3/renderer/subscription.rb
@@ -2,4 +2,12 @@ module Travis::API::V3
   class Renderer::Subscription < ModelRenderer
     representation(:standard, :id, :valid_to, :plan, :coupon, :status, :source, :billing_info, :credit_card_info, :owner)
   end
+
+  class Renderer::BillingInfo < ModelRenderer
+    representation(:minimal, :address, :address2, :billing_email, :city, :company, :country, :first_name, :last_name, :state, :vat_id, :zip_code)
+  end
+
+  class Renderer::CreditCardInfo < ModelRenderer
+    representation(:minimal, :card_owner, :expiration_date, :last_digits)
+  end
 end

--- a/spec/support/billing_spec_helper.rb
+++ b/spec/support/billing_spec_helper.rb
@@ -25,7 +25,8 @@ module Support
           "address2" => "",
           "city" => "Comala",
           "state" => nil,
-          "country" => "Mexico"
+          "country" => "Mexico",
+          "vat_id" => "123456"
         },
         "credit_card_info" => {
           "card_owner" => "ana",
@@ -36,7 +37,7 @@ module Support
           "type" => "Organization",
           "id" => 43
         }
-      }.merge(attributes)
+      }.deep_merge(attributes)
     end
   end
 end

--- a/spec/v3/services/subscriptions/all_spec.rb
+++ b/spec/v3/services/subscriptions/all_spec.rb
@@ -18,12 +18,13 @@ describe Travis::API::V3::Services::Subscriptions::All, set_app: true, billing_s
 
   context 'authenticated' do
     let(:user) { Factory(:user) }
+    let(:organization) { Factory(:org, login: 'travis') }
     let(:token) { Travis::Api::App::AccessToken.create(user: user, app_id: 1) }
     let(:headers) {{ 'HTTP_AUTHORIZATION' => "token #{token}" }}
 
     before do
       stub_billing_request(:get, '/subscriptions', auth_key: billing_auth_key, user_id: user.id)
-        .to_return(status: 200, body: JSON.dump([billing_response_body('id' => 1234)]))
+        .to_return(status: 200, body: JSON.dump([billing_response_body('id' => 1234, 'owner' => { 'type' => 'Organization', 'id' => organization.id })]))
     end
 
     it 'responds with list of subscriptions' do
@@ -44,6 +45,8 @@ describe Travis::API::V3::Services::Subscriptions::All, set_app: true, billing_s
           'status' => 'canceled',
           'source' => 'stripe',
           'billing_info' => {
+            '@type' => 'billing_info',
+            '@representation' => 'minimal',
             'first_name' => 'ana',
             'last_name' => 'rosas',
             'company' => '',
@@ -53,16 +56,22 @@ describe Travis::API::V3::Services::Subscriptions::All, set_app: true, billing_s
             'address2' => '',
             'city' => 'Comala',
             'state' => nil,
-            'country' => 'Mexico'
+            'country' => 'Mexico',
+            'vat_id' => '123456'
           },
           'credit_card_info' => {
+            '@type' => 'credit_card_info',
+            '@representation' => 'minimal',
             'card_owner' => 'ana',
             'last_digits' => '4242',
             'expiration_date' => '9/2021'
           },
           'owner'=> {
-            'type' => 'Organization',
-            'id' => 43
+            '@type' => 'organization',
+            '@representation' => 'minimal',
+            '@href' => "/v3/org/#{organization.id}",
+            'id' => organization.id,
+            'login' => 'travis'
           }
         }]
       })


### PR DESCRIPTION
Instead of exposing those fields as hashes, we parse and then serialize them, so that 1) it's validated (if something's wrong we'll get errors instead of silently rendering potentially badly formatted data) and 2) the generated documentation includes metadata of all exposed data (this I haven't checked but should be the case).