### PR TITLE
[Backport] Remove membership event from set hook (#796)

### DIFF
--- a/lib/travis/api/v3/github.rb
+++ b/lib/travis/api/v3/github.rb
@@ -14,8 +14,7 @@ module Travis::API::V3
     }
     private_constant :DEFAULT_OPTIONS
 
-    EVENTS = %i(push pull_request issue_comment public member create delete
-      membership repository)
+    EVENTS = %i(push pull_request issue_comment public member create delete repository)
     private_constant :EVENTS
 
     def self.client_config

--- a/lib/travis/github/services/set_hook.rb
+++ b/lib/travis/github/services/set_hook.rb
@@ -5,8 +5,7 @@ module Travis
   module Github
     module Services
       class SetHook < Travis::Services::Base
-        EVENTS = %i(push pull_request issue_comment public member create delete
-          membership repository)
+        EVENTS = %i(push pull_request issue_comment public member create delete repository)
 
         register :github_set_hook
 


### PR DESCRIPTION
This backports #796 to `enterprise-2.2`

@joecorcoran - are there any other places where we need to do this fix or is `travis-api` the only place? 

/cc @acnagy - heads up since you brought up some Enterprise customers already running into this! 