### PR TITLE
Don't block API on .com when repo is migrated

### DIFF
--- a/lib/travis/api/v3/service.rb
+++ b/lib/travis/api/v3/service.rb
@@ -176,7 +176,7 @@ module Travis::API::V3
     end
 
     def migrated?(repo)
-      ["migrated", "migrating"].include? repo.migration_status
+      Travis.config.org? && ["migrated", "migrating"].include?(repo.migration_status)
     end
 
     # TODO confirm message, link to docs?

--- a/spec/v3/services/build/restart_spec.rb
+++ b/spec/v3/services/build/restart_spec.rb
@@ -46,6 +46,14 @@ describe Travis::API::V3::Services::Build::Restart, set_app: true do
     let(:headers) { { 'HTTP_AUTHORIZATION' => "token #{token}" } }
     before  { Travis::API::V3::Models::Permission.create(repository: repo, user: repo.owner, pull: true) }
 
+    describe "repo migrating on .com" do
+      before  { Travis.config.host = "travis-ci.com" }
+      before  { repo.update_attributes(migration_status: "migrating") }
+      before  { post("/v3/build/#{build.id}/restart", {}, headers) }
+
+      example { expect(last_response.status).to be == 202 }
+    end
+
     describe "repo migrating" do
       before  { repo.update_attributes(migration_status: "migrating") }
       before  { post("/v3/build/#{build.id}/restart", {}, headers) }


### PR DESCRIPTION
We started setting the migration_status column on .com repositories as
well, so here we must ensure that we're blocking the API only for the
.org API