### PR TITLE
Render an error when setting an invalid preference

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -88,6 +88,7 @@ group :test do
   gem 'timecop',       '~> 0.8.0'
   gem 'webmock'
   gem 'hashdiff'
+  gem 'pry-byebug'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -131,6 +131,7 @@ GEM
     builder (3.2.3)
     bunny (2.9.2)
       amq-protocol (~> 2.3.0)
+    byebug (10.0.2)
     coder (0.4.0)
     coderay (1.1.1)
     coercible (1.0.0)
@@ -291,6 +292,9 @@ GEM
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
       slop (~> 3.4)
+    pry-byebug (3.6.0)
+      byebug (~> 10.0)
+      pry (~> 0.10)
     public_suffix (3.0.3)
     pusher (0.14.6)
       httpclient (~> 2.5)
@@ -446,6 +450,7 @@ DEPENDENCIES
   opencensus-stackdriver
   pg (~> 0.21)
   pry
+  pry-byebug
   pusher (~> 0.14.0)
   rack-attack (= 5.0.0.beta1)
   rack-cache!

--- a/lib/travis/api/v3/access_control/generic.rb
+++ b/lib/travis/api/v3/access_control/generic.rb
@@ -142,8 +142,10 @@ module Travis::API::V3
     end
 
     def preferences_visible?(preferences)
-      true
+      adminable? preferences.parent
     end
+    alias_method :user_preferences_visible?, :preferences_visible?
+    alias_method :organization_preferences_visible?, :preferences_visible?
 
     def organization_visible?(organization)
       full_access? or public_mode?(organization)

--- a/lib/travis/api/v3/access_control/generic.rb
+++ b/lib/travis/api/v3/access_control/generic.rb
@@ -146,6 +146,7 @@ module Travis::API::V3
     end
     alias_method :user_preferences_visible?, :preferences_visible?
     alias_method :organization_preferences_visible?, :preferences_visible?
+    alias_method :preference_visible?, :preferences_visible?
 
     def organization_visible?(organization)
       full_access? or public_mode?(organization)

--- a/lib/travis/api/v3/extensions/preferences.rb
+++ b/lib/travis/api/v3/extensions/preferences.rb
@@ -1,0 +1,17 @@
+module Travis::API::V3
+  module Extensions
+    module Preferences
+      module ClassMethods
+        def has_preferences(klass, column: :preferences, method_name: :preferences)
+          define_method method_name do
+            klass.new(self[column]).tap { |prefs| prefs.sync(self, column) }
+          end
+        end
+      end
+
+      def self.included(base)
+        base.extend(ClassMethods)
+      end
+    end
+  end
+end

--- a/lib/travis/api/v3/model.rb
+++ b/lib/travis/api/v3/model.rb
@@ -1,6 +1,8 @@
 module Travis::API::V3
   class Model < ActiveRecord::Base
     include Extensions::BelongsTo
+    include Extensions::Preferences
+
     self.abstract_class = true
 
     def self.===(other)

--- a/lib/travis/api/v3/models/json_slice.rb
+++ b/lib/travis/api/v3/models/json_slice.rb
@@ -2,7 +2,7 @@ require_relative './json_sync'
 
 module Travis::API::V3
   class Models::JsonSlice
-    include Virtus.model, Enumerable, Models::JsonSync
+    include Virtus.model, Enumerable, Models::JsonSync, ActiveModel::Model
 
     class << self
       attr_accessor :child_klass

--- a/lib/travis/api/v3/models/json_slice.rb
+++ b/lib/travis/api/v3/models/json_slice.rb
@@ -2,7 +2,7 @@ require_relative './json_sync'
 
 module Travis::API::V3
   class Models::JsonSlice
-    include Virtus.model, Enumerable, Models::JsonSync, ActiveModel::Model
+    include Virtus.model, Enumerable, Models::JsonSync, ActiveModel::Validations
 
     class << self
       attr_accessor :child_klass

--- a/lib/travis/api/v3/models/json_slice.rb
+++ b/lib/travis/api/v3/models/json_slice.rb
@@ -31,6 +31,7 @@ module Travis::API::V3
     def update(name, value)
       raise NotFound unless respond_to?(:"#{name}=")
       send(:"#{name}=", value)
+      raise UnprocessableEntity, errors.full_messages.to_sentence unless valid?
       sync!
       read(name)
     end

