### PR TITLE
Redirect badges to .com

### DIFF
--- a/lib/travis/api/app/responders/badge.rb
+++ b/lib/travis/api/app/responders/badge.rb
@@ -5,8 +5,12 @@ module Travis::Api::App::Responders
     end
 
     def apply
-      set_headers
-      send_file(filename, type: :svg, last_modified: last_modified)
+      if redirect_to_com?
+        redirect_to_com
+      else
+        set_headers
+        send_file(filename, type: :svg, last_modified: last_modified)
+      end
     end
 
     def content_type

--- a/lib/travis/api/app/responders/image.rb
+++ b/lib/travis/api/app/responders/image.rb
@@ -11,8 +11,12 @@ module Travis::Api::App::Responders
     end
 
     def apply
-      set_headers
-      send_file(filename, type: :png, last_modified: last_modified)
+      if redirect_to_com?
+        redirect_to_com
+      else
+        set_headers
+        send_file(filename, type: :png, last_modified: last_modified)
+      end
     end
 
     def apply?
@@ -47,5 +51,16 @@ module Travis::Api::App::Responders
         resource ? resource.last_build_finished_at : nil
       end
 
+      def redirect_to_com?
+        Travis.config.org? && ((resource.is_a?(Repository) && resource.migrated?) || resource.nil?)
+      end
+
+      def redirect_to_com
+        path = endpoint.request.path_info.sub(/^\/repo_status/, '')
+        url = [Travis.config.com_url, path].join
+        url = [url, endpoint.env['travis.format_from_path']].join('.') if endpoint.env['travis.format_from_path']
+        url = [url, endpoint.request.query_string].join('?') if endpoint.request.query_string.present?
+        endpoint.redirect(url, 301)
+      end
   end
 end

--- a/lib/travis/config/defaults.rb
+++ b/lib/travis/config/defaults.rb
@@ -88,6 +88,10 @@ module Travis
       load_urls
     end
 
+    def com_url
+      "https://#{host.sub(/org$/, 'com')}"
+    end
+
     def org?
       host.ends_with?('travis-ci.org')
     end

--- a/lib/travis/model/repository.rb
+++ b/lib/travis/model/repository.rb
@@ -210,4 +210,8 @@ class Repository < Travis::Model
   def allow_migration?
     Travis::Features.feature_active?(:allow_merge_globally) && Travis::Features.owner_active?(:allow_migration, self.owner)
   end
+
+  def migrated?
+    migration_status == 'migrated'
+  end
 end


### PR DESCRIPTION
At the moment most of the READMEs of open source projects and some
services (like cargo, npm etc) point to travis-ci.org as a source of
badges. In order to make it easier to transition this commit changes the
behaviour of badges to redirect some of the badges requests to .com. If
a repo is migrated, a request for a badge will be redirected to .com. If
a repo is not found, a request would also be redirected to .com, which
will ensure that new repos on .com will also be available when using the
.org url.