### PR TITLE
Freeze time when travelling

### DIFF
--- a/spec/lib/schedulers/schedule_cron_jobs_spec.rb
+++ b/spec/lib/schedulers/schedule_cron_jobs_spec.rb
@@ -62,7 +62,7 @@ describe "ScheduleCronJobs" do
             repository_id: cron.branch.repository.id,
             finished_at: DateTime.now - 1.hour)
           cron.branch.update_attribute(:last_build_id, last_build.id)
-          Timecop.travel(scheduler_interval.from_now)
+          Timecop.freeze(scheduler_interval.from_now)
         end
 
         after do


### PR DESCRIPTION
While pairing with @rwrede in something else, this test randomly failed on timestamp mismatch. We think that it is because it expects time to be frozen but it's not (`travel` unfreezes it).

Does this fix make sense?