### PR TITLE
[Backport] Fix CLI login flow in Enterprise 2.2.2. 

### DIFF
--- a/lib/travis/api/app/endpoint/home.rb
+++ b/lib/travis/api/app/endpoint/home.rb
@@ -14,6 +14,7 @@ class Travis::Api::App
         pusher: (Travis.config.pusher_ws || Travis.config.pusher.to_h || {}).to_hash.slice(:scheme, :host, :port, :path, :key, :secure, :private),
         github: { api_url: GH.current.api_host.to_s, scopes: Travis.config.oauth2.try(:scope).to_s.split(?,) },
         notifications: { webhook: { public_key: Travis.config.webhook.public_key } }
+      set :check_auth, false
 
       # Landing point. Redirects web browsers to [API documentation](#/docs/).
       get '/' do

--- a/spec/unit/default_spec.rb
+++ b/spec/unit/default_spec.rb
@@ -9,5 +9,9 @@ describe Travis::Api::App::Endpoint::Home, set_app: true do
       status.should == 302
       headers['Location'].should end_with('/docs/')
     end
+
+    it 'does not check auth' do
+      expect(subject.settings.check_auth?).to eq false
+    end
   end
 end


### PR DESCRIPTION
Follow up to https://github.com/travis-ci/travis-api/pull/802/ it's `enterprise-2.2` backport: https://github.com/travis-ci/travis-api/pull/803

There was one last commit to #802 where we fixed the login issue outlined in: https://github.com/travis-pro/team-teal/issues/2769 (private link, apologies). 