### PR TITLE
Hit .org logs for migrated jobs

### DIFF
--- a/lib/travis/api/v3/models/job.rb
+++ b/lib/travis/api/v3/models/job.rb
@@ -18,7 +18,7 @@ module Travis::API::V3
     serialize :debug_options
 
     def log
-      @log ||= Travis::RemoteLog.find_by_job_id(id)
+      @log ||= Travis::RemoteLog::Remote.new.find_by_job_id(id)
     end
 
     def log_complete
@@ -48,6 +48,18 @@ module Travis::API::V3
       config = super&.config || has_attribute?(:config) && read_attribute(:config) || {}
       config.deep_symbolize_keys! if config.respond_to?(:deep_symbolize_keys!)
       config
+    end
+
+    def restarted?
+      !!restarted_at
+    end
+
+    def restarted_post_migration?
+      restarted? && restarted_at > repository.migrated_at
+    end
+
+    def migrated?
+      !!org_id
     end
 
     private def enterprise?

--- a/lib/travis/config/defaults.rb
+++ b/lib/travis/config/defaults.rb
@@ -15,6 +15,14 @@ module Travis
           ENV['LOGS_API_AUTH_TOKEN'] ||
           'notset'
       end
+
+      def fallback_logs_api_auth_url
+        ENV['TRAVIS_API_FALLBACK_LOGS_API_URL'] || 'http://travis-logs-notset.example.com:1234'
+      end
+
+      def fallback_logs_api_auth_token
+        ENV['TRAVIS_API_FALLBACK_LOGS_API_TOKEN'] || 'notset'
+      end
     end
 
     HOSTS = {
@@ -35,6 +43,7 @@ module Travis
             gdpr:                 {},
             insights:             Travis.env == 'test' ? { endpoint: 'https://insights.travis-ci.dev/', auth_token: 'secret' } : {},
             database:             { adapter: 'postgresql', database: "travis_#{Travis.env}", encoding: 'unicode', min_messages: 'warning', variables: { statement_timeout: 10_000 } },
+            fallback_logs_api:    { url: fallback_logs_api_auth_url, token: fallback_logs_api_auth_token },
             logs_api:             { url: logs_api_url, token: logs_api_auth_token },
             log_options:          { s3: { access_key_id: '', secret_access_key: ''}},
             s3:                   { access_key_id: '', secret_access_key: ''},

--- a/lib/travis/model/job.rb
+++ b/lib/travis/model/job.rb
@@ -100,6 +100,18 @@ class Job < Travis::Model
     (super || :created).to_sym
   end
 
+  def migrated?
+    !!org_id
+  end
+
+  def restarted?
+    !!restarted_at
+  end
+
+  def restarted_post_migration?
+    restarted? && restarted_at > repository.migrated_at
+  end
+
   def duration
     started_at && finished_at ? finished_at - started_at : nil
   end
@@ -166,13 +178,13 @@ class Job < Travis::Model
   end
 
   def log
-    @log ||= Travis::RemoteLog.find_by_job_id(id)
+    @log ||= Travis::RemoteLog::Remote.new.find_by_job_id(id)
   end
 
   attr_writer :log
 
   def log_id
-    @log_id ||= Travis::RemoteLog.find_id_by_job_id(id)
+    @log_id ||= Travis::RemoteLog::Remote.new.find_id_by_job_id(id)
   end
 
   attr_writer :log_id

--- a/lib/travis/services/find_log.rb
+++ b/lib/travis/services/find_log.rb
@@ -15,7 +15,7 @@ module Travis
         if params[:id]
           # as we don't have the job id, we first need to get the log to check
           # permissions
-          remote_log = Travis::RemoteLog.find_by_id(Integer(params[:id]))
+          remote_log = Travis::RemoteLog::Remote.new.find_by_id(Integer(params[:id]))
           if remote_log && scope(:job).find_by_id(remote_log.job_id)
             remote_log
           end
@@ -24,9 +24,26 @@ module Travis
 
           job = scope(:job).find_by_id(params[:job_id])
           if job
-            Travis::RemoteLog.find_by_job_id(Integer(params[:job_id]))
+            platform = platform_for(job)
+            id = id_for(job)
+            Travis::RemoteLog::Remote.new(platform: platform).find_by_job_id(id)
           end
         end
+      end
+
+      private def platform_for(job)
+        return :default if deployed_on_org?
+        return :fallback if job.migrated? && !job.restarted_post_migration?
+        :default
+      end
+
+      private def id_for(job)
+        return job.org_id if job.migrated? && !job.restarted_post_migration?
+        job.id
+      end
+
+      private def deployed_on_org?
+        ENV["TRAVIS_SITE"] == "org"
       end
     end
   end

--- a/lib/travis/services/remove_log.rb
+++ b/lib/travis/services/remove_log.rb
@@ -41,7 +41,7 @@ module Travis
       instrument :run
 
       def log
-        @log ||= Travis::RemoteLog.find_by_job_id(job.id)
+        @log ||= Travis::RemoteLog::Remote.new.find_by_job_id(job.id)
       end
 
       def can_remove?

--- a/spec/integration/v2/jobs_spec.rb
+++ b/spec/integration/v2/jobs_spec.rb
@@ -47,8 +47,13 @@ describe 'Jobs', set_app: true do
 
     context 'when log is archived' do
       it 'redirects to archive' do
-        Travis::RemoteLog.expects(:fetch_archived_url)
-          .returns("https://s3.amazonaws.com/archive.travis-ci.org/jobs/#{job.id}/log.txt")
+        remote = stub('remote')
+        remote_log = stub('remote log')
+        remote_log.expects(:archived?).returns(true)
+        remote_log.stubs(:removed_at).returns(nil)
+        remote.stubs(:find_by_job_id).returns(remote_log)
+        remote_log.expects(:archived_url).returns("https://s3.amazonaws.com/archive.travis-ci.org/jobs/#{job.id}/log.txt")
+        Travis::RemoteLog::Remote.expects(:new).returns(remote)
         stub_request(:get, "#{Travis.config.logs_api.url}/logs/#{job.id}?by=job_id&source=api")
           .to_return(
             status: 200,

--- a/spec/lib/model/job/test_spec.rb
+++ b/spec/lib/model/job/test_spec.rb
@@ -4,8 +4,10 @@ describe Job::Test do
 
   before :each do
     Travis::Event.stubs(:dispatch)
-    Travis::RemoteLog.stubs(:find_by_job_id).returns(log)
-    Travis::RemoteLog.stubs(:write_content_for_job_id).returns(log)
+    remote = stub('remote')
+    Travis::RemoteLog::Remote.stubs(:new).returns(remote)
+    remote.stubs(:find_by_job_id).returns(log)
+    remote.stubs(:write_content_for_job_id).returns(log)
   end
 
   it 'is cancelable if the job has not finished yet' do

--- a/spec/lib/services/find_log_spec.rb
+++ b/spec/lib/services/find_log_spec.rb
@@ -7,20 +7,26 @@ describe Travis::Services::FindLog do
     it 'finds the log with the given id' do
       params[:id] = 1
       found_by_id = stub('found-by-id', job_id: job.id)
-      Travis::RemoteLog.expects(:find_by_id).with(1).returns(found_by_id)
+      remote = stub('remote')
+      remote.expects(:find_by_id).with(1).returns(found_by_id)
+      Travis::RemoteLog::Remote.expects(:new).returns(remote)
       service.run.should == found_by_id
     end
 
     it 'finds the log with the given job_id' do
       params[:job_id] = job.id
       found_by_job_id = stub('found-by-job-id', job_id: job.id)
-      Travis::RemoteLog.expects(:find_by_job_id).with(job.id).returns(found_by_job_id)
+      remote = stub('remote')
+      remote.expects(:find_by_job_id).with(job.id).returns(found_by_job_id)
+      Travis::RemoteLog::Remote.expects(:new).returns(remote)
       service.run.should == found_by_job_id
     end
 
     it 'does not raise if the log could not be found' do
       params[:id] = 17
-      Travis::RemoteLog.expects(:find_by_id).with(17).returns(nil)
+      remote = stub('remote')
+      remote.expects(:find_by_id).with(17).returns(nil)
+      Travis::RemoteLog::Remote.expects(:new).returns(remote)
       lambda { service.run }.should_not raise_error
     end
   end

--- a/spec/lib/services/update_job_spec.rb
+++ b/spec/lib/services/update_job_spec.rb
@@ -9,8 +9,10 @@ describe Travis::Services::UpdateJob do
 
   before :each do
     build.matrix.delete_all
-    Travis::RemoteLog.stubs(:find_by_job_id).returns(log)
-    Travis::RemoteLog.stubs(:write_content_for_job_id).returns(log)
+    remote = stub('remote')
+    Travis::RemoteLog::Remote.stubs(:new).returns(remote)
+    remote.stubs(:find_by_job_id).returns(log)
+    remote.stubs(:write_content_for_job_id).returns(log)
   end
 
   describe '#cancel_job_in_worker' do

--- a/spec/unit/endpoint/logs_id_spec.rb
+++ b/spec/unit/endpoint/logs_id_spec.rb
@@ -24,13 +24,16 @@ describe Travis::Api::App::Endpoint::Logs, set_app: true do
     let(:public_job)  { public_build.matrix.first }
 
     before do
+      remote = stubs('remote')
+      Travis::RemoteLog::Remote.stubs(:new).returns(remote)
+
       private_job_id = private_job.id
       private_log = Travis::RemoteLog.new(content: 'private', job_id: private_job_id, id: 1)
-      Travis::RemoteLog.stubs(:find_by_id).with(1).returns(private_log)
+      remote.stubs(:find_by_id).with(1).returns(private_log)
 
       public_job_id = public_job.id
       public_log = Travis::RemoteLog.new(content: 'public', job_id: public_job_id, id: 2)
-      Travis::RemoteLog.stubs(:find_by_id).with(2).returns(public_log)
+      remote.stubs(:find_by_id).with(2).returns(public_log)
     end
 
     describe 'private mode, .com' do

--- a/spec/unit/endpoint/logs_spec.rb
+++ b/spec/unit/endpoint/logs_spec.rb
@@ -8,6 +8,9 @@ describe Travis::Api::App::Endpoint::Logs, set_app: true do
     let(:public_repo)    { Factory.create(:repository, private: false) }
     let!(:private_build) { Factory.create(:build, repository: private_repo, private: true) }
     let!(:public_build)  { Factory.create(:build, repository: public_repo, private: false) }
+    let(:public_migrated_repo) { Factory.create(:repository, private: false, migrated_at: 1.day.ago) }
+    let(:public_migrated_build) { Factory.create(:build, repository: public_migrated_repo, private: false) }
+    let(:public_migrated_job) { public_migrated_build.matrix.first }
     let(:authenticated_headers) {
       { 'HTTP_ACCEPT' => 'text/vnd.travis-ci.2+plain', 'HTTP_AUTHORIZATION' => "token #{token}" }
     }
@@ -26,11 +29,21 @@ describe Travis::Api::App::Endpoint::Logs, set_app: true do
     before do
       private_job_id = private_job.id
       private_log = Travis::RemoteLog.new(content: 'private', job_id: private_job_id)
-      Travis::RemoteLog.stubs(:find_by_job_id).with(private_job_id).returns(private_log)
+      remote = stub('remote')
+      Travis::RemoteLog::Remote.stubs(:new).returns(remote)
+      remote.stubs(:find_by_job_id).with(private_job_id).returns(private_log)
 
       public_job_id = public_job.id
       public_log = Travis::RemoteLog.new(content: 'public', job_id: public_job_id)
-      Travis::RemoteLog.stubs(:find_by_job_id).with(public_job_id).returns(public_log)
+      remote.stubs(:find_by_job_id).with(public_job_id).returns(public_log)
+      # We expect to hit org as well as the migrated job references the public
+      # job via its org_id.
+      fallback_remote = stub('fallback remote')
+      Travis::RemoteLog::Remote.stubs(:new).with(platform: :fallback).returns(fallback_remote)
+      fallback_remote.stubs(:find_by_job_id).with(public_job_id).returns(public_log)
+
+      restarted_public_migrated_log = Travis::RemoteLog.new(content: 'public restarted', job_id: public_migrated_job.id)
+      remote.stubs(:find_by_job_id).with(public_migrated_job.id).returns(restarted_public_migrated_log)
     end
 
     describe 'private mode, .com' do
@@ -107,6 +120,25 @@ describe Travis::Api::App::Endpoint::Logs, set_app: true do
           response = get("/jobs/#{public_job.id}/log", {}, authenticated_headers)
           response.should be_ok
           response.body.should == 'public'
+          response.headers["X-Log-Access-Token"].should be_nil
+        end
+
+        it 'responds with public log from .org when job already migrated not restarted' do
+          public_migrated_job.update_attribute(:org_id, public_job.id)
+          Factory.create(:permission, user: user, repository: public_migrated_repo)
+          response = get("/jobs/#{public_migrated_job.id}/log", {}, authenticated_headers)
+          response.should be_ok
+          response.body.should == 'public'
+          response.headers["X-Log-Access-Token"].should be_nil
+        end
+
+        it 'responds with public log from .com when job already migrated but since restarted' do
+          public_migrated_job.update_attribute(:org_id, public_job.id)
+          public_migrated_job.update_attribute(:restarted_at, 1.hour.ago)
+          Factory.create(:permission, user: user, repository: public_migrated_repo)
+          response = get("/jobs/#{public_migrated_job.id}/log", {}, authenticated_headers)
+          response.should be_ok
+          response.body.should == 'public restarted'
           response.headers["X-Log-Access-Token"].should be_nil
         end
       end

--- a/spec/v3/services/log/find_spec.rb
+++ b/spec/v3/services/log/find_spec.rb
@@ -78,7 +78,9 @@ describe Travis::API::V3::Services::Log::Find, set_app: true do
       key: "jobs/#{s3job.id}/log.txt",
       body: archived_content
     )
-    Travis::RemoteLog.stubs(:find_by_job_id).returns(Travis::RemoteLog.new(log_from_api))
+    remote = stubs('remote')
+    Travis::RemoteLog::Remote.stubs(:new).returns(remote)
+    remote.stubs(:find_by_job_id).returns(Travis::RemoteLog.new(log_from_api))
   end
   after { Fog::Mock.reset }
 


### PR DESCRIPTION
When a job is migrated from .org to .com we still want to be able to see logs. We don't want to move logs between S3 buckets, so instead we will request a log from .org logs app or .org bucket when needed.