### PR TITLE
Prevent sortable on default branches

### DIFF
--- a/lib/travis/api/v3/queries/repositories.rb
+++ b/lib/travis/api/v3/queries/repositories.rb
@@ -73,7 +73,7 @@ module Travis::API::V3
                               || lower(repositories.name), #{query}) as slug_filter")
       end
       list = list.includes(default_branch: :last_build)
-      list = list.includes(current_build: [:repository, :branch, :commit, :stages, :sender]) if includes? 'repository.current_build'.freeze
+      list = list.includes(current_build: [:repository, :branch, :commit, :stages]) if includes? 'repository.current_build'.freeze
       list = list.includes(default_branch: { last_build: :commit }) if includes? 'build.commit'.freeze
       sort list
     end


### PR DESCRIPTION
~Early PR to take advantage of tests DON'T MERGE~

This was causing AR errors when using sort_by=default_branch.last_build
as a filter on /v3/owner/[owner]/repos calls. I'm not convinced this is
a perfect solution, but after an hour of being on org-production I saw
no discernible change in DB load or performance, and it allows the
queries in question to resolve.

Error in sentry:
https://sentry.io/travis-ci/org-api-production/issues/571746986/?query=request_id:d4e62c95-b674-4f17-b967-1df4e70757b7

Issue:
travis-pro/team-teal#2709