--- a/lib/travis/api/v3/models/json_slice.rb
+++ b/lib/travis/api/v3/models/json_slice.rb
@@ -23,11 +23,13 @@ module Travis::API::V3
     end
 
     def read(name)
+      raise NotFound unless respond_to?(name)
       value = send(name)
       child_klass.new(name, value, parent) unless value.nil?
     end
 
     def update(name, value)
+      raise NotFound unless respond_to?(:"#{name}=")
       send(:"#{name}=", value)
       sync!
       read(name)

--- a/lib/travis/api/v3/models/json_sync.rb
+++ b/lib/travis/api/v3/models/json_sync.rb
@@ -5,8 +5,8 @@ module Travis::API::V3
     def sync(parent, attr)
       @parent, @attr = parent, attr
       @sync = -> do
-        previous = @parent.send(@attr) || {}
-        @parent.send("#{@attr}=", previous.merge(to_h).to_json)
+        previous = @parent[@attr] || {}
+        @parent[@attr] = previous.merge(to_h).to_json
         @parent.save!
       end
     end

--- a/lib/travis/api/v3/models/organization.rb
+++ b/lib/travis/api/v3/models/organization.rb
@@ -1,7 +1,11 @@
+require 'travis/api/v3/models/organization_preferences'
+
 module Travis::API::V3
   class Models::Organization < Model
     has_many :memberships
     has_many :users, through: :memberships
+
+    has_preferences Models::OrganizationPreferences
 
     def repositories
       Models::Repository.where(owner_type: 'Organization', owner_id: id)

--- a/lib/travis/api/v3/models/organization_preferences.rb
+++ b/lib/travis/api/v3/models/organization_preferences.rb
@@ -1,0 +1,10 @@
+require 'travis/api/v3/models/preference'
+
+module Travis::API::V3
+  class Models::OrganizationPreferences < Models::JsonSlice
+    child Models::Preference
+
+    attribute :public_insights, Boolean, default: false
+    attribute :members_insights, Boolean, default: false
+  end
+end

--- a/lib/travis/api/v3/models/organization_preferences.rb
+++ b/lib/travis/api/v3/models/organization_preferences.rb
@@ -8,6 +8,6 @@ module Travis::API::V3
     # only admins, all members of the organization, or everybody (public) (note:
     # insights about public repositories are always public)
     attribute :private_insights_visibility, String, default: 'admins'
-    validates :private_insights_visibility, inclusion: %w{admins members public}
+    validates :private_insights_visibility, inclusion: { in: %w{admins members public}, message: "'%{value}' is not allowed" }
   end
 end

--- a/lib/travis/api/v3/models/organization_preferences.rb
+++ b/lib/travis/api/v3/models/organization_preferences.rb
@@ -4,7 +4,10 @@ module Travis::API::V3
   class Models::OrganizationPreferences < Models::JsonSlice
     child Models::Preference
 
-    attribute :public_insights, Boolean, default: false
-    attribute :members_insights, Boolean, default: false
+    # whether to show insights about the organization's private repositories to
+    # only admins, all members of the organization, or everybody (public) (note:
+    # insights about public repositories are always public)
+    attribute :private_insights_visibility, String, default: 'admins'
+    validates :private_insights_visibility, inclusion: %w{admins members public}
   end
 end

--- a/lib/travis/api/v3/models/preferences.rb
+++ b/lib/travis/api/v3/models/preferences.rb
@@ -3,5 +3,6 @@ module Travis::API::V3
     child Models::Preference
 
     attribute :build_emails, Boolean, default: true
+    attribute :public_insights, Boolean, default: false
   end
 end

--- a/lib/travis/api/v3/models/preferences.rb
+++ b/lib/travis/api/v3/models/preferences.rb
@@ -3,6 +3,11 @@ module Travis::API::V3
     child Models::Preference
 
     attribute :build_emails, Boolean, default: true
-    attribute :public_insights, Boolean, default: false
+
+    # whether to show insights about the user's private repositories to
+    # everybody or keep them only for the user (note: insights about public
+    # repositories are always public)
+    attribute :private_insights_visibility, String, default: 'private'
+    validates :private_insights_visibility, inclusion: %w{private public}
   end
 end

