### PR TITLE
Update find repo by slug query to handle lowercase

### DIFF
--- a/lib/travis/api/v3/queries/repository.rb
+++ b/lib/travis/api/v3/queries/repository.rb
@@ -43,7 +43,11 @@ module Travis::API::V3
 
     def by_slug
       owner_name, name = slug.split('/')
-      Models::Repository.where(owner_name: owner_name, name: name, invalidated_at: nil).first
+      Models::Repository.where(
+        "LOWER(repositories.owner_name) = ? AND LOWER(repositories.name) = ? AND repositories.invalidated_at IS NULL",
+        owner_name,
+        repo_name
+      ).first
     end
   end
 end

--- a/lib/travis/api/v3/queries/repository.rb
+++ b/lib/travis/api/v3/queries/repository.rb
@@ -42,7 +42,7 @@ module Travis::API::V3
     end
 
     def by_slug
-      owner_name, name = slug.split('/')
+      owner_name, repo_name = slug.split('/')
       Models::Repository.where(
         "LOWER(repositories.owner_name) = ? AND LOWER(repositories.name) = ? AND repositories.invalidated_at IS NULL",
         owner_name,

--- a/lib/travis/api/v3/queries/repository.rb
+++ b/lib/travis/api/v3/queries/repository.rb
@@ -44,7 +44,7 @@ module Travis::API::V3
     def by_slug
       owner_name, repo_name = slug.split('/')
       Models::Repository.where(
-        "LOWER(repositories.owner_name) = ? AND LOWER(repositories.name) = ? AND repositories.invalidated_at IS NULL",
+        "LOWER(repositories.owner_name.downcase) = ? AND LOWER(repositories.name.downcase) = ? AND repositories.invalidated_at IS NULL",
         owner_name,
         repo_name
       ).first

--- a/lib/travis/api/v3/queries/repository.rb
+++ b/lib/travis/api/v3/queries/repository.rb
@@ -44,9 +44,9 @@ module Travis::API::V3
     def by_slug
       owner_name, repo_name = slug.split('/')
       Models::Repository.where(
-        "LOWER(repositories.owner_name.downcase) = ? AND LOWER(repositories.name.downcase) = ? AND repositories.invalidated_at IS NULL",
-        owner_name,
-        repo_name
+        "LOWER(repositories.owner_name) = ? AND LOWER(repositories.name) = ? AND repositories.invalidated_at IS NULL",
+        owner_name.downcase,
+        repo_name.downcase
       ).first
     end
   end

--- a/lib/travis/model/repository.rb
+++ b/lib/travis/model/repository.rb
@@ -68,7 +68,10 @@ class Repository < Travis::Model
     without_invalidated.joins(:users).where(users: { login: login })
   }
   scope :by_slug, ->(slug) {
-    without_invalidated.where(owner_name: slug.split('/').first, name: slug.split('/').last).order('id DESC')
+    owner_name, repo_name = slug.split('/')
+    without_invalidated.where(
+      "LOWER(repositories.owner_name) = ? AND LOWER(repositories.name) = ?", owner_name, repo_name
+    ).order('id DESC')
   }
   scope :search, ->(query) {
     query = query.gsub('\\', '/')

--- a/lib/travis/model/repository.rb
+++ b/lib/travis/model/repository.rb
@@ -70,7 +70,7 @@ class Repository < Travis::Model
   scope :by_slug, ->(slug) {
     owner_name, repo_name = slug.split('/')
     without_invalidated.where(
-      "LOWER(repositories.owner_name.downcase) = ? AND LOWER(repositories.name.downcase) = ?", owner_name, repo_name
+      "LOWER(repositories.owner_name) = ? AND LOWER(repositories.name) = ?", owner_name.downcase, repo_name.downcase
     ).order('id DESC')
   }
   scope :search, ->(query) {

--- a/lib/travis/model/repository.rb
+++ b/lib/travis/model/repository.rb
@@ -70,7 +70,7 @@ class Repository < Travis::Model
   scope :by_slug, ->(slug) {
     owner_name, repo_name = slug.split('/')
     without_invalidated.where(
-      "LOWER(repositories.owner_name) = ? AND LOWER(repositories.name) = ?", owner_name, repo_name
+      "LOWER(repositories.owner_name.downcase) = ? AND LOWER(repositories.name.downcase) = ?", owner_name, repo_name
     ).order('id DESC')
   }
   scope :search, ->(query) {


### PR DESCRIPTION
This addresses this issue https://github.com/travis-pro/team-teal/issues/2952
and  takes the place of this PR https://github.com/travis-ci/travis-api/pull/908

We still need to update `travis-migrations` to have the index:
```
CREATE INDEX CONCURRENTLY index_repositories_on_lower_owner_name_and_name ON repositories (LOWER(owner_name), LOWER(name)) WHERE invalidated_at IS NULL;
```