### PR TITLE
Fix Repository#default_branch method

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,7 +7,6 @@ $: << 'lib'
 ENV['RACK_ENV'] = ENV['RAILS_ENV'] = ENV['ENV'] = 'test'
 ENV['BILLING_V2_ENABLED'] = 'true'
 ENV['GDPR_ENABLED'] = 'true'
-ENV.delete('DATABASE_URL')
 
 require 'support/coverage' unless ENV['SKIP_COVERAGE']
 


### PR DESCRIPTION
When changing the method to use upsert I missed some things about how it
works, mainly that it checks if a branch returned from
Repository#create_branch is a new record and if it is, a last_build will
be attached there. When using upsert a record will be always fetched
from the database, so I needed to change how the method works.