### PR TITLE
Support subscription data both in the toplevel and under a key

### DIFF
--- a/lib/travis/api/v3/billing_client.rb
+++ b/lib/travis/api/v3/billing_client.rb
@@ -7,7 +7,12 @@ module Travis::API::V3
     end
 
     def all
-      connection.get('/subscriptions').body.map do |subscription_data|
+      # because billing-v2 API is changing from responding with an array, to responding with an
+      # object where this array is under the `subscriptions` key (in order to add permissions
+      # metadata under a separate key), we want to temporarily support both formats
+      response_body = connection.get('/subscriptions').body
+      data = response_body.is_a?(Hash) ? response_body['subscriptions'] : response_body
+      data.map do |subscription_data|
         Travis::API::V3::Models::Subscription.new(subscription_data)
       end
     end


### PR DESCRIPTION
Paired with @rwrede.

We added the explanation for this temporary change in a comment:

> because billing-v2 API is changing from responding with an array, to responding with an object where this array is under the `subscriptions` key (in order to add permissions metadata under a separate key), we want to temporarily support both formats