### PR TITLE
Add rake task to enable migration for opted-in users and other edits

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,4 +1,5 @@
 require "knapsack"
+Dir.glob('lib/tasks/*.rake').each { |r| import r }
 
 namespace :db do
   env = ENV["ENV"] || 'test'

--- a/lib/tasks/enable_repo_migration.rake
+++ b/lib/tasks/enable_repo_migration.rake
@@ -1,0 +1,30 @@
+$: << 'lib'
+# Command to run this task:
+# bundle exec rake merge:enable_allow_migration[10,true]
+# where you want 10 BetMigrationRequests to be processed,
+# and you want debug output to be printed
+require "redis"
+require "travis"
+require "travis/api/v3"
+
+namespace :merge do
+  desc "Enable repo migration for users and orgs"
+  task :enable_allow_migration, :num_requests, :debug do |task, args|
+    args.with_defaults(num_requests: 50, debug: false)
+    Travis::Database.connect
+
+    requests = Travis::API::V3::Models::BetaMigrationRequest.where(accepted_at: nil).limit(args[:num_requests])
+
+    puts "About to enable :allow_migration for #{requests.count} opted-in users and the organizations they selected."
+
+    requests.each do |request|
+       ActiveRecord::Base.transaction do
+        (request.organizations + [request.owner]).each do |owner|
+          Travis::Features.activate_owner(:allow_migration, owner)
+        end
+        request.update(accepted_at: DateTime.now)
+        puts "[Request ID: #{request.id}] Feature activated for Owner: #{request.owner_id} and orgs: #{request.organizations.pluck(:id)}" if args[:debug]
+      end
+    end
+  end
+end

--- a/lib/travis/api/v3/models/user.rb
+++ b/lib/travis/api/v3/models/user.rb
@@ -11,7 +11,7 @@ module Travis::API::V3
     has_many :email_unsubscribes
     has_many :user_beta_features
     has_many :beta_features, through: :user_beta_features
-    has_one  :beta_migration_request
+    has_many  :beta_migration_requests
 
     has_preferences Models::UserPreferences
 

--- a/lib/travis/api/v3/services/beta_migration_request/create.rb
+++ b/lib/travis/api/v3/services/beta_migration_request/create.rb
@@ -10,15 +10,8 @@ module Travis::API::V3
       beta_migration_request = query(:beta_migration_request).create(current_user, organizations)
 
       beta_migration_request.save!
-      enable_opt_in(organizations + [current_user])
 
       result beta_migration_request
-    end
-
-    def enable_opt_in(owners)
-      owners.each do |org|
-        Travis::Features.activate_owner(:beta_migration_opt_in, org)
-      end
     end
 
     def validate_organizations(current_user)


### PR DESCRIPTION
This PR does the following:
- [x] Adds a rake task that allows you to enter the number of `BetaMigrationRequests` you wish to process, then enables `:allow_migration` feature for the owner and the selected orgs.
  - There is an option to specify how many requests you wish to process. It defaults to 50.
  - There is an option to print out debug information, that defaults to false
- [x] The feature flag `beta_migration_opt_in` that was earlier introduced, has no function because the rake task only needs the `BetaMigrationRequest` records, so the related code and tests have been removed.
- [x] A user can initiate multiple `BetaMigrationRequests`, e.g. when they want to selected a different set of orgs that they're admin for, each time. So a `User` now `has_many :beta_migration_requests` 