### PR TITLE
remove sudo key since it's no longer relevant

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
 language: ruby
 
-sudo: false
-
 rvm: 2.5.1
 
 script: "bundle exec rake knapsack:rspec"


### PR DESCRIPTION
Travis CI uses a single linux infrastructure https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration