### PR TITLE
reduce nginx log volume

### DIFF
--- a/bin/start-nginx
+++ b/bin/start-nginx
@@ -1,5 +1,14 @@
 #!/usr/bin/env bash
 
+# IMPORTANT NOTE!
+#
+# this file will get overwritten by the buildpack one in:
+#   https://github.com/travis-ci/nginx-buildpack/blob/master/bin/start-nginx
+#
+# changes to this file will not make it to production! if you want
+# to change this script for production, change it in the buildpack
+# instead!
+
 # make sure we kill all child processes once done
 trap '{ pkill -P $$; rm -f config/nginx.conf; exit 255; }' EXIT
 

--- a/config/nginx.conf.erb
+++ b/config/nginx.conf.erb
@@ -15,8 +15,11 @@ http {
 
 	server_tokens off;
 
+	<% if ENV['NGINX_LOG_REQUEST_TIME'] == 'true' %>
 	log_format l2met 'measure#nginx.service=$request_time request_id=$http_x_request_id';
 	access_log logs/nginx/access.log l2met;
+	<% end %>
+
 	error_log logs/nginx/error.log <%= ENV["NGINX_ERROR_LOG_LEVEL"] %>;
 
 	include mime.types;

--- a/config/nginx.conf.erb
+++ b/config/nginx.conf.erb
@@ -18,6 +18,8 @@ http {
 	<% if ENV['NGINX_LOG_REQUEST_TIME'] == 'true' %>
 	log_format l2met 'measure#nginx.service=$request_time request_id=$http_x_request_id';
 	access_log logs/nginx/access.log l2met;
+	<% else %>
+	access_log off;
 	<% end %>
 
 	error_log logs/nginx/error.log <%= ENV["NGINX_ERROR_LOG_LEVEL"] %>;


### PR DESCRIPTION
We are not currently using the service times from nginx and they are producing a lot of extra log volume. So it would be good to support turning them off.

We're currently excluding them from papertrail via log filter, but we might as well turn them off at the source. This way they also won't show up in `heroku logs`.