### PR TITLE
Merge pull request #818 from travis-ci/jc-hooks into enterprise 2.2 branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ $ bundle exec rake
 ```sh-session
 ENV=development bundle exec ruby -Ilib -S rackup
 ```
-(The database connection can be overwritten by setting a DATABASE_URL env var. Please ensure you also set ENV to the corresponding env and add encryption key config to `config/travis.yml`)
+(The database connection can be overwritten by setting a DATABASE_URL env var. Please ensure you also set ENV to the corresponding env and add encryption key config to `config/travis.yml`).
 
 ### Run the server (production)
 ```sh-session
@@ -76,7 +76,7 @@ If you have problems with Nginx because the websocket is already in use, try res
 
 ### API documentation
 
-v3 documentation can be found at https://developer.travis-ci.org which is a repository that can be found at https://github.com/travis-pro/developer
+v3 documentation can be found at https://developer.travis-ci.org which is a repository that can be found at https://github.com/travis-pro/developer.
 
 ### Adding V3 Endpoints Developer Documentation
 Start with the find/get spec (for example: spec/v3/services/caches/find_spec.rb) for your new endpoint. If you don't have a find route start with whatever route you want to add first. Run the test and add the files you need to clear the errors. They should be:

--- a/lib/travis/api/v3.rb
+++ b/lib/travis/api/v3.rb
@@ -28,6 +28,7 @@ module Travis
       ServerError         = Error              .create(status: 500)
       NotFound            = ClientError        .create(:resource, status: 404, template: '%s not found (or insufficient access)')
 
+      AdminAccessRequired = ClientError        .create('admin access to this repo required',  status: 403)
       AlreadySyncing      = ClientError        .create('sync already in progress', status: 409)
       BuildAlreadyRunning = ClientError        .create('build already running, cannot restart', status: 409)
       BuildNotCancelable  = ClientError        .create('build is not running, cannot cancel', status: 409)

--- a/lib/travis/api/v3/github.rb
+++ b/lib/travis/api/v3/github.rb
@@ -1,21 +1,28 @@
 require 'gh'
+require 'uri'
 
 module Travis::API::V3
   class GitHub
+    def self.config
+      @config ||= Travis::Config.load
+    end
+
+    EVENTS = %i(push pull_request issue_comment public member create delete repository)
+
     DEFAULT_OPTIONS = {
-      client_id:      Travis.config.oauth2.try(:client_id),
-      client_secret:  Travis.config.oauth2.try(:client_secret),
-      scopes:         Travis.config.oauth2.try(:scope).to_s.split(?,),
+      client_id:      config.oauth2.try(:client_id),
+      client_secret:  config.oauth2.try(:client_secret),
+      scopes:         config.oauth2.try(:scope).to_s.split(?,),
       user_agent:     "Travis-API/3 Travis-CI/0.0.1 GH/#{GH::VERSION}",
-      origin:         Travis.config.host,
-      api_url:        Travis.config.github.api_url,
-      web_url:        Travis.config.github.api_url.gsub(%r{\A(https?://)(?:api\.)?([^/]+)(?:/.*)?\Z}, '\1\2'),
-      ssl:            Travis.config.ssl.to_h.merge(Travis.config.github.ssl || {}).compact
+      origin:         config.host,
+      api_url:        config.github.api_url,
+      web_url:        config.github.api_url.gsub(%r{\A(https?://)(?:api\.)?([^/]+)(?:/.*)?\Z}, '\1\2'),
+      ssl:            config.ssl.to_h.merge(config.github.ssl || {}).compact
     }
     private_constant :DEFAULT_OPTIONS
 
-    EVENTS = %i(push pull_request issue_comment public member create delete repository)
-    private_constant :EVENTS
+    HOOKS_URL = "repos/%s/hooks"
+    private_constant :HOOKS_URL
 
     def self.client_config
       {
@@ -37,26 +44,14 @@ module Travis::API::V3
       @gh   = GH.with(token: token, **DEFAULT_OPTIONS)
     end
 
-    def set_hook(repository, flag)
-      hooks_url = "repos/#{repository.slug}/hooks"
-      payload   = {
-        name:   'travis'.freeze,
-        events: EVENTS,
-        active: flag,
-        config: { domain: Travis.config.service_hook_url || '' }
-      }
-
-      if hook = gh[hooks_url].detect { |hook| hook['name'.freeze] == 'travis'.freeze }
-        gh.patch(hook['_links'.freeze]['self'.freeze]['href'.freeze], payload)
-      else
-        gh.post(hooks_url, payload)
-      end
+    def set_hook(repo, active)
+      set_webhook(repo, active)
+      deactivate_service_hook(repo)
     end
 
     def upload_key(repository)
       keys_path = "repos/#{repository.slug}/keys"
-      key = gh[keys_path].
-        detect { |e| e['key'] == repository.key.encoded_public_key }
+      key = gh[keys_path].detect { |e| e['key'] == repository.key.encoded_public_key }
 
       unless key
         gh.post keys_path, {
@@ -65,6 +60,59 @@ module Travis::API::V3
           read_only: !Travis::Features.owner_active?(:read_write_github_keys, repository.owner)
         }
       end
+    end
+
+    private
+
+    def set_webhook(repo, active)
+      payload = {
+        name: 'web'.freeze,
+        events: EVENTS,
+        active: active,
+        config: { url: service_hook_url.to_s }
+      }
+      if url = webhook_url?(repo)
+        info("Updating webhook repo=%s active=%s" % [repo.slug, active])
+        gh.patch(url, payload)
+      else
+        hooks_url = HOOKS_URL % [repo.slug]
+        info("Creating webhook repo=%s active=%s" % [repo.slug, active])
+        gh.post(hooks_url, payload)
+      end
+    end
+
+    def deactivate_service_hook(repo)
+      if url = service_hook_url?(repo)
+        info("Deactivating service hook repo=%s" % [repo.slug])
+        # Have to update events here too, to avoid old hooks failing validation
+        gh.patch(url, { events: EVENTS, active: false })
+      end
+    end
+
+    def service_hook_url?(repo)
+      if hook = hooks(repo).detect { |h| h['name'] == 'travis' }
+        hook.dig('_links', 'self', 'href')
+      end
+    end
+
+    def webhook_url?(repo)
+      if hook = hooks(repo).detect { |h| h['name'] == 'web' && URI(h.dig('config', 'url')) == service_hook_url }
+        hook.dig('_links', 'self', 'href')
+      end
+    end
+
+    def hooks(repo)
+      gh[HOOKS_URL % [repo.slug]]
+    end
+
+    def service_hook_url
+      url = Travis.config.service_hook_url || ''
+      url.prepend('https://') unless url.starts_with?('https://', 'http://')
+      URI(url)
+    end
+
+    def info(msg)
+      Travis.logger.info(msg)
     end
   end
 end

--- a/lib/travis/github.rb
+++ b/lib/travis/github.rb
@@ -1,8 +1,5 @@
 require 'gh'
 require 'core_ext/hash/compact'
-require 'travis/github/education'
-require 'travis/github/oauth'
-require 'travis/github/services'
 
 module Travis
   module Github
@@ -23,5 +20,9 @@ module Travis
         GH.with(:token => user.github_oauth_token, &block)
       end
     end
+
+    require 'travis/github/education'
+    require 'travis/github/oauth'
+    require 'travis/github/services'
   end
 end

--- a/lib/travis/github/services/set_hook.rb
+++ b/lib/travis/github/services/set_hook.rb
@@ -2,65 +2,31 @@ require 'travis/github'
 require 'travis/services/base'
 
 module Travis
+  module API; end # Load-order issue
+  require 'travis/api/v3/github'
+
   module Github
     module Services
       class SetHook < Travis::Services::Base
-        EVENTS = %i(push pull_request issue_comment public member create delete repository)
-
         register :github_set_hook
 
         def run
-          Github.authenticated(current_user) do
-            update
-          end
+          v3_github.set_hook(repo, active?)
         end
 
         private
 
-          def repo
-            @repo ||= run_service(:find_repo, id: params[:id])
-          end
+        def active?
+          params[:active]
+        end
 
-          def active?
-            params[:active]
-          end
+        def v3_github
+          @v3_github ||= Travis::API::V3::GitHub.new(current_user, current_user.github_oauth_token)
+        end
 
-          def hook
-            @hook ||= find || create
-          end
-
-          def update
-            GH.patch(hook_url, payload) unless hook['active'] == active?
-          end
-
-          def find
-            GH[hooks_url].detect { |hook| hook['name'] == 'travis' && hook['config']['domain'] == domain }
-          end
-
-          def create
-            GH.post(hooks_url, payload)
-          end
-
-          def payload
-            {
-              :name   => 'travis',
-              :events => EVENTS,
-              :active => active?,
-              :config => { :user => current_user.login, :token => current_user.tokens.first.token, :domain => domain }
-            }
-          end
-
-          def hooks_url
-            "repos/#{repo.slug}/hooks"
-          end
-
-          def hook_url
-            hook['_links']['self']['href']
-          end
-
-          def domain
-            Travis.config.service_hook_url || ''
-          end
+        def repo
+          @repo ||= run_service(:find_repo, id: params[:id])
+        end
       end
     end
   end

--- a/lib/travis/testing/payloads.rb
+++ b/lib/travis/testing/payloads.rb
@@ -138,67 +138,6 @@ PAYLOADS[:github] = {
     "created":true
   }),
 
-
-  :hook_inactive => %({
-    "last_response": {
-      "status": "ok",
-      "message": "",
-      "code": 200
-    },
-    "config": {
-      "domain": "staging.travis-ci.org",
-      "user": "svenfuchs",
-      "token": "token"
-    },
-    "created_at": "2011-09-18T10:49:06Z",
-    "events": [
-      "push",
-      "pull_request",
-      "issue_comment",
-      "public",
-      "member"
-    ],
-    "active": false,
-    "updated_at": "2012-08-09T09:32:42Z",
-    "name": "travis",
-    "_links": {
-      "self": {
-        "href": "https://api.github.com/repos/svenfuchs/minimal/hooks/77103"
-      }
-    },
-    "id": 77103
-  }),
-
-  :hook_active => %({
-    "last_response": {
-      "status": "ok",
-      "message": "",
-      "code": 200
-    },
-    "config": {
-      "domain": "staging.travis-ci.org",
-      "user": "svenfuchs",
-      "token": "token"
-    },
-    "created_at": "2011-09-18T10:49:06Z",
-    "events": [
-      "push",
-      "pull_request",
-      "issue_comment",
-      "public",
-      "member"
-    ],
-    "active": true,
-    "updated_at": "2012-08-09T09:32:42Z",
-    "name": "travis",
-    "_links": {
-      "self": {
-        "href": "https://api.github.com/repos/svenfuchs/minimal/hooks/77103"
-      }
-    },
-    "id": 77103
-  }),
-
   :oauth => {
     "uid" => "234423",
     "user_info" => {

--- a/spec/support/payloads.rb
+++ b/spec/support/payloads.rb
@@ -483,66 +483,6 @@ GITHUB_PAYLOADS = {
     }
   }),
 
-  'hook_inactive' => %({
-    "last_response": {
-      "status": "ok",
-      "message": "",
-      "code": 200
-    },
-    "config": {
-      "domain": "staging.travis-ci.org",
-      "user": "svenfuchs",
-      "token": "token"
-    },
-    "created_at": "2011-09-18T10:49:06Z",
-    "events": [
-      "push",
-      "pull_request",
-      "issue_comment",
-      "public",
-      "member"
-    ],
-    "active": false,
-    "updated_at": "2012-08-09T09:32:42Z",
-    "name": "travis",
-    "_links": {
-      "self": {
-        "href": "https://api.github.com/repos/svenfuchs/minimal/hooks/77103"
-      }
-    },
-    "id": 77103
-  }),
-
-  'hook_active' => %({
-    "last_response": {
-      "status": "ok",
-      "message": "",
-      "code": 200
-    },
-    "config": {
-      "domain": "staging.travis-ci.org",
-      "user": "svenfuchs",
-      "token": "token"
-    },
-    "created_at": "2011-09-18T10:49:06Z",
-    "events": [
-      "push",
-      "pull_request",
-      "issue_comment",
-      "public",
-      "member"
-    ],
-    "active": true,
-    "updated_at": "2012-08-09T09:32:42Z",
-    "name": "travis",
-    "_links": {
-      "self": {
-        "href": "https://api.github.com/repos/svenfuchs/minimal/hooks/77103"
-      }
-    },
-    "id": 77103
-  }),
-
   'rkh' => %({
     "user": {
       "gravatar_id":"5c2b452f6eea4a6d84c105ebd971d2a4",

--- a/spec/v3/services/repository/deactivate_spec.rb
+++ b/spec/v3/services/repository/deactivate_spec.rb
@@ -64,7 +64,123 @@ describe Travis::API::V3::Services::Repository::Deactivate, set_app: true do
     }}
   end
 
-  describe "existing repository, push access"
-  # as this requires a call to github, and stubbing this request has proven difficult,
-  # this test has been omitted for now
+  describe 'existing repository, wrong access' do
+    let(:token) { Travis::Api::App::AccessToken.create(user: repo.owner, app_id: 1) }
+    let(:headers) {{ 'HTTP_AUTHORIZATION' => "token #{token}" }}
+    before { Travis::API::V3::Models::Permission.create(repository: repo, user: repo.owner, push: true) }
+    before { stub_request(:any, %r(api.github.com/repos/#{repo.slug}/hooks(/\d+)?)) }
+    before { post("/v3/repo/#{repo.id}/deactivate", {}, headers) }
+
+    example 'is success' do
+      expect(last_response.status).to eq 403
+      expect(JSON.load(body)).to include(
+        '@type' => 'error',
+        'error_type' => 'admin_access_required'
+      )
+    end
+  end
+
+  describe "existing repository, admin and push access" do
+    let(:token) { Travis::Api::App::AccessToken.create(user: repo.owner, app_id: 1) }
+    let(:headers) {{ 'HTTP_AUTHORIZATION' => "token #{token}" }}
+    let(:webhook_payload) { JSON.dump(name: 'web', events: Travis::API::V3::GitHub::EVENTS, active: false, config: { url: Travis.config.service_hook_url || '' }) }
+    let(:service_hook_payload) { JSON.dump(events: Travis::API::V3::GitHub::EVENTS, active: false) }
+
+    before { Travis::API::V3::Models::Permission.create(repository: repo, user: repo.owner, admin: true, push: true) }
+    before { stub_request(:any, %r(api.github.com/repos/#{repo.slug}/hooks(/\d+)?)) }
+
+    around do |ex|
+      Travis.config.service_hook_url = 'https://url.of.listener.something'
+      ex.run
+      Travis.config.service_hook_url = nil
+    end
+
+    context 'when repo has service hook and webhook' do
+      before do
+        stub_request(:get, "https://api.github.com/repos/#{repo.slug}/hooks?per_page=100").to_return(
+          status: 200, body: JSON.dump(
+            [
+              { name: 'travis', url: "https://api.github.com/repos/#{repo.slug}/hooks/123" },
+              { name: 'web', url: "https://api.github.com/repos/#{repo.slug}/hooks/456", config: { url: Travis.config.service_hook_url } }
+            ]
+          )
+        )
+        post("/v3/repo/#{repo.id}/deactivate", {}, headers)
+      end
+
+      example 'deactivates service hook' do
+        expect(WebMock).to have_requested(:patch, "https://api.github.com/repos/#{repo.slug}/hooks/123").with(body: service_hook_payload).once
+      end
+
+      example 'updates webhook' do
+        expect(WebMock).to have_requested(:patch, "https://api.github.com/repos/#{repo.slug}/hooks/456").with(body: webhook_payload).once
+      end
+
+      example 'is success' do
+        expect(last_response.status).to eq 200
+        expect(JSON.load(body)).to include(
+          '@type' => 'repository',
+          'active' => false
+        )
+      end
+    end
+
+    context 'when repo has only service hook' do
+      before do
+        stub_request(:get, "https://api.github.com/repos/#{repo.slug}/hooks?per_page=100").to_return(
+          status: 200, body: JSON.dump(
+            [
+              { name: 'travis', url: "https://api.github.com/repos/#{repo.slug}/hooks/123" }
+            ]
+          )
+        )
+        post("/v3/repo/#{repo.id}/deactivate", {}, headers)
+      end
+
+      example 'deactivates service hook' do
+        expect(WebMock).to have_requested(:patch, "https://api.github.com/repos/#{repo.slug}/hooks/123").with(body: service_hook_payload).once
+      end
+
+      example 'creates webhook' do
+        expect(WebMock).to have_requested(:post, "https://api.github.com/repos/#{repo.slug}/hooks").once
+      end
+
+      example 'is success' do
+        expect(last_response.status).to eq 200
+        expect(JSON.load(body)).to include(
+          '@type' => 'repository',
+          'active' => false
+        )
+      end
+    end
+
+    context 'when repo has only webhook' do
+      before do
+        stub_request(:get, "https://api.github.com/repos/#{repo.slug}/hooks?per_page=100").to_return(
+          status: 200, body: JSON.dump(
+            [
+              { name: 'web', url: "https://api.github.com/repos/#{repo.slug}/hooks/456", config: { url: Travis.config.service_hook_url } }
+            ]
+          )
+        )
+        post("/v3/repo/#{repo.id}/deactivate", {}, headers)
+      end
+
+      example 'does nothing with service hook' do
+        expect(WebMock).not_to have_requested(:patch, "https://api.github.com/repos/#{repo.slug}/hooks/123")
+      end
+
+      example 'updates webhook' do
+        expect(WebMock).to have_requested(:patch, "https://api.github.com/repos/#{repo.slug}/hooks/456").once
+      end
+
+      example 'is success' do
+        expect(last_response.status).to eq 200
+        expect(JSON.load(body)).to include(
+          '@type' => 'repository',
+          'active' => false
+        )
+      end
+    end
+  end
 end


### PR DESCRIPTION
This is a backport of PR #818 where we move from service hooks to webhooks to account for GitHub deprecating service hooks both in GitHub.com and GitHub Enterprise