### PR TITLE
opencensus: support per-user override

### DIFF
--- a/lib/travis/api/app/middleware/opencensus.rb
+++ b/lib/travis/api/app/middleware/opencensus.rb
@@ -107,7 +107,7 @@ class Travis::Api::App
         end
 
         override = (
-          ENV['LOG_TRACING_ENABLED_FOR_LOGIN'] && env['travis.access_token']&.user&.login &&
+          ENV['OPENCENSUS_ENABLED_FOR_LOGIN'] && env['travis.access_token']&.user&.login &&
           ENV['OPENCENSUS_ENABLED_FOR_LOGIN'].split(',').include?(env['travis.access_token'].user.login)
         )
 

--- a/lib/travis/api/app/middleware/opencensus.rb
+++ b/lib/travis/api/app/middleware/opencensus.rb
@@ -106,9 +106,14 @@ class Travis::Api::App
           context = formatter.deserialize env[formatter.rack_header_name]
         end
 
-        override = (
+        override = false
+        override ||= (
           ENV['OPENCENSUS_ENABLED_FOR_LOGIN'] && env['travis.access_token']&.user&.login &&
           ENV['OPENCENSUS_ENABLED_FOR_LOGIN'].split(',').include?(env['travis.access_token'].user.login)
+        )
+        override ||= (
+          ENV['OPENCENSUS_ENABLED_FOR_PATH'] &&
+          ENV['OPENCENSUS_ENABLED_FOR_PATH'].split(',').include?(env['REQUEST_PATH'])
         )
 
         # TraceContextData has fields :trace_id, :span_id, :trace_options


### PR DESCRIPTION
This allows us to opt-in specific users and capture 100% of their traces.