### PR TITLE
Proper warn message type

### DIFF
--- a/lib/travis/api/v3/models/message.rb
+++ b/lib/travis/api/v3/models/message.rb
@@ -6,7 +6,7 @@ module Travis::API::V3
       order(%Q{
         CASE
         WHEN level = 'error' THEN '1'
-        WHEN level = 'warning' THEN '2'
+        WHEN level = 'warn' THEN '2'
         WHEN level = 'info' THEN '3'
         WHEN level IS NULL THEN '4'
         END

--- a/spec/v3/services/messages/for_request_spec.rb
+++ b/spec/v3/services/messages/for_request_spec.rb
@@ -2,7 +2,7 @@ describe Travis::API::V3::Services::Messages::ForRequest, set_app: true do
 
   let(:repo) { Travis::API::V3::Models::Repository.where(owner_name: 'svenfuchs', name: 'minimal').first }
   let(:request) { repo.requests.first }
-  let!(:message) { Travis::API::V3::Models::Message.create!(level: 'info', subject_id: request.id, subject_type: 'Request')}
+  let!(:message) { Travis::API::V3::Models::Message.create!(level: 'warn', subject_id: request.id, subject_type: 'Request')}
   let!(:message_2) { Travis::API::V3::Models::Message.create!(level: 'error', subject_id: request.id, subject_type: 'Request')}
 
   describe "retrieve request messages on a public repository" do


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/65193/41957381-0b3a2b6c-79e7-11e8-8049-aeb2e2b992d8.png)

Noticed it wasn't quite right in travis-web. `warning` -> `warn`.