### PR TITLE
Add preferences endpoints

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,9 +25,8 @@ services:
   - redis-server
 
 before_script:
-  #- 'RAILS_ENV=test bundle exec rake db:create --trace'
   - "createdb travis_test || true"
-  - "curl -fs https://raw.githubusercontent.com/travis-ci/travis-migrations/jc-prefs/db/main/structure.sql | psql travis_test"
+  - "curl -fs https://raw.githubusercontent.com/travis-ci/travis-migrations/master/db/main/structure.sql | psql travis_test"
 
 before_install:
   - 'gem update --system'

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,9 @@ services:
   - redis-server
 
 before_script:
-  - 'RAILS_ENV=test bundle exec rake db:create --trace'
+  #- 'RAILS_ENV=test bundle exec rake db:create --trace'
+  - "createdb travis_test || true"
+  - "curl -fs https://raw.githubusercontent.com/travis-ci/travis-migrations/jc-prefs/db/main/structure.sql | psql travis_test"
 
 before_install:
   - 'gem update --system'

--- a/lib/travis/api/v3/access_control/generic.rb
+++ b/lib/travis/api/v3/access_control/generic.rb
@@ -141,6 +141,10 @@ module Travis::API::V3
       visible? key_pair.repository
     end
 
+    def preferences_visible?(preferences)
+      true
+    end
+
     def organization_visible?(organization)
       full_access? or public_mode?(organization)
     end

--- a/lib/travis/api/v3/models/json_slice.rb
+++ b/lib/travis/api/v3/models/json_slice.rb
@@ -4,12 +4,16 @@ module Travis::API::V3
   class Models::JsonSlice
     include Virtus.model, Enumerable, Models::JsonSync
 
-    def self.child(klass)
-      @@child_klass = klass
+    class << self
+      attr_accessor :child_klass
+
+      def child(klass)
+        self.child_klass = klass
+      end
     end
 
     def child_klass
-      @@child_klass
+      self.class.child_klass
     end
 
     def each(&block)

--- a/lib/travis/api/v3/models/json_sync.rb
+++ b/lib/travis/api/v3/models/json_sync.rb
@@ -5,7 +5,7 @@ module Travis::API::V3
     def sync(parent, attr)
       @parent, @attr = parent, attr
       @sync = -> do
-        previous = @parent.send(:"#{@attr}")
+        previous = @parent.attributes[@attr.to_s] || {}
         @parent.send(:"#{@attr}=", previous.merge(to_h).to_json)
         @parent.save!
       end

--- a/lib/travis/api/v3/models/preference.rb
+++ b/lib/travis/api/v3/models/preference.rb
@@ -1,0 +1,7 @@
+module Travis::API::V3
+  class Models::Preference < Struct.new(:name, :value, :parent)
+    def public?
+      true
+    end
+  end
+end

--- a/lib/travis/api/v3/models/preferences.rb
+++ b/lib/travis/api/v3/models/preferences.rb
@@ -1,0 +1,7 @@
+module Travis::API::V3
+  class Models::Preferences < Models::JsonSlice
+    child Models::Preference
+
+    attribute :build_emails, Boolean, default: true
+  end
+end

--- a/lib/travis/api/v3/models/user.rb
+++ b/lib/travis/api/v3/models/user.rb
@@ -43,5 +43,9 @@ module Travis::API::V3
       return @installation if defined? @installation
       @installation = Models::Installation.find_by(owner_type: 'User', owner_id: id, removed_by_id: nil)
     end
+
+    def preferences
+      Models::Preferences.new(super).tap { |prefs| prefs.sync(self, :preferences) }
+    end
   end
 end

--- a/lib/travis/api/v3/permissions/preferences.rb
+++ b/lib/travis/api/v3/permissions/preferences.rb
@@ -1,0 +1,11 @@
+module Travis::API::V3
+  class Permissions::Preferences < Permissions::Generic
+    def read?
+      true
+    end
+
+    def write?
+      true
+    end
+  end
+end

