### PR TITLE
Make a user `adminable` by the user themselves

### DIFF
--- a/lib/travis/api/v3/access_control/generic.rb
+++ b/lib/travis/api/v3/access_control/generic.rb
@@ -169,6 +169,10 @@ module Travis::API::V3
       self.user == user
     end
 
+    def user_adminable?(user)
+      user_writable?(user)
+    end
+
     def is_current_user?(user)
       self.user == user
     end


### PR DESCRIPTION
While implementing auth for insights, I found this missing piece that was complicating the implementation, and changed it because it seemed to me to make sense (also, the change broke no tests):

* A user is now `adminable` for themselves. It was already `writable` but this method was missing