### PR TITLE
Check if repo exists before checking for github_id

### DIFF
--- a/lib/travis/api/v3/models/cron.rb
+++ b/lib/travis/api/v3/models/cron.rb
@@ -39,11 +39,11 @@ module Travis::API::V3
     end
 
     def enqueue
-      if !branch.repository.github_id
+      if !branch.repository&.github_id
         raise StandardError, "Repository does not have a github_id"
       end
 
-      if !branch.repository.active? or !branch.exists_on_github
+      if !branch.repository&.active? or !branch.exists_on_github
         self.destroy
         return false
       end


### PR DESCRIPTION
Fix missing repo bug for a cron's branch, recorded here https://sentry.io/travis-ci/org-api-production/issues/504500778/?query=is:unresolved