### PR TITLE
Protect against missing column config on requests, builds, jobs

### DIFF
--- a/lib/travis/api/v3/models/build.rb
+++ b/lib/travis/api/v3/models/build.rb
@@ -68,8 +68,9 @@ module Travis::API::V3
     end
 
     def config
-      config = super&.config || read_attribute(:config) || {}
+      config = super&.config || has_attribute?(:config) && read_attribute(:config) || {}
       config.deep_symbolize_keys! if config.respond_to?(:deep_symbolize_keys!)
+      config
     end
 
     def branch_name=(value)

--- a/lib/travis/api/v3/models/job.rb
+++ b/lib/travis/api/v3/models/job.rb
@@ -36,8 +36,9 @@ module Travis::API::V3
     end
 
     def config
-      config = super&.config || read_attribute(:config) || {}
+      config = super&.config || has_attribute?(:config) && read_attribute(:config) || {}
       config.deep_symbolize_keys! if config.respond_to?(:deep_symbolize_keys!)
+      config
     end
   end
 end

--- a/lib/travis/api/v3/models/request.rb
+++ b/lib/travis/api/v3/models/request.rb
@@ -32,8 +32,9 @@ module Travis::API::V3
     end
 
     def config
-      config = super&.config || read_attribute(:config) || {}
+      config = super&.config || has_attribute?(:config) && read_attribute(:config) || {}
       config.deep_symbolize_keys! if config.respond_to?(:deep_symbolize_keys!)
+      config
     end
 
     def yaml_config

--- a/lib/travis/model/build.rb
+++ b/lib/travis/model/build.rb
@@ -176,7 +176,7 @@ class Build < Travis::Model
 
   def config
     @config ||= begin
-      config = super&.config || read_attribute(:config) || {}
+      config = super&.config || has_attribute?(:config) && read_attribute(:config) || {}
       config.deep_symbolize_keys! if config.respond_to?(:deep_symbolize_keys!)
       Config.new(config, multi_os: repository.try(:multi_os_enabled?)).normalize
     end

--- a/lib/travis/model/job.rb
+++ b/lib/travis/model/job.rb
@@ -117,8 +117,9 @@ class Job < Travis::Model
   end
 
   def config
-    config = super&.config || read_attribute(:config) || {}
+    config = super&.config || has_attribute?(:config) && read_attribute(:config) || {}
     config.deep_symbolize_keys! if config.respond_to?(:deep_symbolize_keys!)
+    config
   end
 
   def obfuscated_config

--- a/lib/travis/model/request.rb
+++ b/lib/travis/model/request.rb
@@ -119,7 +119,8 @@ class Request < Travis::Model
   end
 
   def config
-    config = super&.config || read_attribute(:config) || {}
+    config = super&.config || has_attribute?(:config) && read_attribute(:config) || {}
     config.deep_symbolize_keys! if config.respond_to?(:deep_symbolize_keys!)
+    config
   end
 end


### PR DESCRIPTION
`read_attribute` returns `nil` anyway if the column is missing, but it looks like they are currently still debating if that is a bug or not https://github.com/rails/rails/issues/31017