### PR TITLE
[BACKPORT] Allow for insecure SSL when creating or updating webhooks

### DIFF
--- a/lib/travis/api/v3/github.rb
+++ b/lib/travis/api/v3/github.rb
@@ -69,7 +69,7 @@ module Travis::API::V3
         name: 'web'.freeze,
         events: EVENTS,
         active: active,
-        config: { url: service_hook_url.to_s }
+        config: { url: service_hook_url.to_s, insecure_ssl: insecure_ssl? }
       }
       if url = webhook_url?(repo)
         info("Updating webhook repo=%s active=%s" % [repo.slug, active])
@@ -113,6 +113,12 @@ module Travis::API::V3
 
     def info(msg)
       Travis.logger.info(msg)
+    end
+
+    private
+
+    def insecure_ssl?
+      Travis.config.ssl.to_h.key?(:verify) && Travis.config.ssl.to_h[:verify] == false
     end
   end
 end

--- a/spec/v3/services/repository/deactivate_spec.rb
+++ b/spec/v3/services/repository/deactivate_spec.rb
@@ -83,7 +83,7 @@ describe Travis::API::V3::Services::Repository::Deactivate, set_app: true do
   describe "existing repository, admin and push access" do
     let(:token) { Travis::Api::App::AccessToken.create(user: repo.owner, app_id: 1) }
     let(:headers) {{ 'HTTP_AUTHORIZATION' => "token #{token}" }}
-    let(:webhook_payload) { JSON.dump(name: 'web', events: Travis::API::V3::GitHub::EVENTS, active: false, config: { url: Travis.config.service_hook_url || '' }) }
+    let(:webhook_payload) { JSON.dump(name: 'web', events: Travis::API::V3::GitHub::EVENTS, active: false, config: { url: Travis.config.service_hook_url || '', insecure_ssl: false }) }
     let(:service_hook_payload) { JSON.dump(events: Travis::API::V3::GitHub::EVENTS, active: false) }
 
     before { Travis::API::V3::Models::Permission.create(repository: repo, user: repo.owner, admin: true, push: true) }
@@ -101,7 +101,7 @@ describe Travis::API::V3::Services::Repository::Deactivate, set_app: true do
           status: 200, body: JSON.dump(
             [
               { name: 'travis', url: "https://api.github.com/repos/#{repo.slug}/hooks/123" },
-              { name: 'web', url: "https://api.github.com/repos/#{repo.slug}/hooks/456", config: { url: Travis.config.service_hook_url } }
+              { name: 'web', url: "https://api.github.com/repos/#{repo.slug}/hooks/456", config: { url: Travis.config.service_hook_url, insecure_ssl: false } }
             ]
           )
         )
@@ -159,7 +159,7 @@ describe Travis::API::V3::Services::Repository::Deactivate, set_app: true do
         stub_request(:get, "https://api.github.com/repos/#{repo.slug}/hooks?per_page=100").to_return(
           status: 200, body: JSON.dump(
             [
-              { name: 'web', url: "https://api.github.com/repos/#{repo.slug}/hooks/456", config: { url: Travis.config.service_hook_url } }
+              { name: 'web', url: "https://api.github.com/repos/#{repo.slug}/hooks/456", config: { url: Travis.config.service_hook_url, insecure_ssl: false } }
             ]
           )
         )


### PR DESCRIPTION
This is the backport of https://github.com/travis-ci/travis-api/pull/885 to the `enterprise-2.2` branch. Please let me know if there is a more established way of doing this, this seems like what we have done for backports in the past. 🤷‍♂️ 