### PR TITLE
include cors headerss on 5xx error

### DIFF
--- a/lib/travis/api/app.rb
+++ b/lib/travis/api/app.rb
@@ -108,6 +108,7 @@ module Travis::Api
           ::Marginalia.set('request_id', env['HTTP_X_REQUEST_ID'])
         end
 
+        use Travis::Api::App::Cors
         use Travis::Api::App::Middleware::RequestId
         use Travis::Api::App::Middleware::ErrorHandler
 
@@ -129,7 +130,6 @@ module Travis::Api
           use Travis::Api::App::Middleware::OpenCensus
         end
 
-        use Travis::Api::App::Cors # if Travis.env == 'development' ???
         if Travis::Api::App.use_monitoring?
           use Rack::Config do |env|
             if env['HTTP_X_REQUEST_ID']

--- a/lib/travis/api/app.rb
+++ b/lib/travis/api/app.rb
@@ -164,12 +164,6 @@ module Travis::Api
 
         # make sure this is below ScopeCheck so we have the token
         use Rack::Attack if Endpoint.production? and not Travis.config.enterprise
-        
-        use Rack::Config do |env|
-          if env['HTTP_DEBUG_ERR'] == 'true'
-            raise :debug
-          end
-        end
 
         # if this is a v3 API request, ignore everything after
         use Travis::API::V3::OptIn

--- a/lib/travis/api/app.rb
+++ b/lib/travis/api/app.rb
@@ -164,6 +164,12 @@ module Travis::Api
 
         # make sure this is below ScopeCheck so we have the token
         use Rack::Attack if Endpoint.production? and not Travis.config.enterprise
+        
+        use Rack::Config do |env|
+          if env['HTTP_DEBUG_ERR'] == 'true'
+            raise :debug
+          end
+        end
 
         # if this is a v3 API request, ignore everything after
         use Travis::API::V3::OptIn

--- a/lib/travis/api/app/cors.rb
+++ b/lib/travis/api/app/cors.rb
@@ -6,7 +6,7 @@ class Travis::Api::App
   #
   # TODO: Be smarter about origin.
   class Cors < Base
-    before do
+    after do
       headers['Access-Control-Allow-Origin']      = "*"
       headers['Access-Control-Allow-Credentials'] = "true"
       headers['Access-Control-Expose-Headers']    = "Content-Type, Cache-Control, Expires, Etag, Last-Modified, X-Request-ID"

--- a/spec/integration/error_handling_spec.rb
+++ b/spec/integration/error_handling_spec.rb
@@ -52,6 +52,9 @@ describe 'Exception', set_app: true do
     expect(res.headers).to eq({
       'Content-Type' => 'text/plain',
       'Content-Length' => '32',
+      'Access-Control-Allow-Origin' => '*',
+      'Access-Control-Allow-Credentials' => 'true',
+      'Access-Control-Expose-Headers' => 'Content-Type, Cache-Control, Expires, Etag, Last-Modified, X-Request-ID',
     })
     sleep 0.1
   end
@@ -67,6 +70,9 @@ describe 'Exception', set_app: true do
       'Content-Type' => 'text/plain',
       'Content-Length' => '81',
       'X-Request-ID' => '235dd08f-10d5-4fcc-9a4d-6b8e6a24f975',
+      'Access-Control-Allow-Origin' => '*',
+      'Access-Control-Allow-Credentials' => 'true',
+      'Access-Control-Expose-Headers' => 'Content-Type, Cache-Control, Expires, Etag, Last-Modified, X-Request-ID',
     })
     sleep 0.1
   end


### PR DESCRIPTION
We've had lots of issues in the past where once we serve a 5xx page, we would get an error in web that looks like:

```
Cross-Origin Request Blocked: The Same Origin Policy disallows reading the remote resource at https://api.travis-ci.org/blub. (Reason: CORS header 'Access-Control-Allow-Origin' missing).
```

Which made it harder to figure out what was even happening. This patch makes it so that we will always include the CORS headers, also in the error case.

Before:

```
➜  ~ curl -v https://api-staging.travis-ci.com -H 'Debug-Err: true'
...
< HTTP/1.1 500 Internal Server Error
< Connection: keep-alive
< Server: nginx
< Date: Fri, 29 Jun 2018 09:44:22 GMT
< Content-Type: text/plain
< Content-Length: 81
< X-Request-Id: 2719549f-4e80-41ee-a003-8411c45252fa
< Via: 1.1 vegur
<
Sorry, we experienced an error.

request_id:2719549f-4e80-41ee-a003-8411c45252fa
```

After:

```
➜  ~ curl -v https://api-staging.travis-ci.com -H 'Debug-Err: true'
...
< HTTP/1.1 500 Internal Server Error
< Connection: keep-alive
< Server: nginx
< Date: Fri, 29 Jun 2018 09:46:03 GMT
< Content-Type: text/plain
< Content-Length: 81
< X-Request-Id: 714abb57-c5ac-499d-9f86-8d811e4f0392
< Access-Control-Allow-Origin: *
< Access-Control-Allow-Credentials: true
< Access-Control-Expose-Headers: Content-Type, Cache-Control, Expires, Etag, Last-Modified, X-Request-ID
< Via: 1.1 vegur
<
Sorry, we experienced an error.

request_id:714abb57-c5ac-499d-9f86-8d811e4f0392
```

By moving things above the error handler we run the risk that we don't get a good error message in the case that the middlewares themselves fail. There are very little middlewares where that is the case though, so this should not be a big deal.

It's worth noting that one type of error will still remain: If we run into a request timeout on heroku's side, we have no control over the response (including the headers), so in that case we still won't get the headers, unfortunately.