--- a/lib/travis/api/v3/queries/preference.rb
+++ b/lib/travis/api/v3/queries/preference.rb
@@ -1,0 +1,13 @@
+module Travis::API::V3
+  class Queries::Preference < Query
+    params :name, :value, prefix: :preference
+
+    def find(user)
+      user.preferences.read(name)
+    end
+
+    def update(user)
+      user.preferences.update(name, value)
+    end
+  end
+end

--- a/lib/travis/api/v3/queries/preferences.rb
+++ b/lib/travis/api/v3/queries/preferences.rb
@@ -1,0 +1,7 @@
+module Travis::API::V3
+  class Queries::Preferences < Query
+    def find(user)
+      user.preferences
+    end
+  end
+end

--- a/lib/travis/api/v3/renderer/preference.rb
+++ b/lib/travis/api/v3/renderer/preference.rb
@@ -1,0 +1,14 @@
+module Travis::API::V3
+  class Renderer::Preference < ModelRenderer
+    type :preference
+    representation :standard, :name, :value
+    representation :minimal, *representations[:standard]
+
+    def href
+      Renderer.href(:preference,
+        :"preference.name" => name,
+        :"script_name" => script_name
+      )
+    end
+  end
+end

--- a/lib/travis/api/v3/renderer/preferences.rb
+++ b/lib/travis/api/v3/renderer/preferences.rb
@@ -1,0 +1,6 @@
+module Travis::API::V3
+  class Renderer::Preferences < CollectionRenderer
+    type           :preferences
+    collection_key :preferences
+  end
+end

--- a/lib/travis/api/v3/routes.rb
+++ b/lib/travis/api/v3/routes.rb
@@ -243,6 +243,17 @@ module Travis::API::V3
       get :current
     end
 
+    resource :preferences do
+      route '/preferences'
+      get   :for_user
+    end
+
+    resource :preference do
+      route '/preference/{preference.name}'
+      get   :find
+      patch :update
+    end
+
     if ENV['BILLING_V2_ENABLED']
       hidden_resource :subscriptions do
         route '/subscriptions'

--- a/lib/travis/api/v3/services.rb
+++ b/lib/travis/api/v3/services.rb
@@ -31,6 +31,8 @@ module Travis::API::V3
     Organizations       = Module.new { extend Services }
     Owner               = Module.new { extend Services }
     Plans               = Module.new { extend Services }
+    Preferences         = Module.new { extend Services }
+    Preference          = Module.new { extend Services }
     Repositories        = Module.new { extend Services }
     Repository          = Module.new { extend Services }
     Request             = Module.new { extend Services }

--- a/lib/travis/api/v3/services/preference/find.rb
+++ b/lib/travis/api/v3/services/preference/find.rb
@@ -1,6 +1,8 @@
 module Travis::API::V3
   class Services::Preference::Find < Service
     def run!
+      user = access_control.user or raise LoginRequired
+      result query.find(user)
     end
   end
 end

--- a/lib/travis/api/v3/services/preference/find.rb
+++ b/lib/travis/api/v3/services/preference/find.rb
@@ -1,0 +1,6 @@
+module Travis::API::V3
+  class Services::Preference::Find < Service
+    def run!
+    end
+  end
+end

--- a/lib/travis/api/v3/services/preference/update.rb
+++ b/lib/travis/api/v3/services/preference/update.rb
@@ -1,0 +1,8 @@
+module Travis::API::V3
+  class Services::Preference::Update < Service
+    params :value, prefix: :preference
+
+    def run!
+    end
+  end
+end

--- a/lib/travis/api/v3/services/preference/update.rb
+++ b/lib/travis/api/v3/services/preference/update.rb
@@ -3,6 +3,8 @@ module Travis::API::V3
     params :value, prefix: :preference
 
     def run!
+      user = access_control.user or raise LoginRequired
+      result query.update(user)
     end
   end
 end

--- a/lib/travis/api/v3/services/preferences/for_user.rb
+++ b/lib/travis/api/v3/services/preferences/for_user.rb
@@ -1,0 +1,8 @@
+module Travis::API::V3
+  class Services::Preferences::ForUser < Service
+    def run!
+      prefs = check_login_and_find(:preferences, access_control.user)
+      result prefs
+    end
+  end
+end

