### PR TITLE
 Remove duplicate env variable before returning the error 

### DIFF
--- a/lib/travis/api/v3/queries/env_vars.rb
+++ b/lib/travis/api/v3/queries/env_vars.rb
@@ -3,7 +3,7 @@ module Travis::API::V3
     params :name, :value, :public, prefix: :env_var
 
     def find(repository)
-      repository.env_vars    
+      repository.env_vars
     end
 
     def create(repository)

--- a/lib/travis/api/v3/queries/env_vars.rb
+++ b/lib/travis/api/v3/queries/env_vars.rb
@@ -8,7 +8,10 @@ module Travis::API::V3
 
     def create(repository)
       env_var = repository.env_vars.create(env_var_params)
-      handle_errors(env_var) unless env_var.valid?
+      unless env_var.valid?
+        repository.env_vars.destroy(env_var.id)
+        handle_errors(env_var)
+      end
       repository.save!
       env_var
     end

--- a/spec/v3/services/env_vars/create_spec.rb
+++ b/spec/v3/services/env_vars/create_spec.rb
@@ -66,6 +66,7 @@ describe Travis::API::V3::Services::EnvVars::Create, set_app: true do
         'error_type' => 'duplicate_resource'
       )
     end
+    example { expect(repo.reload.env_vars.count).to eq(1) }
   end
 
   describe 'authenticated, existing repo, env var is new' do


### PR DESCRIPTION
This change fixes the issue but it seems a bit weird. The [collection class](https://github.com/travis-ci/travis-settings/blob/master/lib/travis/settings/collection.rb) doesn't provide a way to instantiate without saving (`build` vs `create` in ActiveRecord terms) so this is the only way I could think of. Maybe someone that knows that class and its interactions with the underlying ActiveRecord models has a better idea.