### PR TITLE
remove references to the logs db (we talk to logs over http now)

### DIFF
--- a/lib/travis/config/defaults.rb
+++ b/lib/travis/config/defaults.rb
@@ -32,7 +32,6 @@ module Travis
             amqp:          { username: 'guest', password: 'guest', host: 'localhost', prefetch: 1 },
             billing:       {},
             database:      { adapter: 'postgresql', database: "travis_#{Travis.env}", encoding: 'unicode', min_messages: 'warning', variables: { statement_timeout: 10_000 } },
-            logs_database: { adapter: 'postgresql', database: "travis_logs_#{Travis.env}", encoding: 'unicode', min_messages: 'warning', variables: { statement_timeout: 10_000 } },
             logs_api:      { url: logs_api_url, token: logs_api_auth_token },
             log_options:   { s3: { access_key_id: '', secret_access_key: ''}},
             s3:            { access_key_id: '', secret_access_key: ''},

--- a/lib/travis/sidekiq.rb
+++ b/lib/travis/sidekiq.rb
@@ -7,7 +7,6 @@ require 'travis/customerio'
 
 pool_size = ENV['SIDEKIQ_DB_POOL_SIZE'] || 5
 Travis.config.database[:pool] = pool_size.to_i
-Travis.config.logs_database[:pool] = pool_size.to_i
 Travis::Database.connect
 
 Travis::Async.enabled = true

--- a/spec/lib/travis/config_spec.rb
+++ b/spec/lib/travis/config_spec.rb
@@ -82,16 +82,6 @@ describe Travis::Config do
         :variables => { :statement_timeout => 10000 }
       }
     end
-
-    it 'logs database' do
-      config.logs_database.should == {
-        :adapter => 'postgresql',
-        :database => 'travis_logs_test',
-        :encoding => 'unicode',
-        :min_messages => 'warning',
-        :variables => { :statement_timeout => 10000 }
-      }
-    end
   end
 
   describe 'resource urls' do
@@ -118,32 +108,6 @@ describe Travis::Config do
       it { config.database.database.should == 'database' }
       it { config.database.encoding.should == 'unicode' }
       it { config.database.variables.application_name.should_not be_empty }
-      it { config.database.variables.statement_timeout.should eq statement_timeout }
-    end
-
-    describe 'with a TRAVIS_LOGS_DATABASE_URL set' do
-      before { ENV['TRAVIS_LOGS_DATABASE_URL'] = 'postgres://username:password@host:1234/database' }
-
-      it { config.logs_database.username.should == 'username' }
-      it { config.logs_database.password.should == 'password' }
-      it { config.logs_database.host.should == 'host' }
-      it { config.logs_database.port.should == 1234 }
-      it { config.logs_database.database.should == 'database' }
-      it { config.logs_database.encoding.should == 'unicode' }
-      it { config.logs_database.variables.application_name.should_not be_empty }
-      it { config.database.variables.statement_timeout.should eq statement_timeout }
-    end
-
-    describe 'with a LOGS_DATABASE_URL set' do
-      before { ENV['LOGS_DATABASE_URL'] = 'postgres://username:password@host:1234/database' }
-
-      it { config.logs_database.username.should == 'username' }
-      it { config.logs_database.password.should == 'password' }
-      it { config.logs_database.host.should == 'host' }
-      it { config.logs_database.port.should == 1234 }
-      it { config.logs_database.database.should == 'database' }
-      it { config.logs_database.encoding.should == 'unicode' }
-      it { config.logs_database.variables.application_name.should_not be_empty }
       it { config.database.variables.statement_timeout.should eq statement_timeout }
     end
 


### PR DESCRIPTION
we no longer connect directly to the logs database from api. this patch makes that explicit by removing the last relics in the code base.

vaguely refs https://github.com/travis-ci/reliability/issues/60