### PR TITLE
 Expose collection permissions received from billing-v2 

### DIFF
--- a/lib/travis/api/v3/billing_client.rb
+++ b/lib/travis/api/v3/billing_client.rb
@@ -7,9 +7,13 @@ module Travis::API::V3
     end
 
     def all
-      connection.get('/subscriptions').body.fetch('subscriptions').map do |subscription_data|
+      data = connection.get('/subscriptions').body
+      subscriptions = data.fetch('subscriptions').map do |subscription_data|
         Travis::API::V3::Models::Subscription.new(subscription_data)
       end
+      permissions = data.fetch('permissions')
+
+      Travis::API::V3::Models::SubscriptionsCollection.new(subscriptions, permissions)
     end
 
     def get_subscription(id)

--- a/lib/travis/api/v3/billing_client.rb
+++ b/lib/travis/api/v3/billing_client.rb
@@ -7,12 +7,7 @@ module Travis::API::V3
     end
 
     def all
-      # because billing-v2 API is changing from responding with an array, to responding with an
-      # object where this array is under the `subscriptions` key (in order to add permissions
-      # metadata under a separate key), we want to temporarily support both formats
-      response_body = connection.get('/subscriptions').body
-      data = response_body.is_a?(Hash) ? response_body['subscriptions'] : response_body
-      data.map do |subscription_data|
+      connection.get('/subscriptions').body.fetch('subscriptions').map do |subscription_data|
         Travis::API::V3::Models::Subscription.new(subscription_data)
       end
     end

--- a/lib/travis/api/v3/models/subscription.rb
+++ b/lib/travis/api/v3/models/subscription.rb
@@ -19,6 +19,15 @@ module Travis::API::V3
     end
   end
 
+  class Models::SubscriptionsCollection
+    attr_reader :subscriptions, :permissions
+
+    def initialize(subscriptions, permissions)
+      @subscriptions = subscriptions
+      @permissions = permissions
+    end
+  end
+
   class Models::BillingInfo
     attr_reader :id, :address, :address2, :billing_email, :city, :company, :country, :first_name, :last_name, :state, :vat_id, :zip_code
 

--- a/lib/travis/api/v3/renderer/subscriptions.rb
+++ b/lib/travis/api/v3/renderer/subscriptions.rb
@@ -2,5 +2,21 @@ module Travis::API::V3
   class Renderer::Subscriptions < CollectionRenderer
     type           :subscriptions
     collection_key :subscriptions
+
+    def fields
+      super.tap do |fields|
+        fields[:@permissions] = render_entry(permissions)
+      end
+    end
+
+    private
+
+    def list
+      @list.subscriptions
+    end
+
+    def permissions
+      @list.permissions
+    end
   end
 end

--- a/spec/v3/billing_client_spec.rb
+++ b/spec/v3/billing_client_spec.rb
@@ -55,7 +55,7 @@ describe Travis::API::V3::BillingClient, billing_spec_helper: true do
 
     it 'returns the list of subscriptions' do
       stub_billing_request(:get, '/subscriptions', auth_key: auth_key, user_id: user_id)
-        .to_return(body: JSON.dump([billing_subscription_response_body('id' => subscription_id, 'owner' => { 'type' => 'Organization', 'id' => organization.id })]))
+        .to_return(body: JSON.dump(subscriptions: [billing_subscription_response_body('id' => subscription_id, 'owner' => { 'type' => 'Organization', 'id' => organization.id })]))
 
       expect(subject.size).to eq 1
       expect(subject.first.id).to eq(subscription_id)

--- a/spec/v3/billing_client_spec.rb
+++ b/spec/v3/billing_client_spec.rb
@@ -53,12 +53,15 @@ describe Travis::API::V3::BillingClient, billing_spec_helper: true do
   describe '#all' do
     subject { billing.all }
 