--- a/lib/travis/api/v3/models/user.rb
+++ b/lib/travis/api/v3/models/user.rb
@@ -1,3 +1,5 @@
+require 'travis/api/v3/models/user_preferences'
+
 module Travis::API::V3
   class Models::User < Model
     has_many :memberships,   dependent: :destroy
@@ -9,6 +11,8 @@ module Travis::API::V3
     has_many :email_unsubscribes
     has_many :user_beta_features
     has_many :beta_features, through: :user_beta_features
+
+    has_preferences Models::UserPreferences
 
     serialize :github_oauth_token, Travis::Model::EncryptedColumn.new
     scope :with_github_token, -> { where('github_oauth_token IS NOT NULL')}
@@ -43,10 +47,6 @@ module Travis::API::V3
     def installation
       return @installation if defined? @installation
       @installation = Models::Installation.find_by(owner_type: 'User', owner_id: id, removed_by_id: nil)
-    end
-
-    def user_preferences
-      Models::Preferences.new(preferences).tap { |prefs| prefs.sync(self, :preferences) }
     end
   end
 end

--- a/lib/travis/api/v3/models/user_preferences.rb
+++ b/lib/travis/api/v3/models/user_preferences.rb
@@ -1,5 +1,7 @@
+require 'travis/api/v3/models/preference'
+
 module Travis::API::V3
-  class Models::Preferences < Models::JsonSlice
+  class Models::UserPreferences < Models::JsonSlice
     child Models::Preference
 
     attribute :build_emails, Boolean, default: true

--- a/lib/travis/api/v3/models/user_preferences.rb
+++ b/lib/travis/api/v3/models/user_preferences.rb
@@ -10,6 +10,6 @@ module Travis::API::V3
     # everybody or keep them only for the user (note: insights about public
     # repositories are always public)
     attribute :private_insights_visibility, String, default: 'private'
-    validates :private_insights_visibility, inclusion: %w{private public}
+    validates :private_insights_visibility, inclusion: { in: %w{private public}, message: "'%{value}' is not allowed" }
   end
 end

--- a/lib/travis/api/v3/queries/preference.rb
+++ b/lib/travis/api/v3/queries/preference.rb
@@ -3,11 +3,11 @@ module Travis::API::V3
     params :name, :value, prefix: :preference
 
     def find(user)
-      user.user_preferences.read(name)
+      user.preferences.read(name)
     end
 
     def update(user)
-      user.user_preferences.update(name, value)
+      user.preferences.update(name, value)
     end
   end
 end

--- a/lib/travis/api/v3/queries/preference.rb
+++ b/lib/travis/api/v3/queries/preference.rb
@@ -2,12 +2,12 @@ module Travis::API::V3
   class Queries::Preference < Query
     params :name, :value, prefix: :preference
 
-    def find(user)
-      user.preferences.read(name)
+    def find(owner)
+      owner.preferences.read(name)
     end
 
-    def update(user)
-      user.preferences.update(name, value)
+    def update(owner)
+      owner.preferences.update(name, value)
     end
   end
 end

--- a/lib/travis/api/v3/queries/preferences.rb
+++ b/lib/travis/api/v3/queries/preferences.rb
@@ -1,7 +1,7 @@
 module Travis::API::V3
   class Queries::Preferences < Query
-    def find(user)
-      user.user_preferences
+    def find(owner)
+      owner.preferences
     end
   end
 end

--- a/lib/travis/api/v3/renderer/preference.rb
+++ b/lib/travis/api/v3/renderer/preference.rb
@@ -4,11 +4,15 @@ module Travis::API::V3
     representation :standard, :name, :value
     representation :minimal, *representations[:standard]
 
+    # TODO: I couldn't make the framework generate the URL so I'm hardcoding it :_(
     def href
-      Renderer.href(:preference,
-        :"preference.name" => name,
-        :"script_name" => script_name
-      )
+      case model.parent
+      when Models::User
+        "/v3/preference/#{name}"
+      when Models::Organization
+        "/v3/org/#{model.parent.id}/preference/#{name}"
+        # or maybe `super` ??
+      end
     end
   end
 end

--- a/lib/travis/api/v3/routes.rb
+++ b/lib/travis/api/v3/routes.rb
@@ -83,6 +83,11 @@ module Travis::API::V3
       capture id: :digit
       route '/org/{organization.id}'
       get :find
+
+      resource :preferences do
+        route '/preferences'
+        get :for_organization
+      end
     end
 
     resource :organizations do

