### PR TITLE
Read organizations preferences

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -88,6 +88,7 @@ group :test do
   gem 'timecop',       '~> 0.8.0'
   gem 'webmock'
   gem 'hashdiff'
+  gem 'pry-byebug'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -131,6 +131,7 @@ GEM
     builder (3.2.3)
     bunny (2.9.2)
       amq-protocol (~> 2.3.0)
+    byebug (10.0.2)
     coder (0.4.0)
     coderay (1.1.1)
     coercible (1.0.0)
@@ -291,6 +292,9 @@ GEM
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
       slop (~> 3.4)
+    pry-byebug (3.6.0)
+      byebug (~> 10.0)
+      pry (~> 0.10)
     public_suffix (3.0.3)
     pusher (0.14.6)
       httpclient (~> 2.5)
@@ -446,6 +450,7 @@ DEPENDENCIES
   opencensus-stackdriver
   pg (~> 0.21)
   pry
+  pry-byebug
   pusher (~> 0.14.0)
   rack-attack (= 5.0.0.beta1)
   rack-cache!

--- a/lib/travis/api/v3/access_control/generic.rb
+++ b/lib/travis/api/v3/access_control/generic.rb
@@ -142,8 +142,10 @@ module Travis::API::V3
     end
 
     def preferences_visible?(preferences)
-      true
+      adminable? preferences.parent
     end
+    alias_method :user_preferences_visible?, :preferences_visible?
+    alias_method :organization_preferences_visible?, :preferences_visible?
 
     def organization_visible?(organization)
       full_access? or public_mode?(organization)

--- a/lib/travis/api/v3/extensions/preferences.rb
+++ b/lib/travis/api/v3/extensions/preferences.rb
@@ -1,0 +1,17 @@
+module Travis::API::V3
+  module Extensions
+    module Preferences
+      module ClassMethods
+        def has_preferences(klass, column: :preferences, method_name: :preferences)
+          define_method method_name do
+            klass.new(self[column]).tap { |prefs| prefs.sync(self, column) }
+          end
+        end
+      end
+
+      def self.included(base)
+        base.extend(ClassMethods)
+      end
+    end
+  end
+end

--- a/lib/travis/api/v3/model.rb
+++ b/lib/travis/api/v3/model.rb
@@ -1,6 +1,8 @@
 module Travis::API::V3
   class Model < ActiveRecord::Base
     include Extensions::BelongsTo
+    include Extensions::Preferences
+
     self.abstract_class = true
 
     def self.===(other)

--- a/lib/travis/api/v3/models/json_slice.rb
+++ b/lib/travis/api/v3/models/json_slice.rb
@@ -2,7 +2,7 @@ require_relative './json_sync'
 
 module Travis::API::V3
   class Models::JsonSlice
-    include Virtus.model, Enumerable, Models::JsonSync
+    include Virtus.model, Enumerable, Models::JsonSync, ActiveModel::Model
 
     class << self
       attr_accessor :child_klass

--- a/lib/travis/api/v3/models/json_slice.rb
+++ b/lib/travis/api/v3/models/json_slice.rb
@@ -2,7 +2,7 @@ require_relative './json_sync'
 
 module Travis::API::V3
   class Models::JsonSlice
-    include Virtus.model, Enumerable, Models::JsonSync, ActiveModel::Model
+    include Virtus.model, Enumerable, Models::JsonSync, ActiveModel::Validations
 
     class << self
       attr_accessor :child_klass

--- a/lib/travis/api/v3/models/json_sync.rb
+++ b/lib/travis/api/v3/models/json_sync.rb
@@ -5,8 +5,8 @@ module Travis::API::V3
     def sync(parent, attr)
       @parent, @attr = parent, attr
       @sync = -> do
-        previous = @parent.send(@attr) || {}
-        @parent.send("#{@attr}=", previous.merge(to_h).to_json)
+        previous = @parent[@attr] || {}
+        @parent[@attr] = previous.merge(to_h).to_json
         @parent.save!
       end
     end

