### PR TITLE
[Enterprise Backport] Turn off verification for enterprise license check (#747)

### DIFF
--- a/lib/travis/api/v3/services/enterprise_license/find.rb
+++ b/lib/travis/api/v3/services/enterprise_license/find.rb
@@ -2,7 +2,8 @@ module Travis::API::V3
   class Services::EnterpriseLicense::Find < Service
     def run!
       if replicated_endpoint
-        http_options = {url: replicated_endpoint, ssl: Travis.config.ssl.to_h}.compact
+        # We turn off verification because this is an internal IP and a self signed cert so it will always fail
+        http_options = {url: replicated_endpoint, ssl: Travis.config.ssl.to_h.merge(verify: false)}.compact
         response = Faraday.new(http_options).get("license/v1/license")
         replicated_response = JSON.parse(response.body)
         license_id = replicated_response["license_id"]


### PR DESCRIPTION
Backports #747 for `enterprise-2.2`