### PR TITLE
added additional params for subscription cancellation

### DIFF
--- a/lib/travis/api/v3/billing_client.rb
+++ b/lib/travis/api/v3/billing_client.rb
@@ -58,8 +58,8 @@ module Travis::API::V3
       handle_errors_and_respond(response)
     end
 
-    def cancel_subscription(id)
-      response = connection.post("/subscriptions/#{id}/cancel")
+    def cancel_subscription(id, reason_data)
+      response = connection.post("/subscriptions/#{id}/cancel", reason_data)
       handle_errors_and_respond(response)
     end
 

--- a/lib/travis/api/v3/queries/subscription.rb
+++ b/lib/travis/api/v3/queries/subscription.rb
@@ -7,8 +7,9 @@ module Travis::API::V3
     end
 
     def cancel(user_id)
+      reason_data = params.dup.tap { |h| h.delete('subscription.id') }
       client = BillingClient.new(user_id)
-      client.cancel_subscription(params['subscription.id'])
+      client.cancel_subscription(params['subscription.id'], reason_data)
     end
 
     def update_creditcard(user_id)

--- a/lib/travis/api/v3/services/subscription/cancel.rb
+++ b/lib/travis/api/v3/services/subscription/cancel.rb
@@ -1,5 +1,7 @@
 module Travis::API::V3
   class Services::Subscription::Cancel < Service
+    params :reason, :reason_details
+
     def run!
       raise LoginRequired unless access_control.full_access_or_logged_in?
       query.cancel(access_control.user.id)

--- a/spec/v3/billing_client_spec.rb
+++ b/spec/v3/billing_client_spec.rb
@@ -121,7 +121,8 @@ describe Travis::API::V3::BillingClient, billing_spec_helper: true do
   end
 
   describe '#cancel_subscription' do
-    subject { billing.cancel_subscription(subscription_id) }
+    let(:reason_data) { { 'reason' => 'Other', 'reason_details' => 'Cancellation details go here' } }
+    subject { billing.cancel_subscription(subscription_id, reason_data) }
 
     it 'requests the cancelation of a subscription' do
       stubbed_request = stub_billing_request(:post, "/subscriptions/#{subscription_id}/cancel", auth_key: auth_key, user_id: user_id)

--- a/spec/v3/services/subscription/cancel_spec.rb
+++ b/spec/v3/services/subscription/cancel_spec.rb
@@ -1,6 +1,7 @@
 describe Travis::API::V3::Services::Subscription::Cancel, set_app: true, billing_spec_helper: true do
   let(:billing_url) { 'http://billingfake.travis-ci.com' }
   let(:billing_auth_key) { 'secret' }
+  let(:reason_data) { {"reason"=>"Other", "reason_details"=>"Cancellation details go here"} }
 
   before do
     Travis.config.billing.url = billing_url
@@ -9,7 +10,7 @@ describe Travis::API::V3::Services::Subscription::Cancel, set_app: true, billing
 
   context 'unauthenticated' do
     it 'responds 403' do
-      post('/v3/subscription/123/cancel')
+      post('/v3/subscription/123/cancel', { })
 
       expect(last_response.status).to eq(403)
     end
@@ -24,11 +25,12 @@ describe Travis::API::V3::Services::Subscription::Cancel, set_app: true, billing
 
     let!(:stubbed_request) do
       stub_billing_request(:post, "/subscriptions/#{subscription_id}/cancel", auth_key: billing_auth_key, user_id: user.id)
+        .with(body: reason_data)
         .to_return(status: 204)
     end
 
     it 'cancels the subscription' do
-      post("/v3/subscription/#{subscription_id}/cancel", nil, headers)
+      post("/v3/subscription/#{subscription_id}/cancel", JSON.generate(reason_data), headers)
 
       expect(last_response.status).to eq(204)
       expect(stubbed_request).to have_been_made.once


### PR DESCRIPTION
While cancelling a subscription, the api has been updated to pass along additional data related to cancellation reason.