### PR TITLE
Update Travis Enterprise User Management to include counts and help

### DIFF
--- a/bin/user_mgmt.rb
+++ b/bin/user_mgmt.rb
@@ -25,10 +25,10 @@ Marginalia.set('dyno', ENV['DYNO'])
 # Setup model
 ActiveRecord::Base.establish_connection(Travis::Config.load.database.to_h)
 class User < ActiveRecord::Base
-  scope :active,    -> { where('github_oauth_token IS NOT NULL AND suspended = false') }
-  scope :inactive,  -> { where('github_oauth_token IS NULL AND suspended = false') }
-  scope :suspended, -> { where(suspended: true) }
-  scope :alpha,     -> { order(login: :asc) }
+  scope :active,    -> { where('github_oauth_token IS NOT NULL AND suspended = false AND login IS NOT NULL') }
+  scope :inactive,  -> { where('github_oauth_token IS NULL AND suspended = false AND login IS NOT NULL') }
+  scope :suspended, -> { where(suspended: true).where('login IS NOT NULL') }
+  scope :alpha,     -> { order(login: :asc).where('login IS NOT NULL') }
 
   def enterprise_status
     case

--- a/bin/user_mgmt.rb
+++ b/bin/user_mgmt.rb
@@ -25,10 +25,11 @@ Marginalia.set('dyno', ENV['DYNO'])
 # Setup model
 ActiveRecord::Base.establish_connection(Travis::Config.load.database.to_h)
 class User < ActiveRecord::Base
-  scope :active,    -> { where('github_oauth_token IS NOT NULL AND suspended = false AND login IS NOT NULL') }
-  scope :inactive,  -> { where('github_oauth_token IS NULL AND suspended = false AND login IS NOT NULL') }
-  scope :suspended, -> { where(suspended: true).where('login IS NOT NULL') }
-  scope :alpha,     -> { order(login: :asc).where('login IS NOT NULL') }
+  default_scope { where('login IS NOT NULL') }
+  scope :active,    -> { where('github_oauth_token IS NOT NULL AND suspended = false') }
+  scope :inactive,  -> { where('github_oauth_token IS NULL AND suspended = false') }
+  scope :suspended, -> { where(suspended: true) }
+  scope :alpha,     -> { order(login: :asc) }
 
   def enterprise_status
     case

--- a/bin/user_mgmt.rb
+++ b/bin/user_mgmt.rb
@@ -25,7 +25,7 @@ Marginalia.set('dyno', ENV['DYNO'])
 # Setup model
 ActiveRecord::Base.establish_connection(Travis::Config.load.database.to_h)
 class User < ActiveRecord::Base
-  default_scope { where('login IS NOT NULL') }
+  default_scope        { where('login IS NOT NULL') }
   scope :active,    -> { where('github_oauth_token IS NOT NULL AND suspended = false') }
   scope :inactive,  -> { where('github_oauth_token IS NULL AND suspended = false') }
   scope :suspended, -> { where(suspended: true) }

--- a/bin/users
+++ b/bin/users
@@ -3,14 +3,27 @@
 require_relative './user_mgmt'
 
 option = ARGV.first
-users = if option == '--active'
-  User.active.alpha
+users = nil
+
+if option == '--active'
+  users = User.active.alpha
+  counts = "Total: #{users.count}"
 elsif option == '--inactive'
-  User.inactive.alpha
+  users = User.inactive.alpha
+  counts = "Total: #{users.count}"
 elsif option == '--suspended'
-  User.suspended.alpha
+  users = User.suspended.alpha
+  counts = "Total: #{users.count}"
 elsif [nil, '--all'].include?(option)
-  User.all.alpha
+  users = User.all.alpha
+  counts = "Total: #{users.count} Active: #{User.active.count} Inactive: #{User.inactive.count} Suspended: #{User.suspended.count}"
+elsif ['--help']
+  puts "Shows status of users in Travis Enterpise installation"
+  puts "--all or no arguments shows all users and their status"
+  puts "--active shows active users"
+  puts "--inactive shows inactive users"
+  puts "--suspended shows suspennded users (suspended using `travis suspend [username]` command)"
+  exit 1
 else
   puts "Option #{option} not recognised."
   exit 1
@@ -21,5 +34,6 @@ if users
   users.each do |user|
     puts [user.login.ljust(col_width), user.enterprise_status.ljust(col_width)].join(' ' * 5)
   end
+  puts counts
   exit 0
 end

--- a/bin/users
+++ b/bin/users
@@ -17,7 +17,7 @@ elsif option == '--suspended'
 elsif [nil, '--all'].include?(option)
   users = User.all.alpha
   counts = "Total: #{users.count} Active: #{User.active.count} Inactive: #{User.inactive.count} Suspended: #{User.suspended.count}"
-elsif ['--help']
+elsif option == '--help'
   puts "Shows status of users in Travis Enterpise installation"
   puts "--all or no arguments shows all users and their status"
   puts "--active shows active users"


### PR DESCRIPTION
Closes: https://github.com/travis-pro/team-teal/issues/2612 (pardon the private link)

From @danishkhan in that issue: 

------------------------
With only 4 users it's easy to tell how many users there are on the install, but for our customers especially at this stage where it's possible they have more users than they initally purchased a license for it'll be handy for them to see the total count rather than having to count it manually themselves.

Something like

```
ubuntu@ip-10-142-242-227:~$ travis users
anna           Inactive
bnferguson     Active
danishkhan     Active
evildanish     Suspended 2018-03-26

Active: 2 Inactive: 1 Suspended: 1
```

For `--suspended` and `--active`
Having the total will be handy

```
ubuntu@ip-10-142-242-227:~$ travis users --active
bnferguson     Active
danishkhan     Active

Total: 2
```
----------------------

This PR addresses this as so, but also adds a `--help` argument and excludes blank logins from counts as in Enterprise installations you can have users with blank logins if you convert between GitHub Enterprise and .com back ends with the same usernames. 