--- a/lib/travis/api/v3/routes.rb
+++ b/lib/travis/api/v3/routes.rb
@@ -88,6 +88,11 @@ module Travis::API::V3
         route '/preferences'
         get :for_organization
       end
+
+      resource :preference do
+        route '/preference/{preference.name}'
+        get :for_organization
+      end
     end
 
     resource :organizations do

--- a/lib/travis/api/v3/routes.rb
+++ b/lib/travis/api/v3/routes.rb
@@ -91,7 +91,8 @@ module Travis::API::V3
 
       resource :preference do
         route '/preference/{preference.name}'
-        get :for_organization
+        get   :for_organization
+        patch :update
       end
     end
 

--- a/lib/travis/api/v3/services/preference/for_organization.rb
+++ b/lib/travis/api/v3/services/preference/for_organization.rb
@@ -1,0 +1,8 @@
+module Travis::API::V3
+  class Services::Preference::ForOrganization < Service
+    def run!
+      organization = check_login_and_find(:organization)
+      result find(:preference, organization)
+    end
+  end
+end

--- a/lib/travis/api/v3/services/preference/update.rb
+++ b/lib/travis/api/v3/services/preference/update.rb
@@ -3,8 +3,9 @@ module Travis::API::V3
     params :value, prefix: :preference
 
     def run!
-      user = access_control.user or raise LoginRequired
-      result query.update(user)
+      owner = access_control.user or raise LoginRequired
+      owner = find(:organization) if params['organization.id']
+      result query.update(owner) if access_control.adminable?(owner)
     end
   end
 end

--- a/lib/travis/api/v3/services/preferences/for_organization.rb
+++ b/lib/travis/api/v3/services/preferences/for_organization.rb
@@ -1,0 +1,9 @@
+module Travis::API::V3
+  class Services::Preferences::ForOrganization < Service
+    def run!
+      organization = check_login_and_find(:organization)
+      prefs = find(:preferences, organization)
+      result prefs
+    end
+  end
+end

--- a/spec/v3/services/preference/find_spec.rb
+++ b/spec/v3/services/preference/find_spec.rb
@@ -25,7 +25,7 @@ describe Travis::API::V3::Services::Preference::Find, set_app: true do
 
   describe 'authenticated, pref found' do
     before do
-      user.user_preferences.update(:build_emails, false)
+      user.preferences.update(:build_emails, false)
       get("/v3/preference/build_emails", {}, auth_headers)
     end
 

--- a/spec/v3/services/preference/for_organization_spec.rb
+++ b/spec/v3/services/preference/for_organization_spec.rb
@@ -1,10 +1,11 @@
-describe Travis::API::V3::Services::Preferences::ForOrganization, set_app: true do
+describe Travis::API::V3::Services::Preference::ForOrganization, set_app: true do
   let(:organization) { Travis::API::V3::Models::Organization.create!(name: 'travis-ci') }
   let(:user) { Travis::API::V3::Models::User.create!(name: 'svenfuchs') }
   let(:token) { Travis::Api::App::AccessToken.create(user: user, app_id: 1) }
   let(:auth_headers) { { 'HTTP_AUTHORIZATION' => "token #{token}" } }
   let(:json_headers) { { 'CONTENT_TYPE' => 'application/json' } }
-  let(:path) { "/v3/org/#{organization.id}/preferences" }
+  let(:preference_name) { 'private_insights_visibility' }
+  let(:path) { "/v3/org/#{organization.id}/preference/#{preference_name}" }
 
   describe 'not authenticated' do
     let(:last_response) { get(path) }
@@ -41,18 +42,11 @@ describe Travis::API::V3::Services::Preferences::ForOrganization, set_app: true 
         describe 'no preferences have been set yet' do
           it 'returns the defaults' do
             expect(parsed_body).to eql_json(
-              "@type" => "preferences",
+              "@type" => "preference",
               "@href" => path,
               "@representation" => "standard",
-              "preferences" => [
-                {
-                  "@type" => "preference",
-                  "@href" => "/v3/org/#{organization.id}/preference/private_insights_visibility",
-                  "@representation" => "standard",
-                  "name" => "private_insights_visibility",
-                  "value" => "admins"
-                }
-              ]
+              "name" => "private_insights_visibility",
+              "value" => "admins"
             )
           end
         end
