### PR TITLE
Use ids for GitHub API interaction regarding hooks

### DIFF
--- a/lib/travis/api/v3/github.rb
+++ b/lib/travis/api/v3/github.rb
@@ -21,7 +21,7 @@ module Travis::API::V3
     }
     private_constant :DEFAULT_OPTIONS
 
-    HOOKS_URL = "repos/%s/hooks"
+    HOOKS_URL = "repositories/%i/hooks"
     private_constant :HOOKS_URL
 
     def self.client_config
@@ -50,7 +50,7 @@ module Travis::API::V3
     end
 
     def upload_key(repository)
-      keys_path = "repos/#{repository.slug}/keys"
+      keys_path = "repositories/#{repository.github_id}/keys"
       key = gh[keys_path].detect { |e| e['key'] == repository.key.encoded_public_key }
 
       unless key
@@ -72,18 +72,18 @@ module Travis::API::V3
         config: { url: service_hook_url.to_s }
       }
       if url = webhook_url?(repo)
-        info("Updating webhook repo=%s active=%s" % [repo.slug, active])
+        info("Updating webhook repo=%s github_id=%i active=%s" % [repo.slug, repo.github_id, active])
         gh.patch(url, payload)
       else
-        hooks_url = HOOKS_URL % [repo.slug]
-        info("Creating webhook repo=%s active=%s" % [repo.slug, active])
+        hooks_url = HOOKS_URL % [repo.github_id]
+        info("Creating webhook repo=%s github_id=%i active=%s" % [repo.slug, repo.github_id, active])
         gh.post(hooks_url, payload)
       end
     end
 
     def deactivate_service_hook(repo)
       if url = service_hook_url?(repo)
-        info("Deactivating service hook repo=%s" % [repo.slug])
+        info("Deactivating service hook repo=%s github_id=%i" % [repo.slug, repo.github_id])
         # Have to update events here too, to avoid old hooks failing validation
         gh.patch(url, { events: EVENTS, active: false })
       end
@@ -102,7 +102,7 @@ module Travis::API::V3
     end
 
     def hooks(repo)
-      gh[HOOKS_URL % [repo.slug]]
+      gh[HOOKS_URL % [repo.github_id]]
     end
 
     def service_hook_url

--- a/spec/integration/v2/hooks_spec.rb
+++ b/spec/integration/v2/hooks_spec.rb
@@ -18,7 +18,6 @@ describe 'Hooks', set_app: true do
 
   describe 'PUT /hooks' do # TODO really should be /hooks/1
     let(:hook)     { user.service_hooks.first }
-    let(:target)   { "repos/#{hook.owner_name}/#{hook.name}/hooks" }
 
     let :payload do
       {
@@ -31,8 +30,8 @@ describe 'Hooks', set_app: true do
 
     before(:each) do
       Travis.config.service_hook_url = 'notify.travis-ci.org'
-      stub_request(:get, "https://api.github.com/repos/#{repo.slug}/hooks?per_page=100").to_return(status: 200, body: '[]')
-      stub_request(:post, "https://api.github.com/repos/#{repo.slug}/hooks")
+      stub_request(:get, "https://api.github.com/repositories/#{repo.github_id}/hooks?per_page=100").to_return(status: 200, body: '[]')
+      stub_request(:post, "https://api.github.com/repositories/#{repo.github_id}/hooks")
     end
 
     it 'sets the hook' do


### PR DESCRIPTION
To avoid problems with renamed repos or users.

The endpoint is not documented but I found online mentions of it (even quoting GitHub about it, e.g.: https://github.com/piotrmurach/github/issues/283) and in fact I think we use it in some other places.