### PR TITLE
Find migrated logs

### DIFF
--- a/lib/travis/api/v3/models/job.rb
+++ b/lib/travis/api/v3/models/job.rb
@@ -50,8 +50,24 @@ module Travis::API::V3
       config
     end
 
+    def restarted?
+      !!restarted_at
+    end
+
+    def restarted_post_migration?
+      restarted? && restarted_at > repository.migrated_at
+    end
+
+    def migrated?
+      deployed_on_com? && !!org_id
+    end
+
     private def enterprise?
       !!Travis.config.enterprise
+    end
+
+    private def deployed_on_com?
+      ENV["TRAVIS_SITE"] == "com"
     end
   end
 end

--- a/lib/travis/api/v3/models/job.rb
+++ b/lib/travis/api/v3/models/job.rb
@@ -59,15 +59,11 @@ module Travis::API::V3
     end
 
     def migrated?
-      deployed_on_com? && !!org_id
+      !!org_id
     end
 
     private def enterprise?
       !!Travis.config.enterprise
-    end
-
-    private def deployed_on_com?
-      ENV["TRAVIS_SITE"] == "com"
     end
   end
 end

--- a/lib/travis/config/defaults.rb
+++ b/lib/travis/config/defaults.rb
@@ -17,7 +17,7 @@ module Travis
       end
 
       def fallback_logs_api_auth_url
-        ENV['TRAVIS_API_FALLBACK_LOGS_API_URL'] || 'http://travis-logs-fallback-notset.example.com:1234'
+        ENV['TRAVIS_API_FALLBACK_LOGS_API_URL'] || 'http://travis-logs-notset.example.com:1234'
       end
 
       def fallback_logs_api_auth_token

--- a/lib/travis/config/defaults.rb
+++ b/lib/travis/config/defaults.rb
@@ -15,6 +15,14 @@ module Travis
           ENV['LOGS_API_AUTH_TOKEN'] ||
           'notset'
       end
