### PR TITLE
Revert repo slug lowercase

### DIFF
--- a/lib/travis/api/v3/queries/repository.rb
+++ b/lib/travis/api/v3/queries/repository.rb
@@ -43,7 +43,7 @@ module Travis::API::V3
 
     def by_slug
       owner_name, name = slug.split('/')
-      Models::Repository.where(owner_name: owner_name.downcase, name: name.downcase, invalidated_at: nil).first
+      Models::Repository.where(owner_name: owner_name, name: name, invalidated_at: nil).first
     end
   end
 end

--- a/spec/v3/services/repository/find_spec.rb
+++ b/spec/v3/services/repository/find_spec.rb
@@ -154,12 +154,6 @@ describe Travis::API::V3::Services::Repository::Find, set_app: true do
       example { expect(last_response).to be_ok }
       example { expect(parsed_body['slug']).to be == 'svenfuchs/minimal' }
     end
-
-    describe 'public repo by slug with capitalization' do
-      before  { get("/v3/repo/SvenFuchs%2Fminimal") }
-      example { expect(last_response).to be_ok }
-      example { expect(parsed_body['slug']).to be == 'svenfuchs/minimal' }
-    end
   end
 
   shared_examples 'denies unauthenticated access to a public repo' do


### PR DESCRIPTION
#### What does this PR do?
- Revert lowercase name and owner on repo slug to allow case-insensitive repo urls. Doing this could break urls for any repos that are uppercase in the database.
 
#### Related Issue
[1250](https://github.com/travis-pro/team-teal/issues/1250)

#### How this PR makes you feel?
Potentially could have been a big "L"
![l](https://user-images.githubusercontent.com/529465/48506849-a1193900-e807-11e8-8abf-5d064338a36f.gif)

