### PR TITLE
Throttle GET requests to /job/[job ID]/log

### DIFF
--- a/lib/travis/api/attack.rb
+++ b/lib/travis/api/attack.rb
@@ -115,6 +115,15 @@ class Rack::Attack
     request.identifier
   end
 
+  ###
+  # Throttle:  GET requests to /job/[job id]/log - 20 per minute
+  # Scoped by: IP address
+  throttle('job_logs_ip_20min', limit: 20, period: 1.minute) do |request|
+    if request.get? && request.path =~ /\/job\/\d{9,}\/log/
+      request.ip
+    end
+  end
+
   if ENV["MEMCACHIER_SERVERS"]
     cache.store = Dalli::Client.new(
       ENV["MEMCACHIER_SERVERS"].split(","),


### PR DESCRIPTION
We've seen an uptick in people scraping public job logs, theoretically
looking for credentials in the clear. This at  least slows them  down.