@@ -64,18 +58,11 @@ describe Travis::API::V3::Services::Preferences::ForOrganization, set_app: true 
 
           it 'returns the set value merged with the defaults' do
             expect(parsed_body).to eql_json(
-              "@type" => "preferences",
+              "@type" => "preference",
               "@href" => path,
               "@representation" => "standard",
-              "preferences" => [
-                {
-                  "@type" => "preference",
-                  "@href" => "/v3/org/#{organization.id}/preference/private_insights_visibility",
-                  "@representation" => "standard",
-                  "name" => "private_insights_visibility",
-                  "value" => "members"
-                }
-              ]
+              "name" => "private_insights_visibility",
+              "value" => "members"
             )
           end
         end

--- a/spec/v3/services/preference/for_organization_spec.rb
+++ b/spec/v3/services/preference/for_organization_spec.rb
@@ -16,7 +16,7 @@ describe Travis::API::V3::Services::Preference::ForOrganization, set_app: true d
     let(:last_response) { get(path, {}, auth_headers) }
 
     describe 'organization does not exist' do
-      let(:path) { '/v3/org/99999999/preferences' }
+      let(:path) { "/v3/org/99999999/preference/#{preference_name}" }
       it { expect(last_response.status).to eq(404) }
     end
 
@@ -65,6 +65,11 @@ describe Travis::API::V3::Services::Preference::ForOrganization, set_app: true d
               "value" => "members"
             )
           end
+        end
+
+        describe 'preference name is mispelled' do
+          let(:preference_name) { 'does-not-exist' }
+          it { expect(last_response.status).to eq(404) }
         end
       end
     end

--- a/spec/v3/services/preference/update_spec.rb
+++ b/spec/v3/services/preference/update_spec.rb
@@ -26,6 +26,7 @@ describe Travis::API::V3::Services::Preference::Update, set_app: true do
         "value" => false
       )
     end
+    example 'PENDING: Return validation error'
     example do
       expect(user.github_oauth_token).to eq github_oauth_token
     end

--- a/spec/v3/services/preference/update_spec.rb
+++ b/spec/v3/services/preference/update_spec.rb
@@ -3,32 +3,110 @@ describe Travis::API::V3::Services::Preference::Update, set_app: true do
   let(:user) { Travis::API::V3::Models::User.create!(name: 'svenfuchs', github_oauth_token: github_oauth_token) }
   let(:token) { Travis::Api::App::AccessToken.create(user: user, app_id: 1) }
   let(:headers) { { 'HTTP_AUTHORIZATION' => "token #{token}", 'CONTENT_TYPE' => 'application/json' } }
-  let(:params) { JSON.dump('preference.value' => false) }
+  let(:params) { JSON.dump('preference.value' => preference_value) }
 
-  describe 'not authenticated' do
-    before do
-      patch("/v3/preference/build_emails")
-    end
-    include_examples 'not authenticated'
+  example do
+    expect(user.github_oauth_token).to eq github_oauth_token
   end
 
-  describe 'authenticated' do
-    before do
-      patch("/v3/preference/build_emails", params, headers)
+  describe 'for user' do
+    let(:path) { "/v3/preference/build_emails" }
+    let(:preference_value) { false }
+
+    describe 'not authenticated' do
+      let(:last_response) { patch(path) }
+      include_examples 'not authenticated'
+
+      it 'does not update the value' do
+        expect { last_response }.to_not change { user.reload.preferences.build_emails }
+      end
     end
-    example { expect(last_response.status).to eq 200 }
-    example do
-      expect(parsed_body).to eql_json(
-        "@type" => "preference",
-        "@href" => "/v3/preference/build_emails",
-        "@representation" => "standard",
-        "name" => "build_emails",
-        "value" => false
-      )
+
+    describe 'authenticated' do
+      let(:last_response) { patch(path, params, headers) }
+
+      it 'updates the value' do
+        expect { last_response }.to change { user.reload.preferences.build_emails }.from(true).to(false)
+      end
+
+      it 'renders the updated value' do
+        expect(last_response.status).to eq 200
+        expect(parsed_body).to eql_json(
+          "@type" => "preference",
+          "@href" => "/v3/preference/build_emails",
+          "@representation" => "standard",
+          "name" => "build_emails",
+          "value" => false
+        )
+      end
     end
