### PR TITLE
Fix another bug that creates duplicated branches

### DIFF
--- a/lib/travis/api/v3/models/repository.rb
+++ b/lib/travis/api/v3/models/repository.rb
@@ -58,6 +58,10 @@ module Travis::API::V3
     end
 
     def find_or_create_branch(create_without_build: false, name:)
+      if branch = branches.where(name: name).first
+        return branch
+      end
+
       connection = ActiveRecord::Base.connection
       quoted_id   = connection.quote(id)
       quoted_name = connection.quote(name)
@@ -76,6 +80,8 @@ module Travis::API::V3
         new_branch = true
       end
 
+      branches.reload
+      branches.where(name: name).to_sql
       branch = branches.where(name: name).first
       return branch unless new_branch
       return nil    unless create_without_build or branch.builds.any?

--- a/spec/lib/services/find_branches_spec.rb
+++ b/spec/lib/services/find_branches_spec.rb
@@ -1,4 +1,7 @@
 describe Travis::Services::FindBranches do
+  before { ActiveRecord::Base.connection.execute("truncate table repositories cascade") }
+  before { ActiveRecord::Base.connection.execute("truncate table builds cascade") }
+  before { ActiveRecord::Base.connection.execute("truncate table branches cascade") }
   describe 'on org' do
     let(:user)    { Factory(:user) }
     let(:repo)    { Factory(:repository_without_last_build, :owner_name => 'travis-ci', :name => 'travis-core') }


### PR DESCRIPTION
The fix for creating branch duplicates that I shipped to API was
wrong. It only fixed situation for new branches, but was still creating
duplicates for existing branches. The problem is that upsert uses
`unique_name` column and not `name` column. The former is not populated
for older records, so upsert won't work then. Unfortunately due to a way
I wrote a trigger test suite was passing without any problems.