--- a/lib/travis/api/v3/models/organization.rb
+++ b/lib/travis/api/v3/models/organization.rb
@@ -1,7 +1,11 @@
+require 'travis/api/v3/models/organization_preferences'
+
 module Travis::API::V3
   class Models::Organization < Model
     has_many :memberships
     has_many :users, through: :memberships
+
+    has_preferences Models::OrganizationPreferences
 
     def repositories
       Models::Repository.where(owner_type: 'Organization', owner_id: id)

--- a/lib/travis/api/v3/models/organization_preferences.rb
+++ b/lib/travis/api/v3/models/organization_preferences.rb
@@ -1,0 +1,10 @@
+require 'travis/api/v3/models/preference'
+
+module Travis::API::V3
+  class Models::OrganizationPreferences < Models::JsonSlice
+    child Models::Preference
+
+    attribute :public_insights, Boolean, default: false
+    attribute :members_insights, Boolean, default: false
+  end
+end

--- a/lib/travis/api/v3/models/organization_preferences.rb
+++ b/lib/travis/api/v3/models/organization_preferences.rb
@@ -4,7 +4,10 @@ module Travis::API::V3
   class Models::OrganizationPreferences < Models::JsonSlice
     child Models::Preference
 
-    attribute :public_insights, Boolean, default: false
-    attribute :members_insights, Boolean, default: false
+    # whether to show insights about the organization's private repositories to
+    # only admins, all members of the organization, or everybody (public) (note:
+    # insights about public repositories are always public)
+    attribute :private_insights_visibility, String, default: 'admins'
+    validates :private_insights_visibility, inclusion: %w{admins members public}
   end
 end

--- a/lib/travis/api/v3/models/preferences.rb
+++ b/lib/travis/api/v3/models/preferences.rb
@@ -3,5 +3,6 @@ module Travis::API::V3
     child Models::Preference
 
     attribute :build_emails, Boolean, default: true
+    attribute :public_insights, Boolean, default: false
   end
 end

--- a/lib/travis/api/v3/models/preferences.rb
+++ b/lib/travis/api/v3/models/preferences.rb
@@ -3,6 +3,11 @@ module Travis::API::V3
     child Models::Preference
 
     attribute :build_emails, Boolean, default: true
-    attribute :public_insights, Boolean, default: false
+
+    # whether to show insights about the user's private repositories to
+    # everybody or keep them only for the user (note: insights about public
+    # repositories are always public)
+    attribute :private_insights_visibility, String, default: 'private'
+    validates :private_insights_visibility, inclusion: %w{private public}
   end
 end

--- a/lib/travis/api/v3/models/user.rb
+++ b/lib/travis/api/v3/models/user.rb
@@ -1,3 +1,5 @@
+require 'travis/api/v3/models/user_preferences'
+
 module Travis::API::V3
   class Models::User < Model
     has_many :memberships,   dependent: :destroy
@@ -9,6 +11,8 @@ module Travis::API::V3
     has_many :email_unsubscribes
     has_many :user_beta_features
     has_many :beta_features, through: :user_beta_features
+
+    has_preferences Models::UserPreferences
 
     serialize :github_oauth_token, Travis::Model::EncryptedColumn.new
     scope :with_github_token, -> { where('github_oauth_token IS NOT NULL')}
@@ -43,10 +47,6 @@ module Travis::API::V3
     def installation
       return @installation if defined? @installation
       @installation = Models::Installation.find_by(owner_type: 'User', owner_id: id, removed_by_id: nil)
-    end
-
-    def user_preferences
-      Models::Preferences.new(preferences).tap { |prefs| prefs.sync(self, :preferences) }
     end
   end
 end

--- a/lib/travis/api/v3/models/user_preferences.rb
+++ b/lib/travis/api/v3/models/user_preferences.rb
@@ -1,5 +1,7 @@
+require 'travis/api/v3/models/preference'
+
 module Travis::API::V3
-  class Models::Preferences < Models::JsonSlice
+  class Models::UserPreferences < Models::JsonSlice
     child Models::Preference
 
     attribute :build_emails, Boolean, default: true