--- a/spec/v3/services/preference/find_spec.rb
+++ b/spec/v3/services/preference/find_spec.rb
@@ -1,0 +1,102 @@
+describe Travis::API::V3::Services::UserSetting::Find, set_app: true do
+  let(:repo)  { Travis::API::V3::Models::Repository.where(owner_name: 'svenfuchs', name: 'minimal').first_or_create }
+  let(:token) { Travis::Api::App::AccessToken.create(user: repo.owner, app_id: 1) }
+  let(:auth_headers) { { 'HTTP_AUTHORIZATION' => "token #{token}" } }
+  let(:json_headers) { { 'CONTENT_TYPE' => 'application/json' } }
+
+  describe 'not authenticated' do
+    before { get("/v3/repo/#{repo.id}/setting/build_pushes") }
+    include_examples 'not authenticated'
+  end
+
+  describe 'authenticated as wrong user' do
+    let(:other_user) { FactoryGirl.create(:user) }
+    let(:other_token) { Travis::Api::App::AccessToken.create(user: other_user, app_id: 1) }
+
+    before do
+      repo.update_attributes(private: true)
+      get("/v3/repo/#{repo.id}/setting/build_pushes", {}, { 'HTTP_AUTHORIZATION' => "token #{other_token}" })
+    end
+
+    example { expect(last_response.status).to eq(404) }
+    example do
+      expect(JSON.load(body)).to eq(
+        '@type' => 'error',
+        'error_type' => 'not_found',
+        'error_message' => 'repository not found (or insufficient access)',
+        'resource_type' => 'repository'
+      )
+    end
+  end
+
+  describe 'authenticated, missing repo' do
+    before { get('/v3/repo/9999999999/setting/build_pushes', {}, auth_headers) }
+
+    example { expect(last_response.status).to eq(404) }
+    example do
+      expect(JSON.load(body)).to eq(
+        '@type' => 'error',
+        'error_type' => 'not_found',
+        'error_message' => 'repository not found (or insufficient access)',
+        'resource_type' => 'repository'
+      )
+    end
+  end
+
+  describe 'authenticated, existing repo, setting missing, return default' do
+    before { get("/v3/repo/#{repo.id}/setting/build_pushes", {}, auth_headers) }
+
+    example { expect(last_response.status).to eq(200) }
+    example do
+      expect(JSON.load(body)).to eq(
+        '@type' => 'setting',
+        '@representation' => 'standard',
+        '@permissions' => { 'read' => true, 'write' => false },
+        '@href' => "/v3/repo/#{repo.id}/setting/build_pushes",
+        'name' => 'build_pushes',
+        'value' => true
+      )
+    end
+  end
+
+  describe 'authenticated, existing repo, setting found' do
+    before do
+      repo.update_attributes(settings: { 'build_pushes' => false })
+      get("/v3/repo/#{repo.id}/setting/build_pushes", {}, auth_headers)
+    end
+
+    example { expect(last_response.status).to eq(200) }
+    example do
+      expect(JSON.load(body)).to eq(
+        '@type' => 'setting',
+        '@representation' => 'standard',
+        '@permissions' => { 'read' => true, 'write' => false },
+        '@href' => "/v3/repo/#{repo.id}/setting/build_pushes",
+        'name' => 'build_pushes',
+        'value' => false
+      )
+    end
+  end
+
+  describe 'authenticated, existing repo, default auto cancel setting' do
+    before do
+      ENV['AUTO_CANCEL_DEFAULT'] = 'true'
+      get("/v3/repo/#{repo.id}/setting/auto_cancel_pushes", {}, auth_headers)
+    end
+    after do
+      ENV['AUTO_CANCEL_DEFAULT'] = nil
+    end
+
+    example { expect(last_response.status).to eq(200) }
+    example do
+      expect(JSON.load(body)).to eq(
+        '@type' => 'setting',
+        '@representation' => 'standard',
+        '@permissions' => { 'read' => true, 'write' => false },
+        '@href' => "/v3/repo/#{repo.id}/setting/auto_cancel_pushes",
+        'name' => 'auto_cancel_pushes',
+        'value' => true
+      )
+    end
+  end
+end

