### PR TITLE
Allow for insecure SSL when creating or updating webhooks

### DIFF
--- a/lib/travis/api/v3/github.rb
+++ b/lib/travis/api/v3/github.rb
@@ -67,7 +67,7 @@ module Travis::API::V3
         name: 'web'.freeze,
         events: EVENTS,
         active: active,
-        config: { url: service_hook_url.to_s }
+        config: { url: service_hook_url.to_s, insecure_ssl: insecure_ssl? }
       }
       if url = webhook_url?(repo)
         info("Updating webhook repo=%s github_id=%i active=%s" % [repo.slug, repo.github_id, active])
@@ -121,6 +121,12 @@ module Travis::API::V3
 
     def info(msg)
       Travis.logger.info(msg)
+    end
+
+    private
+
+    def insecure_ssl?
+      Travis.config.ssl.to_h.key?(:verify) && Travis.config.ssl.to_h[:verify] == false
     end
   end
 end

--- a/spec/v3/services/repository/activate_spec.rb
+++ b/spec/v3/services/repository/activate_spec.rb
@@ -38,7 +38,7 @@ describe Travis::API::V3::Services::Repository::Activate, set_app: true do
     end
 
     describe "existing repository, push access" do
-      let(:webhook_payload) { JSON.dump(name: 'web', events: Travis::API::V3::GitHub::EVENTS, active: true, config: { url: Travis.config.service_hook_url || '' }) }
+      let(:webhook_payload) { JSON.dump(name: 'web', events: Travis::API::V3::GitHub::EVENTS, active: true, config: { url: Travis.config.service_hook_url || '', insecure_ssl: false }) }
       let(:service_hook_payload) { JSON.dump(events: Travis::API::V3::GitHub::EVENTS, active: false) }
 
       before        { Travis::API::V3::Models::Permission.create(repository: repo, user: repo.owner, admin: true, pull: true, push: true) }
@@ -131,16 +131,40 @@ describe Travis::API::V3::Services::Repository::Activate, set_app: true do
             'active' => true
           )
         end
+
+        context 'when ssl verification has been disabled' do
+          let(:webhook_payload) { JSON.dump(name: 'web', events: Travis::API::V3::GitHub::EVENTS, active: true, config: { url: Travis.config.service_hook_url || '', insecure_ssl: true }) }
+
+          around do |ex|
+            Travis.config.ssl = { verify: false }
+            ex.run
+            Travis.config.ssl = {}
+          end
+
+          example 'updates webhook with ssl disabled' do
+            expect(WebMock).to have_requested(:patch, "https://api.github.com/repositories/#{repo.github_id}/hooks/456").with(body: webhook_payload).once
+          end
+
+          example 'is success' do
+            expect(last_response.status).to eq 200
+            expect(JSON.load(body)).to include(
+              '@type' => 'repository',
+              'active' => true
+            )
+          end
+        end
       end
 
       context 'when webhook does not exist' do
+        let(:webhook_payload) { JSON.dump(name: 'web', events: Travis::API::V3::GitHub::EVENTS, active: true, config: { url: Travis.config.service_hook_url || '', insecure_ssl: false }) }
+
         before do
           stub_request(:get, "https://api.github.com/repositories/#{repo.github_id}/hooks?per_page=100").to_return(status: 200, body: '[]')
           post("/v3/repo/#{repo.id}/activate", {}, headers)
         end
 
         example 'creates webhook' do
-          expect(WebMock).to have_requested(:post, "https://api.github.com/repositories/#{repo.github_id}/hooks").once
+          expect(WebMock).to have_requested(:post, "https://api.github.com/repositories/#{repo.github_id}/hooks").with(body: webhook_payload).once
         end
 
         example 'is success' do
@@ -149,6 +173,20 @@ describe Travis::API::V3::Services::Repository::Activate, set_app: true do
             '@type' => 'repository',
             'active' => true
           )
+        end
+
+        context 'when ssl verification has been disabled' do
+          let(:webhook_payload) { JSON.dump(name: 'web', events: Travis::API::V3::GitHub::EVENTS, active: true, config: { url: Travis.config.service_hook_url || '', insecure_ssl: true}) }
+
+          around do |ex|
+            Travis.config.ssl = { verify: false }
+            ex.run
+            Travis.config.ssl = {}
+          end
+
+          example 'requests webhooks without ssl verification' do
+            expect(WebMock).to have_requested(:post, "https://api.github.com/repositories/#{repo.github_id}/hooks").with(body: webhook_payload).once
+          end
         end
       end
     end

--- a/spec/v3/services/repository/deactivate_spec.rb
+++ b/spec/v3/services/repository/deactivate_spec.rb
@@ -45,7 +45,7 @@ describe Travis::API::V3::Services::Repository::Deactivate, set_app: true do
     end
 
     describe "existing repository, admin and push access" do
-      let(:webhook_payload) { JSON.dump(name: 'web', events: Travis::API::V3::GitHub::EVENTS, active: false, config: { url: Travis.config.service_hook_url || '' }) }
+      let(:webhook_payload) { JSON.dump(name: 'web', events: Travis::API::V3::GitHub::EVENTS, active: false, config: { url: Travis.config.service_hook_url || '', insecure_ssl: false }) }
       let(:service_hook_payload) { JSON.dump(events: Travis::API::V3::GitHub::EVENTS, active: false) }
 
       before { Travis::API::V3::Models::Permission.create(repository: repo, user: repo.owner, admin: true, push: true) }


### PR DESCRIPTION
The 'Disable SSL Verification' setting (`verify: false`) is already used and passed into Faraday in certain circumstances to allow for use of self-signed certs in traffic between Travis CI components. With this PR the setting will also be used when creating or updating webhooks. 

Without this change the 'Disable SSL Verification' setting in Enterprise effectively doesn't work since Github can't communicate with `travis-listener` and so the request never makes it into our system to begin with.

I will be backporting this change to the `enterprise-2.2` branch but I'm pretty sure that this is worth having in master as well. Willing to chat more about that if anyone disagrees!

P.S. I added @joecorcoran and @porras as reviewers since they were suggested by Github. Please let me know if I should add anyone else!