### PR TITLE
Pass the private flag to insights 

### DIFF
--- a/lib/travis/api/v3/proxy_service.rb
+++ b/lib/travis/api/v3/proxy_service.rb
@@ -23,7 +23,7 @@ module Travis::API::V3
     end
 
     def proxy!
-      response = self.class.proxy_client.proxy(@env)
+      response = self.class.proxy_client.proxy(@env) { |r| yield r if block_given? }
       result response.body, status: response.status, result_type: :proxy
     end
 
@@ -42,6 +42,7 @@ module Travis::API::V3
 
         request = @connection.build_request(original.request_method) do |r|
           r.params = original.params
+          yield r if block_given?
         end
 
         # not really documented, but according to https://github.com/lostisland/faraday/blob/f08a985bd1dc380ed2d9839f1103318e2fad5f8b/lib/faraday/connection.rb#L387,

--- a/lib/travis/api/v3/services/insights/insights_proxy.rb
+++ b/lib/travis/api/v3/services/insights/insights_proxy.rb
@@ -2,11 +2,16 @@ module Travis::API::V3
   class Services::Insights::InsightsProxy < ProxyService
     def run!
       check_owner_class
-      raise InsufficientAccess unless Travis.config.org? || access_control.adminable?(owner)
-      proxy!
+      proxy! do |request|
+        request.params.merge!(private: private_flag) unless Travis.config.org?
+      end
     end
 
     private
+
+    def private_flag
+      access_control.adminable?(owner)
+    end
 
     def owner
       @_owner ||= owner_class.find(params['owner_id'])


### PR DESCRIPTION
(Builds on top of #856)

Might need additional small changes since this param is still not implemented upstream and might be different (`public`?).