+  end
+
+  describe 'for organization' do
+    let(:organization) { Travis::API::V3::Models::Organization.create!(name: 'travis-ci') }
+    let(:path) { "/v3/org/#{organization.id}/preference/private_insights_visibility" }
+    let(:preference_value) { 'public' }
+
+    describe 'not authenticated' do
+      let(:last_response) { patch(path) }
+      include_examples 'not authenticated'
+
+      it 'does not update the value' do
+        expect { last_response }.to_not change { organization.reload.preferences.private_insights_visibility }
+      end
+    end
+
     example 'PENDING: Return validation error'
-    example do
-      expect(user.github_oauth_token).to eq github_oauth_token
+
+    describe 'authenticated' do
+      let(:last_response) { patch(path, params, headers) }
+
+      describe 'organization does not exist' do
+        let(:path) { "/v3/org/99999999/preference/private_insights_visibility" }
+        it { expect(last_response.status).to eq(404) }
+      end
+
+      describe 'user is not a member' do
+        it { expect(last_response.status).to eq(404) }
+        it { expect(parsed_body['error_message']).to include('insufficient access')}
+
+        it 'does not update the value' do
+          expect { last_response }.to_not change { organization.reload.preferences.private_insights_visibility }
+        end
+      end
+
+      describe 'user is a member' do
+        before { organization.memberships.create!(user: user, role: role) }
+
+        describe 'as a regular member' do
+          let(:role) { 'member' }
+          it { expect(last_response.status).to eq(404) }
+          it { expect(parsed_body['error_message']).to include('insufficient access')}
+
+          it 'does not update the value' do
+            expect { last_response }.to_not change { organization.reload.preferences.private_insights_visibility }
+          end
+        end
+
+        describe 'as an admin' do
+          let(:role) { 'admin' }
+
+          it 'updates the value' do
+            expect { last_response }.to change { organization.reload.preferences.private_insights_visibility }.from('admins').to('public')
+          end
+
+          it 'renders the updated value' do
+            expect(last_response.status).to eq(200)
+            expect(parsed_body).to eql_json(
+              "@type" => "preference",
+              "@href" => path,
+              "@representation" => "standard",
+              "name" => "private_insights_visibility",
+              "value" => "public"
+            )
+          end
+        end
+      end
     end
   end
 end

--- a/spec/v3/services/preference/update_spec.rb
+++ b/spec/v3/services/preference/update_spec.rb
@@ -56,8 +56,6 @@ describe Travis::API::V3::Services::Preference::Update, set_app: true do
       end
     end
 
-    example 'PENDING: Return validation error'
-
     describe 'authenticated' do
       let(:last_response) { patch(path, params, headers) }
 
@@ -104,6 +102,23 @@ describe Travis::API::V3::Services::Preference::Update, set_app: true do
               "name" => "private_insights_visibility",
               "value" => "public"
             )
+          end
+
+          context 'the updated value is not valid' do
+            let(:preference_value) { 'bananas' }
+
+            it 'does not update the value' do
+              expect { last_response }.to_not change { organization.reload.preferences.private_insights_visibility }
+            end
+
+            it 'renders an error' do
+              expect(last_response.status).to eq(422)
+              expect(parsed_body).to eql_json(
+                "@type" => "error",
+                "error_type" => "unprocessable_entity",
+                "error_message" => "Private insights visibility 'bananas' is not allowed"
+              )
+            end
           end
         end
       end

