### PR TITLE
Load enterprise-2.2 version of the db structure for tests in enterprise-2.2 branch

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -4,7 +4,7 @@ namespace :db do
   env = ENV["ENV"] || 'test'
   abort "Cannot run rake db:create in production." if env == 'production'
 
-  url   = "https://raw.githubusercontent.com/travis-ci/travis-migrations/master/db/main/structure.sql"
+  url   = "https://raw.githubusercontent.com/travis-ci/travis-migrations/enterprise-2.2/db/main/structure.sql"
   file  = 'db/structure.sql'
   system "curl -fs #{url} -o #{file} --create-dirs"
   abort "failed to download #{url}" unless File.exist?(file)


### PR DESCRIPTION
Much like https://github.com/travis-ci/travis-scheduler/pull/139 I'm freezing the version of the db structure we load in tests to be that of the enterprise-2.2 branch. 