### PR TITLE
Add additional context for exception parsing hook data

### DIFF
--- a/lib/travis/api/v3/github.rb
+++ b/lib/travis/api/v3/github.rb
@@ -95,10 +95,15 @@ module Travis::API::V3
       end
     end
 
+    class WebhookError < StandardError; end
+
     def webhook_url?(repo)
-      if hook = hooks(repo).detect { |h| h['name'] == 'web' && URI(h.dig('config', 'url')) == service_hook_url }
+      hooks_data = hooks(repo)
+      if hook = hooks_data.detect { |h| h['name'] == 'web' && URI(h.dig('config', 'url')) == service_hook_url }
         hook.dig('_links', 'self', 'href')
       end
+    rescue => e
+      raise WebhookError, "Error fetching or parsing Webhook information\nOriginal error: #{e.inspect}\nHooks data: #{hooks_data.inspect}"
     end
 
     def hooks(repo)


### PR DESCRIPTION
No change of behavior, this should help debugging an exception we're getting from time to time when parsing the hooks data we receive from GitHub, as if it doesn't always has the format we expect.

I fed some garbage (array of arrays instead of array of hashes) in the tests and this is how the exception looks like:

```
     Travis::API::V3::GitHub::WebhookError:
       Error fetching or parsing Webhook information
       Original error: #<TypeError: no implicit conversion of String into Integer>
       Hooks data: [["some garbage"]]
```

This can be reverted once we figure out what's going on...