--- a/lib/travis/api/v3/queries/preference.rb
+++ b/lib/travis/api/v3/queries/preference.rb
@@ -3,11 +3,11 @@ module Travis::API::V3
     params :name, :value, prefix: :preference
 
     def find(user)
-      user.user_preferences.read(name)
+      user.preferences.read(name)
     end
 
     def update(user)
-      user.user_preferences.update(name, value)
+      user.preferences.update(name, value)
     end
   end
 end

--- a/lib/travis/api/v3/queries/preferences.rb
+++ b/lib/travis/api/v3/queries/preferences.rb
@@ -1,7 +1,7 @@
 module Travis::API::V3
   class Queries::Preferences < Query
-    def find(user)
-      user.user_preferences
+    def find(owner)
+      owner.preferences
     end
   end
 end

--- a/lib/travis/api/v3/routes.rb
+++ b/lib/travis/api/v3/routes.rb
@@ -83,6 +83,11 @@ module Travis::API::V3
       capture id: :digit
       route '/org/{organization.id}'
       get :find
+
+      resource :preferences do
+        route '/preferences'
+        get :for_organization
+      end
     end
 
     resource :organizations do

--- a/lib/travis/api/v3/services/preferences/for_organization.rb
+++ b/lib/travis/api/v3/services/preferences/for_organization.rb
@@ -1,0 +1,9 @@
+module Travis::API::V3
+  class Services::Preferences::ForOrganization < Service
+    def run!
+      organization = check_login_and_find(:organization)
+      prefs = find(:preferences, organization)
+      result prefs
+    end
+  end
+end

--- a/spec/v3/services/preference/find_spec.rb
+++ b/spec/v3/services/preference/find_spec.rb
@@ -25,7 +25,7 @@ describe Travis::API::V3::Services::Preference::Find, set_app: true do
 
   describe 'authenticated, pref found' do
     before do
-      user.user_preferences.update(:build_emails, false)
+      user.preferences.update(:build_emails, false)
       get("/v3/preference/build_emails", {}, auth_headers)
     end
 

--- a/spec/v3/services/preference/update_spec.rb
+++ b/spec/v3/services/preference/update_spec.rb
@@ -26,6 +26,7 @@ describe Travis::API::V3::Services::Preference::Update, set_app: true do
         "value" => false
       )
     end
+    example 'PENDING: Return validation error'
     example do
       expect(user.github_oauth_token).to eq github_oauth_token
     end

