### PR TITLE
Fix sorting of repos on owner/repos endpoint

### DIFF
--- a/lib/travis/api/v3/queries/repositories.rb
+++ b/lib/travis/api/v3/queries/repositories.rb
@@ -4,7 +4,7 @@ module Travis::API::V3
     experimental_params :name_filter, prefix: :repository
     experimental_params :slug_filter, prefix: :repository
     sortable_by :id, :github_id, :owner_name, :name, active: sort_condition(:active),
-                :'default_branch.last_build' => 'builds.started_at',
+                :'default_branch.last_build' => "builds.started_at %{order} NULLS LAST",
                 :current_build => "repositories.current_build_id %{order} NULLS LAST",
                 :name_filter   => "name_filter",
                 :slug_filter   => "slug_filter"

--- a/lib/travis/api/v3/queries/repositories.rb
+++ b/lib/travis/api/v3/queries/repositories.rb
@@ -4,7 +4,7 @@ module Travis::API::V3
     experimental_params :name_filter, prefix: :repository
     experimental_params :slug_filter, prefix: :repository
     sortable_by :id, :github_id, :owner_name, :name, active: sort_condition(:active),
-                :'default_branch.last_build' => "builds.started_at %{order} NULLS LAST",
+                :'default_branch.last_build' => "branches.last_build_id %{order} NULLS LAST",
                 :current_build => "repositories.current_build_id %{order} NULLS LAST",
                 :name_filter   => "name_filter",
                 :slug_filter   => "slug_filter"


### PR DESCRIPTION
This is a test to see if adding NULLS LAST to the default_branch.last_build helps with the issues loading the org page.