--- a/spec/v3/services/preferences/for_organization_spec.rb
+++ b/spec/v3/services/preferences/for_organization_spec.rb
@@ -1,0 +1,97 @@
+describe Travis::API::V3::Services::Preferences::ForOrganization, set_app: true do
+  let(:organization) { Travis::API::V3::Models::Organization.create!(name: 'travis-ci') }
+  let(:user) { Travis::API::V3::Models::User.create!(name: 'svenfuchs') }
+  let(:token) { Travis::Api::App::AccessToken.create(user: user, app_id: 1) }
+  let(:auth_headers) { { 'HTTP_AUTHORIZATION' => "token #{token}" } }
+  let(:json_headers) { { 'CONTENT_TYPE' => 'application/json' } }
+  let(:path) { "/v3/org/#{organization.id}/preferences" }
+
+  describe 'not authenticated' do
+    let(:last_response) { get(path) }
+    include_examples 'not authenticated'
+  end
+
+  describe 'authenticated' do
+    let(:last_response) { get(path, {}, auth_headers) }
+
+    describe 'organization does not exist' do
+      let(:path) { '/v3/org/99999999/preferences' }
+      it { expect(last_response.status).to eq(404) }
+    end
+
+    describe 'user is not a member' do
+      it { expect(last_response.status).to eq(404) }
+      it { expect(parsed_body['error_message']).to include('insufficient access')}
+    end
+
+    describe 'user is a member' do
+      before { organization.memberships.create!(user: user, role: role) }
+
+      describe 'as a regular member' do
+        let(:role) { 'member' }
+        it { expect(last_response.status).to eq(404) }
+        it { expect(parsed_body['error_message']).to include('insufficient access')}
+      end
+
+      describe 'as an admin' do
+        let(:role) { 'admin' }
+
+        example { expect(last_response.status).to eq(200) }
+
+        describe 'no preferences have been set yet' do
+          it 'returns the defaults' do
+            expect(parsed_body).to eql_json(
+              "@type" => "preferences",
+              "@href" => path,
+              "@representation" => "standard",
+              "preferences" => [
+                {
+                  "@type" => "preference",
+                  "@href" => "/v3/preference/public_insights", # needs to change
+                  "@representation" => "standard",
+                  "name" => "public_insights",
+                  "value" => false
+                }, {
+                  "@type" => "preference",
+                  "@href" => "/v3/preference/members_insights", # needs to change
+                  "@representation" => "standard",
+                  "name" => "members_insights",
+                  "value" => false
+                }
+              ]
+            )
+          end
+        end
+
+        describe 'some preference has been set' do
+          before do
+            organization.preferences.update(:members_insights, true)
+          end
+
+          it 'returns the set value merged with the defaults' do
+            expect(parsed_body).to eql_json(
+              "@type" => "preferences",
+              "@href" => path,
+              "@representation" => "standard",
+              "preferences" => [
+                {
+                  "@type" => "preference",
+                  "@href" => "/v3/preference/public_insights", # needs to change
+                  "@representation" => "standard",
+                  "name" => "public_insights",
+                  "value" => false
+                }, {
+                  "@type" => "preference",
+                  "@href" => "/v3/preference/members_insights", # needs to change
+                  "@representation" => "standard",
+                  "name" => "members_insights",
+                  "value" => true
+                }
+              ]
+            )
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/v3/services/preferences/for_organization_spec.rb
+++ b/spec/v3/services/preferences/for_organization_spec.rb
@@ -47,16 +47,10 @@ describe Travis::API::V3::Services::Preferences::ForOrganization, set_app: true 
               "preferences" => [
                 {
                   "@type" => "preference",
-                  "@href" => "/v3/preference/public_insights", # needs to change
+                  "@href" => "/v3/preference/private_insights_visibility", # needs to change
                   "@representation" => "standard",
-                  "name" => "public_insights",
-                  "value" => false
-                }, {
-                  "@type" => "preference",
-                  "@href" => "/v3/preference/members_insights", # needs to change
-                  "@representation" => "standard",
-                  "name" => "members_insights",
-                  "value" => false
+                  "name" => "private_insights_visibility",
+                  "value" => "admins"
                 }
               ]
             )
@@ -65,7 +59,7 @@ describe Travis::API::V3::Services::Preferences::ForOrganization, set_app: true 
 
         describe 'some preference has been set' do
           before do
-            organization.preferences.update(:members_insights, true)
+            organization.preferences.update(:private_insights_visibility, 'members')
           end
 
           it 'returns the set value merged with the defaults' do
@@ -76,16 +70,10 @@ describe Travis::API::V3::Services::Preferences::ForOrganization, set_app: true 
               "preferences" => [
                 {
                   "@type" => "preference",
-                  "@href" => "/v3/preference/public_insights", # needs to change
+                  "@href" => "/v3/preference/private_insights_visibility", # needs to change
                   "@representation" => "standard",
-                  "name" => "public_insights",
-                  "value" => false
-                }, {
-                  "@type" => "preference",
-                  "@href" => "/v3/preference/members_insights", # needs to change
-                  "@representation" => "standard",
-                  "name" => "members_insights",
-                  "value" => true
+                  "name" => "private_insights_visibility",
+                  "value" => "members"
                 }
               ]
             )

