### PR TITLE
Email unsubscribe endpoint

### DIFF
--- a/lib/travis/api/v3/models/email_unsubscribe.rb
+++ b/lib/travis/api/v3/models/email_unsubscribe.rb
@@ -1,0 +1,8 @@
+module Travis::API::V3
+  class Models::EmailUnsubscribe < Model
+    belongs_to :user
+    belongs_to :repository
+
+    validates :repository, uniqueness: { scope: :user }
+  end
+end

--- a/lib/travis/api/v3/models/repository.rb
+++ b/lib/travis/api/v3/models/repository.rb
@@ -7,6 +7,7 @@ module Travis::API::V3
     has_many :permissions, dependent: :delete_all
     has_many :users,       through:   :permissions
     has_many :stars
+    has_many :email_unsubscribes
 
     belongs_to :owner, polymorphic: true
     belongs_to :last_build, class_name: 'Travis::API::V3::Models::Build'.freeze

--- a/lib/travis/api/v3/queries/email_subscription.rb
+++ b/lib/travis/api/v3/queries/email_subscription.rb
@@ -1,0 +1,7 @@
+module Travis::API::V3
+  class Queries::EmailSubscription < Query
+    def unsubscribe(user, repository)
+      repository.email_unsubscribes.find_or_create_by!(user: user)
+    end
+  end
+end

--- a/lib/travis/api/v3/routes.rb
+++ b/lib/travis/api/v3/routes.rb
@@ -212,6 +212,11 @@ module Travis::API::V3
         patch   :update
         delete :delete
       end
+
+      resource :email_subscription do
+        route '/email_subscription'
+        delete :unsubscribe
+      end
     end
 
     resource :user do

--- a/lib/travis/api/v3/services.rb
+++ b/lib/travis/api/v3/services.rb
@@ -15,6 +15,7 @@ module Travis::API::V3
     Caches              = Module.new { extend Services }
     Cron                = Module.new { extend Services }
     Crons               = Module.new { extend Services }
+    EmailSubscription   = Module.new { extend Services }
     EnvVar              = Module.new { extend Services }
     EnvVars             = Module.new { extend Services }
     EnterpriseLicense   = Module.new { extend Services }

--- a/lib/travis/api/v3/services/email_subscription/unsubscribe.rb
+++ b/lib/travis/api/v3/services/email_subscription/unsubscribe.rb
@@ -1,0 +1,9 @@
+module Travis::API::V3
+  class Services::EmailSubscription::Unsubscribe < Service
+    def run!
+      repository = check_login_and_find(:repository)
+      query.unsubscribe(access_control.user, repository)
+      no_content
+    end
+  end
+end

--- a/spec/v3/services/email_subscription/unsubscribe_spec.rb
+++ b/spec/v3/services/email_subscription/unsubscribe_spec.rb
@@ -1,0 +1,51 @@
+require 'spec_helper'
+
+describe Travis::API::V3::Services::EmailSubscription::Unsubscribe, set_app: true do
+  let(:repo)  { Travis::API::V3::Models::Repository.where(owner_name: 'svenfuchs', name: 'minimal').first_or_create }
+  let(:token) { Travis::Api::App::AccessToken.create(user: repo.owner, app_id: 1) }
+  let(:auth_headers) { { 'HTTP_AUTHORIZATION' => "token #{token}" } }
+
+  describe 'not authenticated' do
+    before { delete("/v3/repo/#{repo.id}/email_subscription", {}) }
+    include_examples 'not authenticated'
+  end
+
+  describe 'authenticated, repo missing' do
+    before { delete("/v3/repo/999999/email_subscription", {}, auth_headers) }
+    include_examples 'missing repo'
+  end
+
+  describe 'authenticated, existing repo' do
+    subject(:response) do
+      delete("/v3/repo/#{repo.id}/email_subscription", {}, auth_headers)
+    end
+
+    it 'responds with 204, empty body' do
+      expect(response.status).to eq 204
+      expect(response.body).to be_empty
+    end
+
+    it 'persists the change' do
+      subject
+
+      expect(repo.reload.email_unsubscribes.count).to eq 1
+      expect(repo.email_unsubscribes.first.user).to eq(repo.owner)
+    end
+
+    context 'user was already unsubscribed' do
+      before do
+        delete("/v3/repo/#{repo.id}/email_subscription", {}, auth_headers)
+      end
+
+      it 'does not error' do
+        expect(response.status).to eq 204
+      end
+
+      it 'does not create a second record' do
+        subject
+
+        expect(repo.reload.email_unsubscribes.count).to eq 1
+      end
+    end
+  end
+end


### PR DESCRIPTION
Adds an endpoint to unsubscribe the currently logged in user from build emails for a single repository:

```
DELETE /repo/123/email_subscription

204 No Content
```

Depends on travis-ci/travis-migrations#137
Fixes travis-pro/team-teal#2776, travis-pro/team-teal#2777