### PR TITLE
Use github_id for migrating a repository

### DIFF
--- a/lib/travis/api/v3/models/repository_migration.rb
+++ b/lib/travis/api/v3/models/repository_migration.rb
@@ -23,7 +23,7 @@ module Travis::API::V3::Models
         c.use OpenCensus::Trace::Integrations::FaradayMiddleware if Travis::Api::App::Middleware::OpenCensus.enabled?
         c.adapter Faraday.default_adapter
       end
-      response = connection.post("/api/repository/#{repository.slug}/migrate")
+      response = connection.post("/api/repo/by_github_id/#{repository.github_id}/migrate")
 
       unless response.success?
         raise MigrationRequestFailed

--- a/spec/v3/services/repository/migrate_spec.rb
+++ b/spec/v3/services/repository/migrate_spec.rb
@@ -11,7 +11,7 @@ describe Travis::API::V3::Services::Repository::Migrate, set_app: true do
       context "has admin permissions to the repo" do
         before { Travis::API::V3::Models::Permission.create(repository: repo, user: user, admin: true) }
         before do
-          stub_request(:post, "https://merge.localhost/api/repository/#{repo.slug}/migrate")
+          stub_request(:post, "https://merge.localhost/api/repo/by_github_id/#{repo.github_id}/migrate")
         end
 
         it "makes a request to the merge app" do


### PR DESCRIPTION
github_id is more reliable than slug because it can't change. Slug can
change after a repository transfer, or after renaming a repository or an owner