--- a/spec/v3/services/preferences/for_organization_spec.rb
+++ b/spec/v3/services/preferences/for_organization_spec.rb
@@ -1,0 +1,97 @@
+describe Travis::API::V3::Services::Preferences::ForOrganization, set_app: true do
+  let(:organization) { Travis::API::V3::Models::Organization.create!(name: 'travis-ci') }
+  let(:user) { Travis::API::V3::Models::User.create!(name: 'svenfuchs') }
+  let(:token) { Travis::Api::App::AccessToken.create(user: user, app_id: 1) }
+  let(:auth_headers) { { 'HTTP_AUTHORIZATION' => "token #{token}" } }
+  let(:json_headers) { { 'CONTENT_TYPE' => 'application/json' } }
+  let(:path) { "/v3/org/#{organization.id}/preferences" }
+
+  describe 'not authenticated' do
+    let(:last_response) { get(path) }
+    include_examples 'not authenticated'
+  end
+
+  describe 'authenticated' do
+    let(:last_response) { get(path, {}, auth_headers) }
+
+    describe 'organization does not exist' do
+      let(:path) { '/v3/org/99999999/preferences' }
+      it { expect(last_response.status).to eq(404) }
+    end
+
+    describe 'user is not a member' do
+      it { expect(last_response.status).to eq(404) }
+      it { expect(parsed_body['error_message']).to include('insufficient access')}
+    end
+
+    describe 'user is a member' do
+      before { organization.memberships.create!(user: user, role: role) }
+
+      describe 'as a regular member' do
+        let(:role) { 'member' }
+        it { expect(last_response.status).to eq(404) }
+        it { expect(parsed_body['error_message']).to include('insufficient access')}
+      end
+
+      describe 'as an admin' do
+        let(:role) { 'admin' }
+
+        example { expect(last_response.status).to eq(200) }
+
+        describe 'no preferences have been set yet' do
+          it 'returns the defaults' do
+            expect(parsed_body).to eql_json(
+              "@type" => "preferences",
+              "@href" => path,
+              "@representation" => "standard",
+              "preferences" => [
+                {
+                  "@type" => "preference",
+                  "@href" => "/v3/preference/public_insights", # needs to change
+                  "@representation" => "standard",
+                  "name" => "public_insights",
+                  "value" => false
+                }, {
+                  "@type" => "preference",
+                  "@href" => "/v3/preference/members_insights", # needs to change
+                  "@representation" => "standard",
+                  "name" => "members_insights",
+                  "value" => false
+                }
+              ]
+            )
+          end
+        end
+
+        describe 'some preference has been set' do
+          before do
+            organization.preferences.update(:members_insights, true)
+          end
+
+          it 'returns the set value merged with the defaults' do
+            expect(parsed_body).to eql_json(
+              "@type" => "preferences",
+              "@href" => path,
+              "@representation" => "standard",
+              "preferences" => [
+                {
+                  "@type" => "preference",
+                  "@href" => "/v3/preference/public_insights", # needs to change
+                  "@representation" => "standard",
+                  "name" => "public_insights",
+                  "value" => false
+                }, {
+                  "@type" => "preference",
+                  "@href" => "/v3/preference/members_insights", # needs to change
+                  "@representation" => "standard",
+                  "name" => "members_insights",
+                  "value" => true
+                }
+              ]
+            )
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/v3/services/preferences/for_organization_spec.rb
+++ b/spec/v3/services/preferences/for_organization_spec.rb
@@ -47,16 +47,10 @@ describe Travis::API::V3::Services::Preferences::ForOrganization, set_app: true 
               "preferences" => [
                 {
                   "@type" => "preference",
-                  "@href" => "/v3/preference/public_insights", # needs to change
+                  "@href" => "/v3/preference/private_insights_visibility", # needs to change
                   "@representation" => "standard",
-                  "name" => "public_insights",
-                  "value" => false
-                }, {
-                  "@type" => "preference",
-                  "@href" => "/v3/preference/members_insights", # needs to change
-                  "@representation" => "standard",
-                  "name" => "members_insights",
-                  "value" => false
+                  "name" => "private_insights_visibility",
+                  "value" => "admins"
                 }
               ]
             )
@@ -65,7 +59,7 @@ describe Travis::API::V3::Services::Preferences::ForOrganization, set_app: true 
 
         describe 'some preference has been set' do
           before do
-            organization.preferences.update(:members_insights, true)
+            organization.preferences.update(:private_insights_visibility, 'members')
           end
 
           it 'returns the set value merged with the defaults' do
@@ -76,16 +70,10 @@ describe Travis::API::V3::Services::Preferences::ForOrganization, set_app: true 
               "preferences" => [
                 {
                   "@type" => "preference",
-                  "@href" => "/v3/preference/public_insights", # needs to change
+                  "@href" => "/v3/preference/private_insights_visibility", # needs to change
                   "@representation" => "standard",
-                  "name" => "public_insights",
-                  "value" => false
-                }, {
-                  "@type" => "preference",
-                  "@href" => "/v3/preference/members_insights", # needs to change
-                  "@representation" => "standard",
-                  "name" => "members_insights",
-                  "value" => true
+                  "name" => "private_insights_visibility",
+                  "value" => "members"
                 }
               ]
             )

--- a/spec/v3/services/preferences/for_user_spec.rb
+++ b/spec/v3/services/preferences/for_user_spec.rb
@@ -26,6 +26,12 @@ describe Travis::API::V3::Services::Preferences::ForUser, set_app: true do
             "@representation" => "standard",
             "name" => "build_emails",
             "value" => true
