### PR TITLE
Allow multiple env vars that have same name with different branch.

### DIFF
--- a/lib/travis/api/v3/models/env_var.rb
+++ b/lib/travis/api/v3/models/env_var.rb
@@ -8,13 +8,17 @@ module Travis::API::V3
     attribute :repository_id, Integer
 
     validates :name, presence: true
-    validates_each :id, :name do |record, attr, value|
-      others = record.repository.env_vars.select { |ev| ev.id != record.id }
-      record.errors.add(:base, :duplicate_resource) if others.find { |ev| ev.send(attr) == record.send(attr) }
-    end
+    validate :check_duplicates
 
     def repository
       @repository ||= Models::Repository.find(repository_id)
+    end
+
+    private
+
+    def check_duplicates
+      others = repository.env_vars.select { |ev| ev.id != id }
+      errors.add(:base, :duplicate_resource) if others.find { |ev| ev.name == name && ev.branch == branch }
     end
   end
 end


### PR DESCRIPTION
It's possible on Travis CI web console but currently the API v3 returns the error `409 resource already exists`. This PR makes it possible via the API.

<img width="1350" alt="スクリーンショット 2019-08-24 15 09 37" src="https://user-images.githubusercontent.com/899217/63633304-56272e80-c681-11e9-8ece-6eb9626041d5.png">
