### PR TITLE
perform repository_id access check in ruby when we have a repository_id

### DIFF
--- a/lib/travis/api/v3/access_control/anonymous.rb
+++ b/lib/travis/api/v3/access_control/anonymous.rb
@@ -19,7 +19,7 @@ module Travis::API::V3
 
     private
 
-    def visible_objects(list, factory)
+    def visible_objects(list, repository_id, factory)
       return factory.none unless unrestricted_api?
       list.where(private: false)
     end

--- a/lib/travis/api/v3/access_control/generic.rb
+++ b/lib/travis/api/v3/access_control/generic.rb
@@ -54,24 +54,24 @@ module Travis::API::V3
       !!Travis.config.enterprise
     end
 
-    def visible_repositories(list)
+    def visible_repositories(list, repository_id = nil)
       # naïve implementation, can be replaced with smart implementation in specific subclasses
-      visible_objects(list, Models::Repository)
+      visible_objects(list, repository_id, Models::Repository)
     end
 
-    def visible_builds(list)
+    def visible_builds(list, repository_id = nil)
       # naïve implementation, can be replaced with smart implementation in specific subclasses
-      visible_objects(list, Models::Build)
+      visible_objects(list, repository_id, Models::Build)
     end
 
-    def visible_jobs(list)
+    def visible_jobs(list, repository_id = nil)
       # naïve implementation, can be replaced with smart implementation in specific subclasses
-      visible_objects(list, Models::Job)
+      visible_objects(list, repository_id, Models::Job)
     end
 
-    def visible_requests(list)
+    def visible_requests(list, repository_id = nil)
       # naïve implementation, can be replaced with smart implementation in specific subclasses
-      visible_objects(list, Models::Request)
+      visible_objects(list, repository_id, Models::Request)
     end
 
     def permissions(object)
@@ -237,7 +237,7 @@ module Travis::API::V3
       end
     end
 
-    def visible_objects(list, factory)
+    def visible_objects(list, repository_id, factory)
       return list if full_access?
       list.select { |r| visible?(r) }
     end

--- a/lib/travis/api/v3/access_control/user.rb
+++ b/lib/travis/api/v3/access_control/user.rb
@@ -91,7 +91,7 @@ module Travis::API::V3
     def visible_objects(list, repository_id, factory)
       if repository_id
         if private_access_repository_ids.include?(repository_id)
-          list.where("#{factory.table_name}.repository_id = ?", private_access_repository_ids, repository_id)
+          list.where("#{factory.table_name}.repository_id = ?", repository_id)
         else
           list.where("#{factory.table_name}.private = false")
         end

--- a/lib/travis/api/v3/access_control/user.rb
+++ b/lib/travis/api/v3/access_control/user.rb
@@ -80,8 +80,16 @@ module Travis::API::V3
 
     private
 
-    def visible_objects(list, factory)
-      list.where("#{factory.table_name}.private = false OR #{factory.table_name}.repository_id IN (?)", private_access_repository_ids)
+    def visible_objects(list, repository_id, factory)
+      if repository_id
+        if private_access_repository_ids.include?(repository_id)
+          list.where("#{factory.table_name}.repository_id = ?", private_access_repository_ids, repository_id)
+        else
+          list.where("#{factory.table_name}.private = false")
+        end
+      else
+        list.where("#{factory.table_name}.private = false OR #{factory.table_name}.repository_id IN (?)", private_access_repository_ids)
+      end
     end
   end
 end

--- a/lib/travis/api/v3/access_control/user.rb
+++ b/lib/travis/api/v3/access_control/user.rb
@@ -19,8 +19,16 @@ module Travis::API::V3
       permission?(:admin, repository) ? user : super
     end
 
-    def visible_repositories(list)
-      list.where('repositories.private = false OR repositories.id IN (?)'.freeze, private_access_repository_ids)
+    def visible_repositories(list, repository_id = nil)
+      if repository_id
+        if private_access_repository_ids.include?(repository_id)
+          list.where('repositories.id = ?', repository_id)
+        else
+          list.where('repositories.private = false')
+        end
+      else
+        list.where('repositories.private = false OR repositories.id IN (?)'.freeze, private_access_repository_ids)
+      end
     end
 
     protected

--- a/lib/travis/api/v3/services/builds/find.rb
+++ b/lib/travis/api/v3/services/builds/find.rb
@@ -5,8 +5,9 @@ module Travis::API::V3
     paginate
 
     def run!
-      unfiltered = query.find(find(:repository))
-      result access_control.visible_builds(unfiltered)
+      repository = find(:repository)
+      unfiltered = query.find(repository)
+      result access_control.visible_builds(unfiltered, repository.id)
     end
   end
 end

--- a/lib/travis/api/v3/services/requests/find.rb
+++ b/lib/travis/api/v3/services/requests/find.rb
@@ -2,8 +2,9 @@ module Travis::API::V3
   class Services::Requests::Find < Service
     paginate
     def run!
-      unfiltered = query.find(find(:repository))
-      result access_control.visible_requests(unfiltered) 
+      repository = find(:repository)
+      unfiltered = query.find(repository)
+      result access_control.visible_requests(unfiltered, repository.id)
     end
   end
 end

--- a/lib/travis/model/scope_access.rb
+++ b/lib/travis/model/scope_access.rb
@@ -88,10 +88,6 @@ module Travis
           end
 
           def viewable_in_private_mode_with_repo(user, repository_id)
