### PR TITLE
Rename lead resource, update endpoint

### DIFF
--- a/lib/travis/api/v3/models/leads.rb
+++ b/lib/travis/api/v3/models/leads.rb
@@ -1,5 +1,5 @@
 module Travis::API::V3
-  class Models::Lead
+  class Models::Leads
     attr_reader :id, :name, :status_label, :contacts, :custom
 
     def initialize(attributes = {})

--- a/lib/travis/api/v3/renderer/leads.rb
+++ b/lib/travis/api/v3/renderer/leads.rb
@@ -1,5 +1,5 @@
 module Travis::API::V3
-  class Renderer::Lead < ModelRenderer
+  class Renderer::Leads < ModelRenderer
     representation(:standard, :id, :name, :status_label, :contacts, :custom)
   end
 end

--- a/lib/travis/api/v3/routes.rb
+++ b/lib/travis/api/v3/routes.rb
@@ -325,8 +325,8 @@ module Travis::API::V3
       get :active_repos, '/repos/active'
     end
 
-    hidden_resource :lead do
-      route '/lead'
+    hidden_resource :leads do
+      route '/leads'
       post :create
     end
   end

--- a/lib/travis/api/v3/services.rb
+++ b/lib/travis/api/v3/services.rb
@@ -27,7 +27,7 @@ module Travis::API::V3
     Job                   = Module.new { extend Services }
     Jobs                  = Module.new { extend Services }
     KeyPair               = Module.new { extend Services }
-    Lead                  = Module.new { extend Services }
+    Leads                 = Module.new { extend Services }
     Lint                  = Module.new { extend Services }
     Log                   = Module.new { extend Services }
     Messages              = Module.new { extend Services }

--- a/lib/travis/api/v3/services/leads/create.rb
+++ b/lib/travis/api/v3/services/leads/create.rb
@@ -2,8 +2,8 @@ require 'uri'
 require 'closeio'
 
 module Travis::API::V3
-  class Services::Lead::Create < Service
-    result_type :lead
+  class Services::Leads::Create < Service
+    result_type :leads
     params :name, :email, :team_size, :phone, :message, :utm_source
 
     def run!
@@ -45,7 +45,7 @@ module Travis::API::V3
       note = api_client.create_note({ lead_id: lead['id'], note: message })
 
       # Return result
-      model = Travis::API::V3::Models::Lead.new(lead)
+      model = Travis::API::V3::Models::Leads.new(lead)
       result model
     end
   end

--- a/spec/v3/services/leads/create_spec.rb
+++ b/spec/v3/services/leads/create_spec.rb
@@ -1,8 +1,8 @@
-describe Travis::API::V3::Services::Lead::Create, set_app: true do
+describe Travis::API::V3::Services::Leads::Create, set_app: true do
   let(:user) { Factory(:user) }
   let(:token) { Travis::Api::App::AccessToken.create(user: user, app_id: 1) }
   let(:headers) {{ 'HTTP_AUTHORIZATION' => "token #{token}" }}
-  let(:endpoint) { "/v3/lead" }
+  let(:endpoint) { "/v3/leads" }
   let(:parsed_body) { JSON.load(body) }
   let(:full_options) {{
     "name" => "Test Name",
@@ -14,7 +14,7 @@ describe Travis::API::V3::Services::Lead::Create, set_app: true do
   }}
   let(:options) { full_options }
   let(:expected_lead_data) {{
-    "@type"           => "lead",
+    "@type"           => "leads",
     "@representation" => "standard",
     "id"              => "lead_12345",
     "name"            => options['name'],


### PR DESCRIPTION
The point of this PR is to more closely follow the convention of POSTing to plural endpoints. This is safe to do because right now only an in-development project (travis-web plans page) uses the `/lead` endpoint.