### PR TITLE
Enterprise backport #915 return 409 if repo ssh key is missing on repo activate

### DIFF
--- a/lib/travis/api/v3.rb
+++ b/lib/travis/api/v3.rb
@@ -43,6 +43,8 @@ module Travis
       MethodNotAllowed    = ClientError        .create('method not allowed', status: 405)
       NotImplemented      = ServerError        .create('request not (yet) implemented', status: 501)
       PrivateRepoFeature  = ClientError        .create('this feature is only available on private repositories and for Travis CI Enterprise customers', status: 403)
+      RepositoryInactive  = ClientError        .create('cannot create requests on an inactive repository', status: 406)
+      RepoSshKeyMissing   = ClientError        .create('request cannot be completed because the repo ssh key is still pending to be created. please retry in a bit, or try syncing the repository if this condition does not resolve', status: 409)
       RequestLimitReached = ClientError        .create('request limit reached for resource', status: 429)
       SourceUnknown       = NotFound           .create('source unknown', status: 400)
       UnprocessableEntity = ClientError        .create('request unable to be processed due to semantic errors', status: 422)

--- a/lib/travis/api/v3/services/repository/activate.rb
+++ b/lib/travis/api/v3/services/repository/activate.rb
@@ -3,7 +3,14 @@ require 'travis/api/v3/services/repository/deactivate'
 module Travis::API::V3
   class Services::Repository::Activate < Services::Repository::Deactivate
     def run!
-      repository = super(true).resource
+      repository = check_login_and_find(:repository)
+      check_access(repository)
+      check_repo_key(repository)
+      return repo_migrated if migrated?(repository)
+
+      admin = access_control.admin_for(repository)
+      github(admin).set_hook(repository, true)
+      repository.update_attributes(active: true)
 
       if repository.private? || access_control.enterprise?
         admin = access_control.admin_for(repository)
@@ -16,6 +23,10 @@ module Travis::API::V3
 
     def check_access(repository)
       access_control.permissions(repository).activate!
+    end
+
+    def check_repo_key(repository)
+      raise RepoSshKeyMissing if repository.key.nil?
     end
   end
 end


### PR DESCRIPTION
Backporting https://github.com/travis-ci/travis-api/pull/915 in the Enterprise 2.2. branch