+    let(:permissions) { [{'owner' => {'type' => 'Organization', 'id' => 1}, 'create' => true}] }
+
     it 'returns the list of subscriptions' do
       stub_billing_request(:get, '/subscriptions', auth_key: auth_key, user_id: user_id)
-        .to_return(body: JSON.dump(subscriptions: [billing_subscription_response_body('id' => subscription_id, 'owner' => { 'type' => 'Organization', 'id' => organization.id })]))
+        .to_return(body: JSON.dump(subscriptions: [billing_subscription_response_body('id' => subscription_id, 'owner' => { 'type' => 'Organization', 'id' => organization.id })], permissions: permissions))
 
-      expect(subject.size).to eq 1
-      expect(subject.first.id).to eq(subscription_id)
+      expect(subject.subscriptions.size).to eq 1
+      expect(subject.subscriptions.first.id).to eq(subscription_id)
+      expect(subject.permissions).to eq(permissions)
     end
   end
 

--- a/spec/v3/services/subscriptions/all_spec.rb
+++ b/spec/v3/services/subscriptions/all_spec.rb
@@ -36,7 +36,7 @@ describe Travis::API::V3::Services::Subscriptions::All, set_app: true, billing_s
 
     let(:subscriptions_data) { [billing_subscription_response_body('id' => 1234, 'plan' => plan,'permissions' => { 'read' => true, 'write' => false }, 'owner' => { 'type' => 'Organization', 'id' => organization.id })] }
 
-    let(:v2_response_body) { JSON.dump(subscriptions_data) }
+    let(:v2_response_body) { JSON.dump(subscriptions: subscriptions_data) }
 
     let(:expected_json) do
       {
@@ -97,16 +97,6 @@ describe Travis::API::V3::Services::Subscriptions::All, set_app: true, billing_s
       get('/v3/subscriptions', {}, headers)
       expect(last_response.status).to eq(200)
       expect(parsed_body).to eql_json(expected_json)
-    end
-
-    context 'with subscription data nested under a `subscriptions` key' do
-      let(:v2_response_body) { JSON.dump(subscriptions: subscriptions_data)}
-
-      it 'responds with list of subscriptions' do
-        get('/v3/subscriptions', {}, headers)
-        expect(last_response.status).to eq(200)
-        expect(parsed_body).to eql_json(expected_json)
-      end
     end
 
     context 'with a null plan' do

--- a/spec/v3/services/subscriptions/all_spec.rb
+++ b/spec/v3/services/subscriptions/all_spec.rb
@@ -35,14 +35,16 @@ describe Travis::API::V3::Services::Subscriptions::All, set_app: true, billing_s
     end
 
     let(:subscriptions_data) { [billing_subscription_response_body('id' => 1234, 'plan' => plan,'permissions' => { 'read' => true, 'write' => false }, 'owner' => { 'type' => 'Organization', 'id' => organization.id })] }
+    let(:permissions_data) { [{'owner' => {'type' => 'Organization', 'id' => 1}, 'create' => true}] }
 
-    let(:v2_response_body) { JSON.dump(subscriptions: subscriptions_data) }
+    let(:v2_response_body) { JSON.dump(subscriptions: subscriptions_data, permissions: permissions_data) }
 
     let(:expected_json) do
       {
         '@type' => 'subscriptions',
         '@representation' => 'standard',
         '@href' => '/v3/subscriptions',
+        '@permissions' => permissions_data,
         'subscriptions' => [{
           '@type' => 'subscription',
           '@representation' => 'standard',


### PR DESCRIPTION
With this PR the `/v3/subscriptions` endpoint response gets an extra `@permissions` key with information about whether the current user can create new subscriptions, on a per-owner basis:

```js
{
  "@type": "subscriptions",
  // ...
  "@permissions": [
    { "owner": { "type": "User", "id": 1 }, "create": true },
    { "owner": { "type": "Organization", "id": 1 }, "create": false }
  ],
  "subscriptions": [
    {
      // ...
    }
  ]
}
```