+
+      def fallback_logs_api_auth_url
+        ENV['TRAVIS_API_FALLBACK_LOGS_API_URL'] || 'notset'
+      end
+
+      def fallback_logs_api_auth_token
+        ENV['TRAVIS_API_FALLBACK_LOGS_API_TOKEN'] || 'notset'
+      end
     end
 
     HOSTS = {
@@ -35,8 +43,7 @@ module Travis
             gdpr:                 {},
             insights:             Travis.env == 'test' ? { endpoint: 'https://insights.travis-ci.dev/', auth_token: 'secret' } : {},
             database:             { adapter: 'postgresql', database: "travis_#{Travis.env}", encoding: 'unicode', min_messages: 'warning', variables: { statement_timeout: 10_000 } },
-            org_logs_api:         { url: logs_api_url, token: logs_api_auth_token },
-            com_logs_api:         { url: logs_api_url, token: logs_api_auth_token },
+            fallback_logs_api:    { url: fallback_logs_api_auth_url, token: fallback_logs_api_auth_token },
             logs_api:             { url: logs_api_url, token: logs_api_auth_token },
             log_options:          { s3: { access_key_id: '', secret_access_key: ''}},
             s3:                   { access_key_id: '', secret_access_key: ''},

--- a/lib/travis/config/defaults.rb
+++ b/lib/travis/config/defaults.rb
@@ -17,7 +17,7 @@ module Travis
       end
 
       def fallback_logs_api_auth_url
-        ENV['TRAVIS_API_FALLBACK_LOGS_API_URL'] || 'notset'
+        ENV['TRAVIS_API_FALLBACK_LOGS_API_URL'] || 'http://travis-logs-fallback-notset.example.com:1234'
       end
 
       def fallback_logs_api_auth_token

--- a/lib/travis/config/defaults.rb
+++ b/lib/travis/config/defaults.rb
@@ -35,6 +35,8 @@ module Travis
             gdpr:                 {},
             insights:             Travis.env == 'test' ? { endpoint: 'https://insights.travis-ci.dev/', auth_token: 'secret' } : {},
             database:             { adapter: 'postgresql', database: "travis_#{Travis.env}", encoding: 'unicode', min_messages: 'warning', variables: { statement_timeout: 10_000 } },
+            org_logs_api:         { url: logs_api_url, token: logs_api_auth_token },
+            com_logs_api:         { url: logs_api_url, token: logs_api_auth_token },
             logs_api:             { url: logs_api_url, token: logs_api_auth_token },
             log_options:          { s3: { access_key_id: '', secret_access_key: ''}},
             s3:                   { access_key_id: '', secret_access_key: ''},

--- a/lib/travis/model/job.rb
+++ b/lib/travis/model/job.rb
@@ -100,6 +100,18 @@ class Job < Travis::Model
     (super || :created).to_sym
   end
 
+  def migrated?
+    !!org_id
+  end
+
+  def restarted?
+    !!restarted_at
+  end
+
+  def restarted_post_migration?
+    restarted? && restarted_at > repository.migrated_at
+  end
+
   def duration
     started_at && finished_at ? finished_at - started_at : nil
   end

--- a/lib/travis/services/find_log.rb
+++ b/lib/travis/services/find_log.rb
@@ -24,15 +24,22 @@ module Travis
 
           job = scope(:job).find_by_id(params[:job_id])
           if job
-            Travis::RemoteLog.find_by_job_id(Integer(params[:job_id]))
+            platform = platform_for(job)
+            id = id_for(job)
+            Travis::RemoteLog.find_by_job_id(id, platform: platform)
           end
         end
       end
 
       private def platform_for(job)
-        return :org if deployed_on_org?
-        return :org if job.migrated? && !job.restarted_after_migration?
-        :com
+        return "org" if deployed_on_org?
+        return "org" if job.migrated? && !job.restarted_after_migration?
+        "com"
+      end
+
+      private def id_for(job)
+        return job.org_id if job.migrated? && !job.restarted_after_migration?
+        job.id
       end
 
       private def deployed_on_org?

--- a/lib/travis/services/find_log.rb
+++ b/lib/travis/services/find_log.rb
@@ -33,12 +33,12 @@ module Travis
 
       private def platform_for(job)
         return "org" if deployed_on_org?
-        return "org" if job.migrated? && !job.restarted_after_migration?
+        return "org" if job.migrated? && !job.restarted_post_migration?
         "com"
       end
 
       private def id_for(job)
-        return job.org_id if job.migrated? && !job.restarted_after_migration?
+        return job.org_id if job.migrated? && !job.restarted_post_migration?
         job.id
       end
 

--- a/lib/travis/services/find_log.rb
+++ b/lib/travis/services/find_log.rb
@@ -28,6 +28,16 @@ module Travis
           end
         end
       end
+
+      private def platform_for(job)
+        return :org if deployed_on_org?
+        return :org if job.migrated? && !job.restarted_after_migration?
+        :com
+      end
+
+      private def deployed_on_org?
+        ENV["TRAVIS_SITE"] == "org"
+      end
     end
   end
 end

--- a/spec/lib/services/find_log_spec.rb
+++ b/spec/lib/services/find_log_spec.rb
@@ -14,7 +14,7 @@ describe Travis::Services::FindLog do
     it 'finds the log with the given job_id' do
       params[:job_id] = job.id
       found_by_job_id = stub('found-by-job-id', job_id: job.id)
-      Travis::RemoteLog.expects(:find_by_job_id).with(job.id).returns(found_by_job_id)
+      Travis::RemoteLog.expects(:find_by_job_id).with(job.id, {:platform => 'com'}).returns(found_by_job_id)
       service.run.should == found_by_job_id
     end
 

--- a/spec/lib/travis/remote_log_spec.rb
+++ b/spec/lib/travis/remote_log_spec.rb
@@ -208,10 +208,10 @@ describe Travis::RemoteLog do
 end
 
 describe Travis::RemoteLog::Client do
-  let(:org_url) { 'http://orgloggo.example.com' }
-  let(:org_token) { 'orgtoken' }
-  let(:com_url) { 'http://comloggo.example.com' }
-  let(:com_token) { 'comtoken' }
+  let(:default_url) { 'http://orgloggo.example.com' }
+  let(:default_token) { 'default_token' }
+  let(:fallback_url) { 'http://comloggo.example.com' }
+  let(:fallback_token) { 'fallback_token' }
   let :stubs do
     Faraday::Adapter::Test::Stubs.new do |stub|
       stub.get('/logs/4') { [200, {}, JSON.dump(content: 'huh wow')] }
@@ -253,15 +253,15 @@ describe Travis::RemoteLog::Client do
     end
   end
 
-  subject { described_class.new(org_url: org_url, org_token: org_token, com_url: com_url, com_token: com_token) }
+  subject { described_class.new(default_url: default_url, default_token: default_token, fallback_url: fallback_url, fallback_token: fallback_token) }
 
   before do
     subject.instance_variable_set(
-      :@org_conn,
+      :@default_conn,
       Faraday.new { |c| c.adapter :test, stubs }
     )
     subject.instance_variable_set(
-      :@com_conn,
+      :@fallback_conn,
       Faraday.new { |c| c.adapter :test, stubs }
     )
   end

--- a/spec/lib/travis/remote_log_spec.rb
+++ b/spec/lib/travis/remote_log_spec.rb
@@ -208,8 +208,10 @@ describe Travis::RemoteLog do
 end
 
 describe Travis::RemoteLog::Client do
-  let(:url) { 'http://loggo.example.com' }
-  let(:token) { 'fafafafcoolbeansgeocitiesangelfire' }
+  let(:org_url) { 'http://orgloggo.example.com' }
+  let(:org_token) { 'orgtoken' }
+  let(:com_url) { 'http://comloggo.example.com' }
+  let(:com_token) { 'comtoken' }
   let :stubs do
     Faraday::Adapter::Test::Stubs.new do |stub|
       stub.get('/logs/4') { [200, {}, JSON.dump(content: 'huh wow')] }
@@ -251,11 +253,15 @@ describe Travis::RemoteLog::Client do
     end
   end
 
-  subject { described_class.new(url: url, token: token) }
+  subject { described_class.new(org_url: org_url, org_token: org_token, com_url: com_url, com_token: com_token) }
 
   before do
     subject.instance_variable_set(
-      :@conn,
+      :@org_conn,
+      Faraday.new { |c| c.adapter :test, stubs }
+    )
+    subject.instance_variable_set(
+      :@com_conn,
       Faraday.new { |c| c.adapter :test, stubs }
     )
   end

--- a/spec/unit/endpoint/logs_spec.rb
+++ b/spec/unit/endpoint/logs_spec.rb
@@ -26,11 +26,11 @@ describe Travis::Api::App::Endpoint::Logs, set_app: true do
     before do
       private_job_id = private_job.id
       private_log = Travis::RemoteLog.new(content: 'private', job_id: private_job_id)
-      Travis::RemoteLog.stubs(:find_by_job_id).with(private_job_id).returns(private_log)
+      Travis::RemoteLog.stubs(:find_by_job_id).with(private_job_id, {:platform => 'com'}).returns(private_log)
 
       public_job_id = public_job.id
       public_log = Travis::RemoteLog.new(content: 'public', job_id: public_job_id)
-      Travis::RemoteLog.stubs(:find_by_job_id).with(public_job_id).returns(public_log)
+      Travis::RemoteLog.stubs(:find_by_job_id).with(public_job_id, {:platform => 'com'}).returns(public_log)
     end
 
     describe 'private mode, .com' do

--- a/spec/unit/endpoint/logs_spec.rb
+++ b/spec/unit/endpoint/logs_spec.rb
@@ -38,7 +38,7 @@ describe Travis::Api::App::Endpoint::Logs, set_app: true do
       # job via its org_id.
       Travis::RemoteLog.stubs(:find_by_job_id).with(public_job_id, {:platform => 'org'}).returns(public_log)
 
-      restarted_public_migrated_log = Travis::RemoteLog.new(content: 'public', job_id: public_migrated_job.id)
+      restarted_public_migrated_log = Travis::RemoteLog.new(content: 'public restarted', job_id: public_migrated_job.id)
       Travis::RemoteLog.stubs(:find_by_job_id).with(public_migrated_job.id, {:platform => 'com'}).returns(restarted_public_migrated_log)
     end
 
@@ -134,7 +134,7 @@ describe Travis::Api::App::Endpoint::Logs, set_app: true do
           Factory.create(:permission, user: user, repository: public_migrated_repo)
           response = get("/jobs/#{public_migrated_job.id}/log", {}, authenticated_headers)
           response.should be_ok
-          response.body.should == 'public'
+          response.body.should == 'public restarted'
           response.headers["X-Log-Access-Token"].should be_nil
         end
       end


### PR DESCRIPTION
We move over build/job records, but not log db records, as part of the build history migration. This adds logic to API when fetching logs to determine which logs backend we should query.