--- a/spec/v3/services/preference/find_spec.rb
+++ b/spec/v3/services/preference/find_spec.rb
@@ -1,101 +1,42 @@
-describe Travis::API::V3::Services::UserSetting::Find, set_app: true do
-  let(:repo)  { Travis::API::V3::Models::Repository.where(owner_name: 'svenfuchs', name: 'minimal').first_or_create }
-  let(:token) { Travis::Api::App::AccessToken.create(user: repo.owner, app_id: 1) }
+describe Travis::API::V3::Services::Preference::Find, set_app: true do
+  let(:user) { Travis::API::V3::Models::User.create!(name: 'svenfuchs') }
+  let(:token) { Travis::Api::App::AccessToken.create(user: user, app_id: 1) }
   let(:auth_headers) { { 'HTTP_AUTHORIZATION' => "token #{token}" } }
-  let(:json_headers) { { 'CONTENT_TYPE' => 'application/json' } }
 
   describe 'not authenticated' do
-    before { get("/v3/repo/#{repo.id}/setting/build_pushes") }
+    before { get("/v3/preference/build_emails") }
     include_examples 'not authenticated'
   end
 
-  describe 'authenticated as wrong user' do
-    let(:other_user) { FactoryGirl.create(:user) }
-    let(:other_token) { Travis::Api::App::AccessToken.create(user: other_user, app_id: 1) }
-
-    before do
-      repo.update_attributes(private: true)
-      get("/v3/repo/#{repo.id}/setting/build_pushes", {}, { 'HTTP_AUTHORIZATION' => "token #{other_token}" })
-    end
-
-    example { expect(last_response.status).to eq(404) }
-    example do
-      expect(JSON.load(body)).to eq(
-        '@type' => 'error',
-        'error_type' => 'not_found',
-        'error_message' => 'repository not found (or insufficient access)',
-        'resource_type' => 'repository'
-      )
-    end
-  end
-
-  describe 'authenticated, missing repo' do
-    before { get('/v3/repo/9999999999/setting/build_pushes', {}, auth_headers) }
-
-    example { expect(last_response.status).to eq(404) }
-    example do
-      expect(JSON.load(body)).to eq(
-        '@type' => 'error',
-        'error_type' => 'not_found',
-        'error_message' => 'repository not found (or insufficient access)',
-        'resource_type' => 'repository'
-      )
-    end
-  end
-
-  describe 'authenticated, existing repo, setting missing, return default' do
-    before { get("/v3/repo/#{repo.id}/setting/build_pushes", {}, auth_headers) }
+  describe 'authenticated, pref missing, return default' do
+    before { get("/v3/preference/build_emails", {}, auth_headers) }
 
     example { expect(last_response.status).to eq(200) }
     example do
