### PR TITLE
Embed Plan representation in Subscription representation

### DIFF
--- a/lib/travis/api/v3/models/plan.rb
+++ b/lib/travis/api/v3/models/plan.rb
@@ -1,0 +1,14 @@
+module Travis::API::V3
+  class Models::Plan
+    attr_reader :id, :name, :builds, :price, :currency, :annual
+
+    def initialize(attributes = {})
+      @id = attributes.fetch('id')
+      @name = attributes.fetch('name')
+      @builds = attributes.fetch('builds')
+      @price = attributes.fetch('price')
+      @currency = attributes.fetch('currency')
+      @annual = attributes.fetch('annual')
+    end
+  end
+end

--- a/lib/travis/api/v3/models/subscription.rb
+++ b/lib/travis/api/v3/models/subscription.rb
@@ -5,7 +5,8 @@ module Travis::API::V3
     def initialize(attributes = {})
       @id = attributes.fetch('id')
       @valid_to = attributes.fetch('valid_to') && DateTime.parse(attributes.fetch('valid_to'))
-      @plan = Models::Plan.new(attributes.fetch('plan'))
+      plan_data = attributes.fetch('plan')
+      @plan = plan_data && Models::Plan.new(plan_data)
       @coupon = attributes['coupon']
       @status = attributes.fetch('status')
       @source = attributes.fetch('source')

--- a/lib/travis/api/v3/models/subscription.rb
+++ b/lib/travis/api/v3/models/subscription.rb
@@ -5,7 +5,7 @@ module Travis::API::V3
     def initialize(attributes = {})
       @id = attributes.fetch('id')
       @valid_to = attributes.fetch('valid_to') && DateTime.parse(attributes.fetch('valid_to'))
-      @plan = attributes.fetch('plan')
+      @plan = Models::Plan.new(attributes.fetch('plan'))
       @coupon = attributes['coupon']
       @status = attributes.fetch('status')
       @source = attributes.fetch('source')

--- a/lib/travis/api/v3/renderer/plan.rb
+++ b/lib/travis/api/v3/renderer/plan.rb
@@ -1,0 +1,5 @@
+module Travis::API::V3
+  class Renderer::Plan < ModelRenderer
+    representation(:minimal, :id, :name, :builds, :price, :currency, :annual)
+  end
+end

