### PR TITLE
Remove service hooks requests

### DIFF
--- a/lib/travis/api/v3/github.rb
+++ b/lib/travis/api/v3/github.rb
@@ -46,7 +46,6 @@ module Travis::API::V3
 
     def set_hook(repo, active)
       set_webhook(repo, active)
-      deactivate_service_hook(repo)
     end
 
     def upload_key(repository)

--- a/lib/travis/api/v3/github.rb
+++ b/lib/travis/api/v3/github.rb
@@ -46,6 +46,7 @@ module Travis::API::V3
 
     def set_hook(repo, active)
       set_webhook(repo, active)
+      deactivate_service_hook(repo) if Travis.config.enterprise
     end
 
     def upload_key(repository)

--- a/spec/v3/services/repository/activate_spec.rb
+++ b/spec/v3/services/repository/activate_spec.rb
@@ -79,6 +79,18 @@ describe Travis::API::V3::Services::Repository::Activate, set_app: true do
           post("/v3/repo/#{repo.id}/activate", {}, headers)
         end
 
+        context 'enterprise' do
+          around do |ex|
+            Travis.config.enterprise = true
+            ex.run
+            Travis.config.enterprise = false
+          end
+
+          example 'deactivates service hook' do
+            expect(WebMock).to have_requested(:patch, "https://api.github.com/repositories/#{repo.github_id}/hooks/123").with(body: service_hook_payload).once
+          end
+        end
+
         example 'no longer deactivates service hook' do
           expect(WebMock).not_to have_requested(:patch, "https://api.github.com/repositories/#{repo.github_id}/hooks/123").with(body: service_hook_payload)
         end

--- a/spec/v3/services/repository/activate_spec.rb
+++ b/spec/v3/services/repository/activate_spec.rb
@@ -79,8 +79,8 @@ describe Travis::API::V3::Services::Repository::Activate, set_app: true do
           post("/v3/repo/#{repo.id}/activate", {}, headers)
         end
 
-        example 'deactivates service hook' do
-          expect(WebMock).to have_requested(:patch, "https://api.github.com/repositories/#{repo.github_id}/hooks/123").with(body: service_hook_payload).once
+        example 'no longer deactivates service hook' do
+          expect(WebMock).not_to have_requested(:patch, "https://api.github.com/repositories/#{repo.github_id}/hooks/123").with(body: service_hook_payload)
         end
 
         example 'updates webhook' do

--- a/spec/v3/services/repository/deactivate_spec.rb
+++ b/spec/v3/services/repository/deactivate_spec.rb
@@ -70,8 +70,8 @@ describe Travis::API::V3::Services::Repository::Deactivate, set_app: true do
           post("/v3/repo/#{repo.id}/deactivate", {}, headers)
         end
 
-        example 'deactivates service hook' do
-          expect(WebMock).to have_requested(:patch, "https://api.github.com/repositories/#{repo.github_id}/hooks/123").with(body: service_hook_payload).once
+        example 'no longer deactivates service hook' do
+          expect(WebMock).not_to have_requested(:patch, "https://api.github.com/repositories/#{repo.github_id}/hooks/123").with(body: service_hook_payload)
         end
 
         example 'updates webhook' do
@@ -99,8 +99,8 @@ describe Travis::API::V3::Services::Repository::Deactivate, set_app: true do
           post("/v3/repo/#{repo.id}/deactivate", {}, headers)
         end
 
-        example 'deactivates service hook' do
-          expect(WebMock).to have_requested(:patch, "https://api.github.com/repositories/#{repo.github_id}/hooks/123").with(body: service_hook_payload).once
+        example 'no longer deactivates service hook' do
+          expect(WebMock).not_to have_requested(:patch, "https://api.github.com/repositories/#{repo.github_id}/hooks/123").with(body: service_hook_payload)
         end
 
         example 'creates webhook' do

--- a/spec/v3/services/repository/deactivate_spec.rb
+++ b/spec/v3/services/repository/deactivate_spec.rb
@@ -70,6 +70,18 @@ describe Travis::API::V3::Services::Repository::Deactivate, set_app: true do
           post("/v3/repo/#{repo.id}/deactivate", {}, headers)
         end
 
+        context 'enterprise' do
+          around do |ex|
+            Travis.config.enterprise = true
+            ex.run
+            Travis.config.enterprise = false
+          end
+
+          example 'deactivates service hook' do
+            expect(WebMock).to have_requested(:patch, "https://api.github.com/repositories/#{repo.github_id}/hooks/123").with(body: service_hook_payload).once
+          end
+        end
+
         example 'no longer deactivates service hook' do
           expect(WebMock).not_to have_requested(:patch, "https://api.github.com/repositories/#{repo.github_id}/hooks/123").with(body: service_hook_payload)
         end
@@ -97,6 +109,18 @@ describe Travis::API::V3::Services::Repository::Deactivate, set_app: true do
             )
           )
           post("/v3/repo/#{repo.id}/deactivate", {}, headers)
+        end
+
+        context 'enterprise' do
+          around do |ex|
+            Travis.config.enterprise = true
+            ex.run
+            Travis.config.enterprise = false
+          end
+
+          example 'deactivates service hook' do
+            expect(WebMock).to have_requested(:patch, "https://api.github.com/repositories/#{repo.github_id}/hooks/123").with(body: service_hook_payload).once
+          end
         end
 
         example 'no longer deactivates service hook' do


### PR DESCRIPTION
We've been making patch requests even after the GitHub service hooks
endpoints have been switched off. This removes them.