### PR TITLE
Delay app-initialize until unicorn workers are ready

### DIFF
--- a/config/unicorn.rb
+++ b/config/unicorn.rb
@@ -19,7 +19,4 @@ before_fork do |server, worker|
   $: << 'lib'
   require 'nakayoshi_fork'
   require 'travis/api/app'
-
-  # signal to nginx we're ready
-  FileUtils.touch("#{tmp_dir}/app-initialized")
 end


### PR DESCRIPTION
We currently signal the `app-initialized` event too early, before the unicorn workers are ready. This makes nginx boot too soon, which starts sending traffic too early resulting in 30 second timeouts as http 500 errors.

By delaying that until the unicorn workers are ready (currently ~30 seconds after the master is), we may be able to delay the overall boot time, and only start receiving traffic once we're ready.