### PR TITLE
Turn off verification for enterprise license check 

### DIFF
--- a/lib/travis/api/v3/services/enterprise_license/find.rb
+++ b/lib/travis/api/v3/services/enterprise_license/find.rb
@@ -2,7 +2,8 @@ module Travis::API::V3
   class Services::EnterpriseLicense::Find < Service
     def run!
       if replicated_endpoint
-        http_options = {url: replicated_endpoint, ssl: Travis.config.ssl.to_h}.compact
+        # We turn off verification because this is an internal IP and a self signed cert so it will always fail
+        http_options = {url: replicated_endpoint, ssl: Travis.config.ssl.to_h.merge(verify: false)}.compact
         response = Faraday.new(http_options).get("license/v1/license")
         replicated_response = JSON.parse(response.body)
         license_id = replicated_response["license_id"]


### PR DESCRIPTION
Fixes: https://github.com/travis-pro/travis-enterprise/issues/291

In Travis Enterprise we hit Replicated's internal Integration API to check on license details for notification around trials, seats, and renewals. This is only available internally on the platform machine and is not exposed to the outside world. But it does use https, but it's a self signed cert by Replicated. We've started tightening down certificate verification around the application but in this case it's causing things to break. I've reached out to Replicated for how they typically handle this, but in the mean time I'm turning off cert verification for this one end point since it's an internal IP and the risk is much lower. 