+          }, {
+            "@type" => "preference",
+            "@href" => "/v3/preference/public_insights",
+            "@representation" => "standard",
+            "name" => "public_insights",
+            "value" => false
           }
         ]
       )
@@ -51,6 +57,12 @@ describe Travis::API::V3::Services::Preferences::ForUser, set_app: true do
             "@href" => "/v3/preference/build_emails",
             "@representation" => "standard",
             "name" => "build_emails",
+            "value" => false
+          }, {
+            "@type" => "preference",
+            "@href" => "/v3/preference/public_insights",
+            "@representation" => "standard",
+            "name" => "public_insights",
             "value" => false
           }
         ]

--- a/spec/v3/services/preferences/for_user_spec.rb
+++ b/spec/v3/services/preferences/for_user_spec.rb
@@ -40,8 +40,8 @@ describe Travis::API::V3::Services::Preferences::ForUser, set_app: true do
 
   describe 'authenticated, user has prefs' do
     before do
-      user.user_preferences.update(:build_emails, false)
-      user.user_preferences.update(:private_insights_visibility, 'public')
+      user.preferences.update(:build_emails, false)
+      user.preferences.update(:private_insights_visibility, 'public')
       get("/v3/preferences", {}, auth_headers)
     end
 

--- a/spec/v3/services/preferences/for_user_spec.rb
+++ b/spec/v3/services/preferences/for_user_spec.rb
@@ -28,10 +28,10 @@ describe Travis::API::V3::Services::Preferences::ForUser, set_app: true do
             "value" => true
           }, {
             "@type" => "preference",
-            "@href" => "/v3/preference/public_insights",
+            "@href" => "/v3/preference/private_insights_visibility",
             "@representation" => "standard",
-            "name" => "public_insights",
-            "value" => false
+            "name" => "private_insights_visibility",
+            "value" => "private"
           }
         ]
       )
@@ -41,6 +41,7 @@ describe Travis::API::V3::Services::Preferences::ForUser, set_app: true do
   describe 'authenticated, user has prefs' do
     before do
       user.user_preferences.update(:build_emails, false)
+      user.user_preferences.update(:private_insights_visibility, 'public')
       get("/v3/preferences", {}, auth_headers)
     end
 
@@ -60,10 +61,10 @@ describe Travis::API::V3::Services::Preferences::ForUser, set_app: true do
             "value" => false
           }, {
             "@type" => "preference",
-            "@href" => "/v3/preference/public_insights",
+            "@href" => "/v3/preference/private_insights_visibility",
             "@representation" => "standard",
-            "name" => "public_insights",
-            "value" => false
+            "name" => "private_insights_visibility",
+            "value" => "public"
           }
         ]
       )


### PR DESCRIPTION
Includes a refactoring I'd like some of you to review: I extracted the wiring of a preferences method to a [_"macro-style"_ class method](https://github.com/travis-ci/travis-api/pull/872/files#diff-1964519b6dd1a6efb1338ffd7d3a058eR5), and did a small change so that all the pieces involved use the [`[]` accessor](https://github.com/travis-ci/travis-api/pull/872/files#diff-1964519b6dd1a6efb1338ffd7d3a058eR7) instead of [calling the method](https://github.com/travis-ci/travis-api/pull/872/files#diff-5db9038dc48b5008aed142437f6148dfL49) (also [here](https://github.com/travis-ci/travis-api/pull/872/files#diff-ab3df38df414689fc3b4d01f7c5868f8L8)), so that the preferences method can have the same name as the column (and it _shadows_ it, disallowing unintended access to the raw data).

Depends on: https://github.com/travis-ci/travis-migrations/pull/166 (and its follow-ups).

Next steps: providing API to update these preferences. In this context, the reading code already return a [URL for that, which is wrong](https://github.com/travis-ci/travis-api/pull/872/files#diff-ab4d05f5db9d4e0d73837af3c1e341f3R50). I didn't bother to fix it in this PR (it's not possible to update anyway) because I think it makes more sense to fix that together with the ability to actually change them.