### PR TITLE
return commit branch name instead of branch object for requests

### DIFF
--- a/lib/travis/api/v3/models/pull_request.rb
+++ b/lib/travis/api/v3/models/pull_request.rb
@@ -7,7 +7,7 @@ module Travis::API::V3
     serialize  :payload
 
     def branch_name
-      commit.branch if commit
+      commit.branch_name if commit
     end
 
     def payload

--- a/lib/travis/api/v3/models/request.rb
+++ b/lib/travis/api/v3/models/request.rb
@@ -18,7 +18,7 @@ module Travis::API::V3
     has_many   :messages, as: :subject
 
     def branch_name
-      commit.branch if commit
+      commit.branch_name if commit
     end
 
     def config=(config)


### PR DESCRIPTION
this request: https://developer.travis-ci.org/explore/repo/269284/requests currently returns:

```
{
...
  "requests":        [
    {
      "@type":           "request",
      ...
      "branch_name":     {
        "@type":           "branch",
        "@href":           "/repo/269284/branch/joshk-changelog",
        "@representation": "minimal",
        "name":            "..."
      },
...
```

but according to the docs it should be a string. this hopefully remedies that!