### PR TITLE
Don't block API requests for migrated repo on .com in V2

### DIFF
--- a/lib/travis/api/app/endpoint.rb
+++ b/lib/travis/api/app/endpoint.rb
@@ -50,7 +50,7 @@ class Travis::Api::App
       }
 
       def disallow_migrating!(repo)
-        halt 403, MSGS[:migrated] if repo.migration_status == "migrating" || repo.migration_status == "migrated"
+        halt 403, MSGS[:migrated] if Travis.config.org? && (repo.migration_status == "migrating" || repo.migration_status == "migrated")
       end
 
       def allow_public?

--- a/spec/integration/v2/builds_spec.rb
+++ b/spec/integration/v2/builds_spec.rb
@@ -149,6 +149,13 @@ describe 'Builds', set_app: true do
       it { last_response.status.should == 403 }
     end
 
+    context 'when the repo is migrated on .com' do
+      before { Travis.config.host = 'travis-ci.com' }
+      before { repo.update_attributes(migration_status: "migrated") }
+      before { post "/builds/#{build.id}/restart", {}, headers }
+      it { last_response.status.should == 202 }
+    end
+
     context 'when build passed' do
       before do
         build.matrix.each { |j| j.update_attribute(:state, 'passed') }


### PR DESCRIPTION
We started setting the migration_status column on .com repositories as
well, so here we must ensure that we're blocking the API only for the
.org API