-            user.repository_ids.include?(repository_id) ?
-              where('true') :
-              where('false')
-
             if user.nil?
               where('false')
             elsif self == ::Repository

--- a/lib/travis/model/scope_access.rb
+++ b/lib/travis/model/scope_access.rb
@@ -3,13 +3,21 @@ module Travis
     def self.included(base)
       base.class_eval do
         class << self
-          def viewable_by(user)
+          def viewable_by(user, repository_id = nil)
             if Travis.config.org?
               self.unscoped
             elsif Travis.config[:public_mode]
-              viewable_in_public_mode(user)
+              if repository_id
+                viewable_in_public_mode_with_repo(user, repository_id)
+              else
+                viewable_in_public_mode(user)
+              end
             else
-              viewable_in_private_mode(user)
+              if repository_id
+                viewable_in_private_mode_with_repo(user, repository_id)
+              else
+                viewable_in_private_mode(user)
+              end
             end
           end
 
@@ -37,6 +45,32 @@ module Travis
             end
           end
 
+          def viewable_in_public_mode_with_repo(user, repository_id)
+            return viewable_in_public_mode(user) unless user
+
+            if self == ::Repository
+              return user.repository_ids.include?(repository_id) ?
+                where('true') :
+                where('repositories.private <> ?', true)
+            elsif self == ::Request
+              return user.repository_ids.include?(repository_id) ?
+                where('true') :
+                where('requests.private <> ?', true)
+            elsif self == ::Build
+              return user.repository_ids.include?(repository_id) ?
+                where('true') :
+                where('builds.private <> ?', true)
+            elsif self == ::Job
+              return user.repository_ids.include?(repository_id) ?
+                where('true') :
+                where('jobs.private <> ?', true)
+            else
+              return user.repository_ids.include?(repository_id) ?
+                joins(:repository).where('true') :
+                joins(:repository).where("#{table_name}.private <> ?", true)
+            end
+          end
+
           def viewable_in_private_mode(user)
             if user.nil?
               where('false')
@@ -50,6 +84,36 @@ module Travis
               where('jobs.repository_id IN (?)', user.repository_ids)
             else
               where("#{table_name}.repository_id IN (?)", user.repository_ids)
+            end
+          end
+
+          def viewable_in_private_mode_with_repo(user, repository_id)
+            user.repository_ids.include?(repository_id) ?
+              where('true') :
+              where('false')
+
+            if user.nil?
+              where('false')
+            elsif self == ::Repository
+              user.repository_ids.include?(repository_id) ?
+                where('repositories.id = ?', repository_id) :
+                where('false')
+            elsif self == ::Request
+              user.repository_ids.include?(repository_id) ?
+                where('requests.repository_id = ?', repository_id) :
+                where('false')
+            elsif self == ::Build
+              user.repository_ids.include?(repository_id) ?
+                where('builds.repository_id = ?', repository_id) :
+                where('false')
+            elsif self == ::Job
+              user.repository_ids.include?(repository_id) ?
+                where('jobs.repository_id = ?', repository_id) :
+                where('false')
+            else
+              user.repository_ids.include?(repository_id) ?
+                where("#{table_name}.repository_id = ?", repository_id) :
+                where('false')
             end
           end
         end

--- a/lib/travis/services/base.rb
+++ b/lib/travis/services/base.rb
@@ -27,9 +27,9 @@ module Travis
         @current_user = args.last
       end
 
-      def scope(key)
+      def scope(key, repository_id = nil)
         scope = key.to_s.camelize.constantize
-        scope = scope.viewable_by(current_user) if self.class.scope_access?
+        scope = scope.viewable_by(current_user, repository_id) if self.class.scope_access?
         scope
       end
 

--- a/lib/travis/services/find_builds.rb
+++ b/lib/travis/services/find_builds.rb
@@ -27,7 +27,7 @@ module Travis
 
         def by_params
           scope = if repo
-            builds = scope(:build).where(repository_id: repo.id)
+            builds = scope(:build, repo.id).where(repository_id: repo.id)
             builds = builds.by_event_type(params[:event_type]) if params[:event_type]
             if params[:number]
               builds.where(:number => params[:number].to_s)

--- a/lib/travis/services/find_requests.rb
+++ b/lib/travis/services/find_requests.rb
@@ -22,7 +22,7 @@ module Travis
             columns = %w/id repository_id commit_id created_at owner_id owner_type
                          event_type base_commit head_commit result message state
                          pull_request_id/
-            requests = scope(:request).where(repository_id: repo.id)
+            requests = scope(:request, repo.id).where(repository_id: repo.id)
             requests = requests.select(columns.map { |c| %Q["requests"."#{c}"] })
             if params[:older_than]
               requests.older_than(params[:older_than])


### PR DESCRIPTION
we've been having some issues with slow queries that include checking all repository ids.

an example is:

```
SELECT COUNT(*) FROM "builds" WHERE "builds"."repository_id" = 12345 AND "builds"."event_type" IN ('push', 'api', 'cron') AND (builds.private = false OR builds.repository_id IN (11111, 22222, 12345))
```

the postgres query planner is not smart enough to figure out if the top-level repo id is in the list, it doesn't handle the OR very gracefully.

in the case where we have a repository id, instead of pushing the authentication check down into sql, we can perform it in memory in ruby. we're fetching the list of a user's repo ids already anyway. this makes the queries smaller, the postgres logs less noisy, and the queries potentially more efficient.

for the huge COUNT queries on requests/builds/jobs this can make a big difference.

refs travis-ci/reliability#88