-      expect(JSON.load(body)).to eq(
-        '@type' => 'setting',
-        '@representation' => 'standard',
-        '@permissions' => { 'read' => true, 'write' => false },
-        '@href' => "/v3/repo/#{repo.id}/setting/build_pushes",
-        'name' => 'build_pushes',
-        'value' => true
+      expect(parsed_body).to eql_json(
+        "@type" => "preference",
+        "@href" => "/v3/preference/build_emails",
+        "@representation" => "standard",
+        "name" => "build_emails",
+        "value" => true
       )
     end
   end
 
-  describe 'authenticated, existing repo, setting found' do
+  describe 'authenticated, pref found' do
     before do
-      repo.update_attributes(settings: { 'build_pushes' => false })
-      get("/v3/repo/#{repo.id}/setting/build_pushes", {}, auth_headers)
+      user.preferences.update(:build_emails, false)
+      get("/v3/preference/build_emails", {}, auth_headers)
     end
 
     example { expect(last_response.status).to eq(200) }
     example do
-      expect(JSON.load(body)).to eq(
-        '@type' => 'setting',
-        '@representation' => 'standard',
-        '@permissions' => { 'read' => true, 'write' => false },
-        '@href' => "/v3/repo/#{repo.id}/setting/build_pushes",
-        'name' => 'build_pushes',
-        'value' => false
-      )
-    end
-  end
-
-  describe 'authenticated, existing repo, default auto cancel setting' do
-    before do
-      ENV['AUTO_CANCEL_DEFAULT'] = 'true'
-      get("/v3/repo/#{repo.id}/setting/auto_cancel_pushes", {}, auth_headers)
-    end
-    after do
-      ENV['AUTO_CANCEL_DEFAULT'] = nil
-    end
-
-    example { expect(last_response.status).to eq(200) }
-    example do
-      expect(JSON.load(body)).to eq(
-        '@type' => 'setting',
-        '@representation' => 'standard',
-        '@permissions' => { 'read' => true, 'write' => false },
-        '@href' => "/v3/repo/#{repo.id}/setting/auto_cancel_pushes",
-        'name' => 'auto_cancel_pushes',
-        'value' => true
+      expect(parsed_body).to eql_json(
+        "@type" => "preference",
+        "@href" => "/v3/preference/build_emails",
+        "@representation" => "standard",
+        "name" => "build_emails",
+        "value" => false
       )
     end
   end

--- a/spec/v3/services/preference/update_spec.rb
+++ b/spec/v3/services/preference/update_spec.rb
@@ -1,0 +1,104 @@
+describe Travis::API::V3::Services::UserSetting::Update, set_app: true do
+  let(:repo)  { Travis::API::V3::Models::Repository.where(owner_name: 'svenfuchs', name: 'minimal').first_or_create }
+  let(:other_user) { FactoryGirl.create(:user) }
+  let(:token) { Travis::Api::App::AccessToken.create(user: repo.owner, app_id: 1) }
+  let(:other_token) { Travis::Api::App::AccessToken.create(user: other_user, app_id: 2) }
+  let(:auth_headers) { { 'HTTP_AUTHORIZATION' => "token #{token}" } }
+  let(:json_headers) { { 'CONTENT_TYPE' => 'application/json' } }
+
+  let(:old_params) { JSON.dump('setting.value' => false) }
+  let(:new_params) { JSON.dump('setting.value' => false) }
+
+  describe 'not authenticated' do
+    before do
+      patch("/v3/repo/#{repo.id}/setting/build_pushes", new_params, json_headers)
+    end
+
+    example { expect(last_response.status).to eq(403) }
+    example do
+      expect(JSON.load(body)).to eq(
+        '@type' => 'error',
+        'error_type' => 'login_required',
+        'error_message' => 'login required'
+      )
+    end
+  end
+
+  describe 'authenticated, missing repo' do
+    before do
+      patch('/v3/repo/9999999999/setting/build_pushes', new_params, json_headers.merge(auth_headers))
+    end
+
+    example { expect(last_response.status).to eq(404) }
+    example do
+      expect(JSON.load(body)).to eq(
+        '@type' => 'error',
+        'error_type' => 'not_found',
+        'error_message' => 'repository not found (or insufficient access)',
+        'resource_type' => 'repository'
+      )
+    end
+  end
+
+  shared_examples 'successful patch' do
+    example { expect(last_response.status).to eq(200) }
+    example do
+      expect(JSON.load(body)).to eq(
+        '@type' => 'setting',
+        '@representation' => 'standard',
+        '@permissions' => { 'read' => true, 'write' => true },
+        '@href' => "/v3/repo/#{repo.id}/setting/build_pushes",
+        'name' => 'build_pushes',
+        'value' => false
+      )
+    end
+    example 'value is persisted' do
+      expect(repo.reload.user_settings.build_pushes).to eq false
+    end
+    example 'does not clobber other things in the settings hash' do
+      expect(repo.reload.settings['env_vars']).to eq(['something'])
+    end
+  end
+
+  describe 'authenticated, existing repo, old params' do
+    before do
+      repo.update_attribute(:settings, JSON.dump('env_vars' => ['something']))
+      Travis::API::V3::Models::Permission.create(repository: repo, user: repo.owner, push: true)
+      patch("/v3/repo/#{repo.id}/setting/build_pushes", old_params, json_headers.merge(auth_headers))
+    end
+    include_examples 'successful patch'
+  end
+
+  describe 'authenticated, existing repo, new params' do
+    before do
+      repo.update_attribute(:settings, JSON.dump('env_vars' => ['something']))
+      Travis::API::V3::Models::Permission.create(repository: repo, user: repo.owner, push: true)
+      patch("/v3/repo/#{repo.id}/setting/build_pushes", new_params, json_headers.merge(auth_headers))
+    end
+    include_examples 'successful patch'
+  end
+
+  describe 'authenticated, existing repo, user does not have correct permissions' do
+    before do
+      patch("/v3/repo/#{repo.id}/setting/build_pushes", new_params, json_headers.merge('HTTP_AUTHORIZATION' => "token #{other_token}"))
+    end
+
+    example { expect(last_response.status).to eq(403) }
+    example do
+      expect(JSON.load(body)).to eq(
+        '@type' => 'error',
+        'error_type' => 'insufficient_access',
+        'error_message' => 'operation requires write access to user_setting',
+        'permission' => 'write',
+        'resource_type' => 'user_setting',
+        'user_setting' => {
+          '@type' => 'setting',
+          '@href' => "/v3/repo/#{repo.id}/setting/build_pushes",
+          '@representation' => 'minimal',
+          'name' => 'build_pushes',
+          'value' => false
+        }
+      )
+    end
+  end
+end

--- a/spec/v3/services/preference/update_spec.rb
+++ b/spec/v3/services/preference/update_spec.rb
@@ -1,103 +1,28 @@
-describe Travis::API::V3::Services::UserSetting::Update, set_app: true do
-  let(:repo)  { Travis::API::V3::Models::Repository.where(owner_name: 'svenfuchs', name: 'minimal').first_or_create }
-  let(:other_user) { FactoryGirl.create(:user) }
-  let(:token) { Travis::Api::App::AccessToken.create(user: repo.owner, app_id: 1) }
-  let(:other_token) { Travis::Api::App::AccessToken.create(user: other_user, app_id: 2) }
-  let(:auth_headers) { { 'HTTP_AUTHORIZATION' => "token #{token}" } }
-  let(:json_headers) { { 'CONTENT_TYPE' => 'application/json' } }
-
-  let(:old_params) { JSON.dump('setting.value' => false) }
-  let(:new_params) { JSON.dump('setting.value' => false) }
+describe Travis::API::V3::Services::Preference::Update, set_app: true do
+  let(:user) { Travis::API::V3::Models::User.create!(name: 'svenfuchs') }
+  let(:token) { Travis::Api::App::AccessToken.create(user: user, app_id: 1) }
+  let(:headers) { { 'HTTP_AUTHORIZATION' => "token #{token}", 'CONTENT_TYPE' => 'application/json' } }
+  let(:params) { JSON.dump('preference.value' => false) }
 
   describe 'not authenticated' do
     before do
-      patch("/v3/repo/#{repo.id}/setting/build_pushes", new_params, json_headers)
+      patch("/v3/preference/build_emails")
     end
-
-    example { expect(last_response.status).to eq(403) }
-    example do
-      expect(JSON.load(body)).to eq(
-        '@type' => 'error',
-        'error_type' => 'login_required',
-        'error_message' => 'login required'
-      )
-    end
+    include_examples 'not authenticated'
   end
 
-  describe 'authenticated, missing repo' do
+  describe 'authenticated' do
     before do
-      patch('/v3/repo/9999999999/setting/build_pushes', new_params, json_headers.merge(auth_headers))
+      patch("/v3/preference/build_emails", params, headers)
     end
-
-    example { expect(last_response.status).to eq(404) }
+    example { expect(last_response.status).to eq 200 }
     example do
-      expect(JSON.load(body)).to eq(
-        '@type' => 'error',
-        'error_type' => 'not_found',
-        'error_message' => 'repository not found (or insufficient access)',
-        'resource_type' => 'repository'
-      )
-    end
-  end
-
-  shared_examples 'successful patch' do
-    example { expect(last_response.status).to eq(200) }
-    example do
-      expect(JSON.load(body)).to eq(
-        '@type' => 'setting',
-        '@representation' => 'standard',
-        '@permissions' => { 'read' => true, 'write' => true },
-        '@href' => "/v3/repo/#{repo.id}/setting/build_pushes",
-        'name' => 'build_pushes',
-        'value' => false
-      )
-    end
-    example 'value is persisted' do
-      expect(repo.reload.user_settings.build_pushes).to eq false
-    end
-    example 'does not clobber other things in the settings hash' do
-      expect(repo.reload.settings['env_vars']).to eq(['something'])
-    end
-  end
-
-  describe 'authenticated, existing repo, old params' do
-    before do
-      repo.update_attribute(:settings, JSON.dump('env_vars' => ['something']))
-      Travis::API::V3::Models::Permission.create(repository: repo, user: repo.owner, push: true)
-      patch("/v3/repo/#{repo.id}/setting/build_pushes", old_params, json_headers.merge(auth_headers))
-    end
-    include_examples 'successful patch'
-  end
-
-  describe 'authenticated, existing repo, new params' do
-    before do
-      repo.update_attribute(:settings, JSON.dump('env_vars' => ['something']))
-      Travis::API::V3::Models::Permission.create(repository: repo, user: repo.owner, push: true)
-      patch("/v3/repo/#{repo.id}/setting/build_pushes", new_params, json_headers.merge(auth_headers))
-    end
-    include_examples 'successful patch'
-  end
-
-  describe 'authenticated, existing repo, user does not have correct permissions' do
-    before do
-      patch("/v3/repo/#{repo.id}/setting/build_pushes", new_params, json_headers.merge('HTTP_AUTHORIZATION' => "token #{other_token}"))
-    end
-
-    example { expect(last_response.status).to eq(403) }
-    example do
-      expect(JSON.load(body)).to eq(
-        '@type' => 'error',
-        'error_type' => 'insufficient_access',
-        'error_message' => 'operation requires write access to user_setting',
-        'permission' => 'write',
-        'resource_type' => 'user_setting',
-        'user_setting' => {
-          '@type' => 'setting',
-          '@href' => "/v3/repo/#{repo.id}/setting/build_pushes",
-          '@representation' => 'minimal',
-          'name' => 'build_pushes',
-          'value' => false
-        }
+      expect(parsed_body).to eql_json(
+        "@type" => "preference",
+        "@href" => "/v3/preference/build_emails",
+        "@representation" => "standard",
+        "name" => "build_emails",
+        "value" => false
       )
     end
   end

--- a/spec/v3/services/preferences/for_user_spec.rb
+++ b/spec/v3/services/preferences/for_user_spec.rb
@@ -16,16 +16,16 @@ describe Travis::API::V3::Services::Preferences::ForUser, set_app: true do
 
     example do
       expect(parsed_body).to eql_json(
-        "@type"=>"preferences",
-        "@href"=>"/v3/preferences",
-        "@representation"=>"standard",
-        "preferences"=>[
+        "@type" => "preferences",
+        "@href" => "/v3/preferences",
+        "@representation" => "standard",
+        "preferences" => [
           {
-            "@type"=>"preference",
-            "@href"=>"/v3/preference/build_emails",
-            "@representation"=>"standard",
-            "name"=>"build_emails",
-            "value"=>true
+            "@type" => "preference",
+            "@href" => "/v3/preference/build_emails",
+            "@representation" => "standard",
+            "name" => "build_emails",
+            "value" => true
           }
         ]
       )
@@ -42,16 +42,16 @@ describe Travis::API::V3::Services::Preferences::ForUser, set_app: true do
 
     example do
       expect(parsed_body).to eql_json(
-        "@type"=>"preferences",
-        "@href"=>"/v3/preferences",
-        "@representation"=>"standard",
-        "preferences"=>[
+        "@type" => "preferences",
+        "@href" => "/v3/preferences",
+        "@representation" => "standard",
+        "preferences" => [
           {
-            "@type"=>"preference",
-            "@href"=>"/v3/preference/build_emails",
-            "@representation"=>"standard",
-            "name"=>"build_emails",
-            "value"=>false
+            "@type" => "preference",
+            "@href" => "/v3/preference/build_emails",
+            "@representation" => "standard",
+            "name" => "build_emails",
+            "value" => false
           }
         ]
       )

--- a/spec/v3/services/preferences/for_user_spec.rb
+++ b/spec/v3/services/preferences/for_user_spec.rb
@@ -1,0 +1,60 @@
+describe Travis::API::V3::Services::Preferences::ForUser, set_app: true do
+  let(:user) { Travis::API::V3::Models::User.create!(name: 'svenfuchs') }
+  let(:token) { Travis::Api::App::AccessToken.create(user: user, app_id: 1) }
+  let(:auth_headers) { { 'HTTP_AUTHORIZATION' => "token #{token}" } }
+  let(:json_headers) { { 'CONTENT_TYPE' => 'application/json' } }
+
+  describe 'not authenticated' do
+    before { get("/v3/preferences") }
+    include_examples 'not authenticated'
+  end
+
+  describe 'authenticated, user has no prefs, return defaults' do
+    before { get("/v3/preferences", {}, auth_headers) }
+
+    example { expect(last_response.status).to eq(200) }
+
+    example do
+      expect(parsed_body).to eql_json(
+        "@type"=>"preferences",
+        "@href"=>"/v3/preferences",
+        "@representation"=>"standard",
+        "preferences"=>[
+          {
+            "@type"=>"preference",
+            "@href"=>"/v3/preference/build_emails",
+            "@representation"=>"standard",
+            "name"=>"build_emails",
+            "value"=>true
+          }
+        ]
+      )
+    end
+  end
+
+  describe 'authenticated, user has prefs' do
+    before do
+      user.preferences.update(:build_emails, false)
+      get("/v3/preferences", {}, auth_headers)
+    end
+
+    example { expect(last_response.status).to eq(200) }
+
+    example do
+      expect(parsed_body).to eql_json(
+        "@type"=>"preferences",
+        "@href"=>"/v3/preferences",
+        "@representation"=>"standard",
+        "preferences"=>[
+          {
+            "@type"=>"preference",
+            "@href"=>"/v3/preference/build_emails",
+            "@representation"=>"standard",
+            "name"=>"build_emails",
+            "value"=>false
+          }
+        ]
+      )
+    end
+  end
+end


### PR DESCRIPTION
Depends on https://github.com/travis-ci/travis-migrations/pull/138

Adds three new services to API V3, for reading/writing user preferences. The only preference at the moment is `build_emails`, which will toggle whether or not the user receives emails when builds pass/error/fail.

## `Preferences::ForUser`

Read all preferences for the authenticated user.

```
curl -H "Authorization: token abc123" \
  /v3/preferences
```
```json
{
  "@type": "preferences",
  "@href": "/v3/preferences",
  "@representation": "standard",
  "@preferences": [
    {
      "@type": "preference",
      "@href": "/v3/preference/build_emails",
      "@representation": "standard",
      "name": "build_emails",
      "value": true
    }
  ]
}
```

## `Preference::Find`

Read one preference for the authenticated user.

```
curl -H "Authorization: token abc123" \
  /v3/preference/build_emails
```
```json
{
  "@type": "preference",
  "@href": "/v3/preference/build_emails",
  "@representation": "standard",
  "name": "build_emails",
  "value": true
}
```

## `Preference::Update`

Change one preference for the authenticated user.

```
curl -X PATCH \
  -H "Authorization: token abc123" \
  -H "Content-Type: application/json" \
  --data-binary '{"preference.value":false}' \
  /v3/preference/build_emails
```
```json
{
  "@type": "preference",
  "@href": "/v3/preference/build_emails",
  "@representation": "standard",
  "name": "build_emails",
  "value": false
}
```