--- a/spec/support/billing_spec_helper.rb
+++ b/spec/support/billing_spec_helper.rb
@@ -11,7 +11,14 @@ module Support
       {
         "id" => 81,
         "valid_to" => "2017-11-28T00:09:59.502Z",
-        "plan" => "travis-ci-ten-builds",
+        "plan" => {
+          "id" => "travis-ci-ten-builds",
+          "name" => "Startup",
+          "builds" => 10,
+          "annual" => false,
+          "price" => 12500,
+          "currency" => "USD"
+        },
         "coupon" => "",
         "status" => "canceled",
         "source" => "stripe",

--- a/spec/v3/billing_client_spec.rb
+++ b/spec/v3/billing_client_spec.rb
@@ -18,10 +18,10 @@ describe Travis::API::V3::BillingClient, billing_spec_helper: true do
 
     it 'returns the subscription' do
       stub_billing_request(:get, "/subscriptions/#{subscription_id}", auth_key: auth_key, user_id: user_id)
-        .to_return(body: JSON.dump(billing_response_body('id' => subscription_id, 'plan' => 'travis-ci-two-builds', 'owner' => { 'type' => 'Organization', 'id' => organization.id } )))
+        .to_return(body: JSON.dump(billing_response_body('id' => subscription_id, 'owner' => { 'type' => 'Organization', 'id' => organization.id } )))
       expect(subject).to be_a(Travis::API::V3::Models::Subscription)
       expect(subject.id).to eq(subscription_id)
-      expect(subject.plan).to eq('travis-ci-two-builds')
+      expect(subject.plan).to be_a(Travis::API::V3::Models::Plan)
     end
 
     it 'raises error if subscription is not found' do

--- a/spec/v3/services/subscriptions/all_spec.rb
+++ b/spec/v3/services/subscriptions/all_spec.rb
@@ -40,7 +40,16 @@ describe Travis::API::V3::Services::Subscriptions::All, set_app: true, billing_s
           '@representation' => 'standard',
           'id' => 1234,
           'valid_to' => '2017-11-28T00:09:59Z',
-          'plan' => 'travis-ci-ten-builds',
+          'plan' => {
+            '@type' => 'plan',
+            '@representation' => 'minimal',
+            'id' => 'travis-ci-ten-builds',
+            'name' => 'Startup',
+            'builds' => 10,
+            'price' => 12500,
+            'currency' => 'USD',
+            'annual' => false
+          },
           'coupon' => '',
           'status' => 'canceled',
           'source' => 'stripe',

--- a/spec/v3/services/subscriptions/all_spec.rb
+++ b/spec/v3/services/subscriptions/all_spec.rb
@@ -21,10 +21,22 @@ describe Travis::API::V3::Services::Subscriptions::All, set_app: true, billing_s
     let(:organization) { Factory(:org, login: 'travis') }
     let(:token) { Travis::Api::App::AccessToken.create(user: user, app_id: 1) }
     let(:headers) {{ 'HTTP_AUTHORIZATION' => "token #{token}" }}
+    let(:plan) do
+      {
+        '@type' => 'plan',
+        '@representation' => 'minimal',
+        'id' => 'travis-ci-ten-builds',
+        'name' => 'Startup',
+        'builds' => 10,
+        'price' => 12500,
+        'currency' => 'USD',
+        'annual' => false
+      }
+    end
 
     before do
       stub_billing_request(:get, '/subscriptions', auth_key: billing_auth_key, user_id: user.id)
-        .to_return(status: 200, body: JSON.dump([billing_response_body('id' => 1234, 'owner' => { 'type' => 'Organization', 'id' => organization.id })]))
+        .to_return(status: 200, body: JSON.dump([billing_response_body('id' => 1234, 'plan' => plan, 'owner' => { 'type' => 'Organization', 'id' => organization.id })]))
     end
 
     it 'responds with list of subscriptions' do
@@ -40,16 +52,7 @@ describe Travis::API::V3::Services::Subscriptions::All, set_app: true, billing_s
           '@representation' => 'standard',
           'id' => 1234,
           'valid_to' => '2017-11-28T00:09:59Z',
-          'plan' => {
-            '@type' => 'plan',
-            '@representation' => 'minimal',
-            'id' => 'travis-ci-ten-builds',
-            'name' => 'Startup',
-            'builds' => 10,
-            'price' => 12500,
-            'currency' => 'USD',
-            'annual' => false
-          },
+          'plan' => plan,
           'coupon' => '',
           'status' => 'canceled',
           'source' => 'stripe',
@@ -84,6 +87,17 @@ describe Travis::API::V3::Services::Subscriptions::All, set_app: true, billing_s
           }
         }]
       })
+    end
+
+    context 'with a null plan' do
+      let(:plan) { nil }
+
+      it 'responds with a null plan' do
+        get('/v3/subscriptions', {}, headers)
+
+        expect(last_response.status).to eq(200)
+        expect(parsed_body['subscriptions'][0].fetch('plan')).to eq(nil)
+      end
     end
   end
 end

--- a/spec/v3/services/subscriptions/create_spec.rb
+++ b/spec/v3/services/subscriptions/create_spec.rb
@@ -61,7 +61,14 @@ describe Travis::API::V3::Services::Subscriptions::Create, set_app: true, billin
           .to_return(status: 201, body: JSON.dump(billing_response_body(
             'id' => 1234,
             'owner' => { 'type' => 'Organization', 'id' => organization.id },
-            'plan' => 'travis-ci-ten-builds',
+            'plan' => {
+              'id' => 'travis-ci-ten-builds',
+              'name' => 'Startup',
+              'builds' => 10,
+              'price' => 12500,
+              'currency' => 'USD',
+              'annual' => false
+            },
             'billing_info' => {
               'first_name' => 'Travis',
               'last_name' => 'Schmidt',
@@ -91,7 +98,16 @@ describe Travis::API::V3::Services::Subscriptions::Create, set_app: true, billin
           '@representation' => 'standard',
           'id' => 1234,
           'valid_to' => '2017-11-28T00:09:59Z',
-          'plan' => 'travis-ci-ten-builds',
+          'plan' => {
+            '@type' => 'plan',
+            '@representation' => 'minimal',
+            'id' => 'travis-ci-ten-builds',
+            'name' => 'Startup',
+            'builds' => 10,
+            'price' => 12500,
+            'currency' => 'USD',
+            'annual' => false
+          },
           'coupon' => '',
           'status' => 'canceled',
           'source' => 'stripe',


### PR DESCRIPTION
This is the reintroduction of #743, which was reverted because the corresponding endpoint in billing-v2 was failing in some circumstances due to old invalid data. This was fixed in travis-pro/billing-v2#75.

I have also added handling for null values in the plan attribute (which is what billing-v2 does now in presence of an invalid plan).