### PR TITLE
Add private flag to insights API

### DIFF
--- a/lib/travis/api/v3/services/insights/insights_proxy.rb
+++ b/lib/travis/api/v3/services/insights/insights_proxy.rb
@@ -10,6 +10,10 @@ module Travis::API::V3
     private
 
     def private_flag
+      params['private'] == 'true' && can_get_private?
+    end
+
+    def can_get_private?
       case owner.preferences.private_insights_visibility
       when 'public'
         true


### PR DESCRIPTION
A `private=true` param can be passed to Insights requests so that results include private insights, otherwise only public insights are returned. Permissions are still taken into account, so if a user without permissions sets the flag, they will only get public insights anyway.