### PR TITLE
Add history migration status to standard repository representation

### DIFF
--- a/lib/travis/api/v3/renderer/repository.rb
+++ b/lib/travis/api/v3/renderer/repository.rb
@@ -1,7 +1,7 @@
 module Travis::API::V3
   class Renderer::Repository < ModelRenderer
     representation(:minimal,  :id, :name, :slug)
-    representation(:standard, :id, :name, :slug, :description, :github_id, :github_language, :active, :private, :owner, :default_branch, :starred, :managed_by_installation, :active_on_org, :migration_status)
+    representation(:standard, :id, :name, :slug, :description, :github_id, :github_language, :active, :private, :owner, :default_branch, :starred, :managed_by_installation, :active_on_org, :migration_status, :history_migration_status)
     representation(:experimental, :id, :name, :slug, :description, :github_id, :github_language, :active, :private, :owner, :default_branch, :starred, :current_build, :last_started_build, :next_build_number)
     representation(:additional, :allow_migration)
 

--- a/spec/v3/services/beta_feature/update_spec.rb
+++ b/spec/v3/services/beta_feature/update_spec.rb
@@ -72,13 +72,13 @@ describe Travis::API::V3::Services::BetaFeature::Update, set_app: true do
       expect(user.reload.beta_features.first.name).to eq 'FOO2'
     end
     example 'updates last activated at' do
-      expect(user.user_beta_features.last.last_activated_at.to_s).to eq Time.now.utc.to_s
+      expect(user.user_beta_features.last.last_activated_at).to be_within(1.second).of Time.now.utc
     end
     example 'sets last deactivated at' do
       Timecop.travel(10) do
         params['beta_feature.enabled'] = false
         patch("/v3/user/#{user.id}/beta_feature/#{beta_feature.id}", JSON.generate(params), auth_headers.merge(json_headers))
-        expect(user.user_beta_features.last.last_deactivated_at.utc.to_s).to eq Time.now.utc.to_s
+        expect(user.user_beta_features.last.last_deactivated_at.utc).to be_within(1.second).of Time.now.utc
       end
     end
   end

--- a/spec/v3/services/owner/find_spec.rb
+++ b/spec/v3/services/owner/find_spec.rb
@@ -98,6 +98,7 @@ describe Travis::API::V3::Services::Owner::Find, set_app: true do
           "managed_by_installation"=>false,
           "active_on_org"     => nil,
           "migration_status"  => nil,
+          "history_migration_status"  => nil
         }]
       }}
     end
@@ -157,7 +158,8 @@ describe Travis::API::V3::Services::Owner::Find, set_app: true do
           "starred"         => false,
           "managed_by_installation"=>false,
           "active_on_org"   => nil,
-          "migration_status" => nil
+          "migration_status" => nil,
+          "history_migration_status"  => nil
         }]
       }}
     end

--- a/spec/v3/services/repositories/for_current_user_spec.rb
+++ b/spec/v3/services/repositories/for_current_user_spec.rb
@@ -71,7 +71,8 @@ describe Travis::API::V3::Services::Repositories::ForCurrentUser, set_app: true 
         "starred"            => false,
         "managed_by_installation"=>false,
         "active_on_org"=>nil,
-        "migration_status" => nil
+        "migration_status" => nil,
+        "history_migration_status" => nil
         }]
     }}
   end

--- a/spec/v3/services/repositories/for_owner_spec.rb
+++ b/spec/v3/services/repositories/for_owner_spec.rb
@@ -92,7 +92,8 @@ describe Travis::API::V3::Services::Repositories::ForOwner, set_app: true do
           "starred"          => false,
           "managed_by_installation"=>false,
           "active_on_org"    => nil,
-          "migration_status" => nil
+          "migration_status" => nil,
+          "history_migration_status"  => nil
         }]}}
   end
 
@@ -139,6 +140,7 @@ describe Travis::API::V3::Services::Repositories::ForOwner, set_app: true do
         "managed_by_installation"=>false,
         "active_on_org"     => nil,
         "migration_status"  => nil,
+        "history_migration_status"  => nil,
         "last_started_build"=>{
           "@type"          =>"build",
           "@href"          =>"/v3/build/#{build.id}",
@@ -245,6 +247,7 @@ describe Travis::API::V3::Services::Repositories::ForOwner, set_app: true do
         "managed_by_installation"=> false,
         "active_on_org"    => nil,
         "migration_status" => nil,
+        "history_migration_status"  => nil,
         "current_build" => {
           "@type"               => "build",
           "@href"               => "/v3/build/#{build.id}",
@@ -396,7 +399,8 @@ describe Travis::API::V3::Services::Repositories::ForOwner, set_app: true do
         "starred"         => false,
         "managed_by_installation"=>false,
         "active_on_org"   => nil,
-        "migration_status" => nil}, {
+        "migration_status" => nil,
+        "history_migration_status"  => nil}, {
         "@type"           => "repository",
         "@href"           => "/v3/repo/#{repo2.id}",
         "@representation" => "standard",
@@ -435,6 +439,7 @@ describe Travis::API::V3::Services::Repositories::ForOwner, set_app: true do
           "starred"        => false,
           "managed_by_installation"=>false,
           "active_on_org"  =>nil,
-          "migration_status" => nil}]}
+          "migration_status" => nil,
+          "history_migration_status" => nil}]}
   end
 end

--- a/spec/v3/services/repository/find_spec.rb
+++ b/spec/v3/services/repository/find_spec.rb
@@ -94,7 +94,8 @@ describe Travis::API::V3::Services::Repository::Find, set_app: true do
       "starred"            => false,
       "active_on_org"      => nil,
       "managed_by_installation" => false,
-      "migration_status"   => nil
+      "migration_status"   => nil,
+      "history_migration_status" => nil
     })}
   end
 


### PR DESCRIPTION
This is necessary as part of the Merge work to ensure that we can avoid showing the banner within travis-web notifying users to navigate to org to view their build history after it has been successfully migrated.