### PR TITLE
Lowercase owner and name for repo slug

### DIFF
--- a/lib/travis/api/v3/queries/repository.rb
+++ b/lib/travis/api/v3/queries/repository.rb
@@ -43,7 +43,7 @@ module Travis::API::V3
 
     def by_slug
       owner_name, name = slug.split('/')
-      Models::Repository.where(owner_name: owner_name, name: name, invalidated_at: nil).first
+      Models::Repository.where(owner_name: owner_name.downcase, name: name.downcase, invalidated_at: nil).first
     end
   end
 end

--- a/spec/v3/services/repository/find_spec.rb
+++ b/spec/v3/services/repository/find_spec.rb
@@ -154,6 +154,12 @@ describe Travis::API::V3::Services::Repository::Find, set_app: true do
       example { expect(last_response).to be_ok }
       example { expect(parsed_body['slug']).to be == 'svenfuchs/minimal' }
     end
+
+    describe 'public repo by slug with capitalization' do
+      before  { get("/v3/repo/SvenFuchs%2Fminimal") }
+      example { expect(last_response).to be_ok }
+      example { expect(parsed_body['slug']).to be == 'svenfuchs/minimal' }
+    end
   end
 
   shared_examples 'denies unauthenticated access to a public repo' do


### PR DESCRIPTION
#### What does this PR do?
- Lowercase name and owner on repo slug to allow case-insensitive repo urls
 
#### Related Issue
[1250](https://github.com/travis-pro/team-teal/issues/1250)

#### How this PR makes you feel?
![ant-man](https://user-images.githubusercontent.com/529465/48425138-6b018980-e721-11e8-8470-0edb72b5c73b.gif)
