### PR TITLE
Add github_service_hook attr to repos

### DIFF
--- a/lib/travis/api/v3/renderer/repository.rb
+++ b/lib/travis/api/v3/renderer/repository.rb
@@ -1,7 +1,7 @@
 module Travis::API::V3
   class Renderer::Repository < ModelRenderer
     representation(:minimal,  :id, :name, :slug)
-    representation(:standard, :id, :name, :slug, :description, :github_id, :github_language, :active, :private, :owner, :default_branch, :starred, :managed_by_installation, :active_on_org, :migration_status)
+    representation(:standard, :id, :name, :slug, :description, :github_id, :github_language, :active, :private, :owner, :default_branch, :starred, :managed_by_installation, :active_on_org, :migration_status, :github_service_hook)
     representation(:experimental, :id, :name, :slug, :description, :github_id, :github_language, :active, :private, :owner, :default_branch, :starred, :current_build, :last_started_build, :next_build_number)
     representation(:additional, :allow_migration)
 
@@ -9,6 +9,10 @@ module Travis::API::V3
 
     def self.available_attributes
       super.add('email_subscribed')
+    end
+
+    def github_service_hook
+      false
     end
 
     def active

--- a/spec/v3/services/owner/find_spec.rb
+++ b/spec/v3/services/owner/find_spec.rb
@@ -98,6 +98,7 @@ describe Travis::API::V3::Services::Owner::Find, set_app: true do
           "managed_by_installation"=>false,
           "active_on_org"     => nil,
           "migration_status"  => nil,
+          "github_service_hook" => false
         }]
       }}
     end
@@ -157,7 +158,8 @@ describe Travis::API::V3::Services::Owner::Find, set_app: true do
           "starred"         => false,
           "managed_by_installation"=>false,
           "active_on_org"   => nil,
-          "migration_status" => nil
+          "migration_status" => nil,
+          "github_service_hook" => false
         }]
       }}
     end

--- a/spec/v3/services/repositories/for_current_user_spec.rb
+++ b/spec/v3/services/repositories/for_current_user_spec.rb
@@ -71,7 +71,8 @@ describe Travis::API::V3::Services::Repositories::ForCurrentUser, set_app: true 
         "starred"            => false,
         "managed_by_installation"=>false,
         "active_on_org"=>nil,
-        "migration_status" => nil
+        "migration_status" => nil,
+        "github_service_hook" => false
         }]
     }}
   end

--- a/spec/v3/services/repositories/for_owner_spec.rb
+++ b/spec/v3/services/repositories/for_owner_spec.rb
@@ -92,7 +92,8 @@ describe Travis::API::V3::Services::Repositories::ForOwner, set_app: true do
           "starred"          => false,
           "managed_by_installation"=>false,
           "active_on_org"    => nil,
-          "migration_status" => nil
+          "migration_status" => nil,
+          "github_service_hook" => false
         }]}}
   end
 
@@ -139,6 +140,7 @@ describe Travis::API::V3::Services::Repositories::ForOwner, set_app: true do
         "managed_by_installation"=>false,
         "active_on_org"     => nil,
         "migration_status"  => nil,
+        "github_service_hook" => false,
         "last_started_build"=>{
           "@type"          =>"build",
           "@href"          =>"/v3/build/#{build.id}",
@@ -245,6 +247,7 @@ describe Travis::API::V3::Services::Repositories::ForOwner, set_app: true do
         "managed_by_installation"=> false,
         "active_on_org"    => nil,
         "migration_status" => nil,
+        "github_service_hook" => false,
         "current_build" => {
           "@type"               => "build",
           "@href"               => "/v3/build/#{build.id}",
@@ -396,7 +399,10 @@ describe Travis::API::V3::Services::Repositories::ForOwner, set_app: true do
         "starred"         => false,
         "managed_by_installation"=>false,
         "active_on_org"   => nil,
-        "migration_status" => nil}, {
+        "migration_status" => nil,
+        "github_service_hook" => false,
+      },
+      {
         "@type"           => "repository",
         "@href"           => "/v3/repo/#{repo2.id}",
         "@representation" => "standard",
@@ -431,10 +437,13 @@ describe Travis::API::V3::Services::Repositories::ForOwner, set_app: true do
           "@type"         => "branch",
           "@href"         => "/v3/repo/#{repo2.id}/branch/master",
           "@representation"=>"minimal",
-          "name"           =>"master" },
+          "name"           =>"master"
+        },
           "starred"        => false,
           "managed_by_installation"=>false,
-          "active_on_org"  =>nil,
-          "migration_status" => nil}]}
+          "active_on_org"  => nil,
+          "migration_status" => nil,
+          "github_service_hook" => false,
+      }]}
   end
 end

--- a/spec/v3/services/repository/find_spec.rb
+++ b/spec/v3/services/repository/find_spec.rb
@@ -94,7 +94,8 @@ describe Travis::API::V3::Services::Repository::Find, set_app: true do
       "starred"            => false,
       "active_on_org"      => nil,
       "managed_by_installation" => false,
-      "migration_status"   => nil
+      "migration_status"   => nil,
+      "github_service_hook" => false
     })}
   end
 


### PR DESCRIPTION
This allows us to display a web UI prompt if we could not migrate
a repo from service hooks to webhooks.

Database values are not yet populated – for now, this is a placeholder attribute that always returns false.