### PR TITLE
Revert changes that were supposed to stop creating branches duplicates

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,6 +7,7 @@ $: << 'lib'
 ENV['RACK_ENV'] = ENV['RAILS_ENV'] = ENV['ENV'] = 'test'
 ENV['BILLING_V2_ENABLED'] = 'true'
 ENV['GDPR_ENABLED'] = 'true'
+ENV.delete('DATABASE_URL')
 
 require 'support/coverage' unless ENV['SKIP_COVERAGE']
 

--- a/spec/v3/services/repositories/for_owner_spec.rb
+++ b/spec/v3/services/repositories/for_owner_spec.rb
@@ -12,9 +12,9 @@ describe Travis::API::V3::Services::Repositories::ForOwner, set_app: true do
   after         { repo.update_attribute(:private, false)                            }
 
   describe "sorting by default_branch.last_build" do
-    let!(:repo2) { Travis::API::V3::Models::Repository.create!(owner_name: 'svenfuchs', owner: repo.owner, name: 'second-repo', default_branch_name: 'other-branch') }
-    let!(:branch) { repo2.default_branch }
-    let!(:build) { Travis::API::V3::Models::Build.create(repository: repo2, branch_id: branch.id, branch_name: 'other-branch') }
+    let!(:repo2) { Travis::API::V3::Models::Repository.create!(owner_name: 'svenfuchs', owner: repo.owner, name: 'second-repo', default_branch_name: 'master') }
+    let!(:branch) { Travis::API::V3::Models::Branch.create(repository: repo2, name: 'master') }
+    let!(:build) { Travis::API::V3::Models::Build.create(repository: repo2, branch_id: branch.id, branch_name: 'master') }
 
     before do
       branch.update_attributes!(last_build_id: build.id)


### PR DESCRIPTION
We're seeing errors in the database that might be related to these
commits. Reverting for now.

Revert "Remove commented code"
This reverts commit ca8da470c30f8b902178aff6ca405444acb633f0.
Revert "Fix Repository#default_branch method (#863)"
This reverts commit ec121fafa21a02a9f9c7664a0258baa21924588a.
Revert "Make sure that branches use upsert"
This reverts commit aef9578120c659acdeae2b0f21fbc0c613a64d4a.
Revert "Fix specs"
This reverts commit 01399bebd7245a238d468476a710cef15463e461.
Revert "Don't create branch duplicates (#862)"
This reverts commit 96d22d966f07a31540cb631df1ccbaa4622a5bd0.