--- a/spec/v3/services/preferences/for_user_spec.rb
+++ b/spec/v3/services/preferences/for_user_spec.rb
@@ -26,6 +26,12 @@ describe Travis::API::V3::Services::Preferences::ForUser, set_app: true do
             "@representation" => "standard",
             "name" => "build_emails",
             "value" => true
+          }, {
+            "@type" => "preference",
+            "@href" => "/v3/preference/public_insights",
+            "@representation" => "standard",
+            "name" => "public_insights",
+            "value" => false
           }
         ]
       )
@@ -51,6 +57,12 @@ describe Travis::API::V3::Services::Preferences::ForUser, set_app: true do
             "@href" => "/v3/preference/build_emails",
             "@representation" => "standard",
             "name" => "build_emails",
+            "value" => false
+          }, {
+            "@type" => "preference",
+            "@href" => "/v3/preference/public_insights",
+            "@representation" => "standard",
+            "name" => "public_insights",
             "value" => false
           }
         ]

--- a/spec/v3/services/preferences/for_user_spec.rb
+++ b/spec/v3/services/preferences/for_user_spec.rb
@@ -40,8 +40,8 @@ describe Travis::API::V3::Services::Preferences::ForUser, set_app: true do
 
   describe 'authenticated, user has prefs' do
     before do
-      user.user_preferences.update(:build_emails, false)
-      user.user_preferences.update(:private_insights_visibility, 'public')
+      user.preferences.update(:build_emails, false)
+      user.preferences.update(:private_insights_visibility, 'public')
       get("/v3/preferences", {}, auth_headers)
     end
 

--- a/spec/v3/services/preferences/for_user_spec.rb
+++ b/spec/v3/services/preferences/for_user_spec.rb
@@ -28,10 +28,10 @@ describe Travis::API::V3::Services::Preferences::ForUser, set_app: true do
             "value" => true
           }, {
             "@type" => "preference",
-            "@href" => "/v3/preference/public_insights",
+            "@href" => "/v3/preference/private_insights_visibility",
             "@representation" => "standard",
-            "name" => "public_insights",
-            "value" => false
+            "name" => "private_insights_visibility",
+            "value" => "private"
           }
         ]
       )
@@ -41,6 +41,7 @@ describe Travis::API::V3::Services::Preferences::ForUser, set_app: true do
   describe 'authenticated, user has prefs' do
     before do
       user.user_preferences.update(:build_emails, false)
+      user.user_preferences.update(:private_insights_visibility, 'public')
       get("/v3/preferences", {}, auth_headers)
     end
 
@@ -60,10 +61,10 @@ describe Travis::API::V3::Services::Preferences::ForUser, set_app: true do
             "value" => false
           }, {
             "@type" => "preference",
-            "@href" => "/v3/preference/public_insights",
+            "@href" => "/v3/preference/private_insights_visibility",
             "@representation" => "standard",
-            "name" => "public_insights",
-            "value" => false
+            "name" => "private_insights_visibility",
+            "value" => "public"
           }
         ]
       )


### PR DESCRIPTION
Based on #871, #872, #873 and #874, and also https://github.com/travis-ci/travis-migrations/pull/166 and https://github.com/travis-ci/travis-migrations/pull/167 (yes the original idea was easier review and deployment, in the end it accumulated a bit :roll_eyes:).

Note: The build is broken because the migration PRs need to get merged first.

### Documenting the endpoint

Once this is merged it will show up in the API docs, but in the meantime:

Accessing and updating the insights preferences is done similar to how the user's `build_emails` preference is used. The new preference is called `private_insights_visibility` and instead of a boolean it's a string. The accepted values are `'private'` and `'public'` for a user, and `'admins'`, `'members'` and `'public'` for an organization. The URLs are:

* `GET /v3/org/{org.id}/preferences` Get all organization's preferences
* `GET /v3/org/{org.id}/preference/private_insights_visibility` Get this specific preference
* `PATCH /v3/org/{org.id}/preference/private_insights_visibility` Update the preference
* `GET /v3/preferences` Get all current user's preferences
* `GET /v3/preference/private_insights_visibility` Get this specific preference for the current user
* `PATCH /v3/preference/private_insights_visibility` Update the preference for the current user

The expected payload when updating is, like in the case for `build_emails`, like this:

```json
{
  "preference.value": "members"
}
```