### PR TITLE
Order builds by number::int DESC by default

### DIFF
--- a/lib/travis/api/v3/queries/builds.rb
+++ b/lib/travis/api/v3/queries/builds.rb
@@ -3,8 +3,9 @@ module Travis::API::V3
     params :state, :event_type, :previous_state, :created_by, prefix: :build
     params :name, prefix: :branch, method_name: :branch_name
 
-    sortable_by :id, :created_at, :started_at, :finished_at
-    default_sort "created_at:desc,id:desc"
+    sortable_by :id, :created_at, :started_at, :finished_at,
+      number: "number::int %{order}"
+    default_sort "number:desc,id:desc"
 
     def find(repository)
       sort filter(repository.builds)


### PR DESCRIPTION
After we import the build history from .org to .com we may end up with
id and created_at fields out of sync with numbers. Historically a lower
created_at or id values where always also lower number values. After the
import it's no longer true. That's why we want to change the default
sort value