### PR TITLE
leads create: add utm fields and lead source

### DIFF
--- a/lib/travis/api/v3/services/leads/create.rb
+++ b/lib/travis/api/v3/services/leads/create.rb
@@ -4,11 +4,11 @@ require 'closeio'
 module Travis::API::V3
   class Services::Leads::Create < Service
     result_type :leads
-    params :name, :email, :team_size, :phone, :message, :utm_source
+    params :name, :email, :team_size, :phone, :message, :lead_source, :utm_fields
 
     def run!
       # Get params
-      name, email, team_size, phone, message, utm_source = params.values_at('name', 'email', 'team_size', 'phone', 'message', 'utm_source')
+      name, email, team_size, phone, message, lead_source, utm_fields = params.values_at('name', 'email', 'team_size', 'phone', 'message', 'lead_source', 'utm_fields')
       team_size = team_size.to_i unless team_size.nil?
       name = name.strip unless name.nil?
       message = message.strip unless message.nil?
@@ -22,23 +22,31 @@ module Travis::API::V3
       # Prep data for request
       api_client = Closeio::Client.new(Travis.config.closeio.key)
       custom_fields = api_client.list_custom_fields
-      team_size_field = custom_fields['data'].find { |field| field['name'] == 'team_size' }
-      utm_source_field = custom_fields['data'].find { |field| field['name'] == 'utm_source' }
+      team_size_field = fetch_custom_field(custom_fields, 'team_size')
+      lead_source_field = fetch_custom_field(custom_fields, 'lead_source')
 
       phones = []
       phones.push({ type: "office", phone: phone }) unless phone.nil?
 
       lead_data = {
         name: name,
-        "custom.#{utm_source_field['id']}": utm_source || 'Travis API',
         contacts: [{
           name: name,
           emails: [{ type: "office", email: email }],
           phones: phones
-        }]
+        }],
+        "custom.#{lead_source_field['id']}": lead_source || 'Travis API',
       }
 
       lead_data["custom.#{team_size_field['id']}"] = team_size if team_size
+
+      # Handle UTM fields
+      supported_utm_fields = ['utm_source', 'utm_campaign', 'utm_medium', 'utm_term', 'utm_content']
+      supported_utm_fields.each do |field_name|
+        field = fetch_custom_field(custom_fields, field_name)
+        field_data = utm_fields[field_name]
+        lead_data["custom.#{field['id']}"] = field_data if field && field_data
+      end
 
       # Send request
       lead = api_client.create_lead(lead_data)
@@ -47,6 +55,12 @@ module Travis::API::V3
       # Return result
       model = Travis::API::V3::Models::Leads.new(lead)
       result model
+    end
+
+    private
+  
+    def fetch_custom_field(custom_fields, field_name)
+      custom_fields['data'].find { |field| field['name'] == field_name }
     end
   end
 end

--- a/lib/travis/api/v3/services/leads/create.rb
+++ b/lib/travis/api/v3/services/leads/create.rb
@@ -44,7 +44,7 @@ module Travis::API::V3
       supported_utm_fields = ['utm_source', 'utm_campaign', 'utm_medium', 'utm_term', 'utm_content']
       supported_utm_fields.each do |field_name|
         field = fetch_custom_field(custom_fields, field_name)
-        field_data = utm_fields[field_name]
+        field_data = utm_fields[field_name] if utm_fields
         lead_data["custom.#{field['id']}"] = field_data if field && field_data
       end
 

--- a/spec/v3/services/leads/create_spec.rb
+++ b/spec/v3/services/leads/create_spec.rb
@@ -10,7 +10,14 @@ describe Travis::API::V3::Services::Leads::Create, set_app: true do
     "team_size" => "123",
     "phone" => "+1 123-456-7890",
     "message" => "Interested in CI",
-    "utm_source" => "Custom Source"
+    "lead_source" => "Custom Source",
+    "utm_fields" => {
+      "utm_source" => "Custom UTM source",
+      "utm_campaign" => "Custom UTM campaign",
+      "utm_medium" => "Custom UTM medium",
+      "utm_term" => "Custom UTM term",
+      "utm_content" => "Custom UTM content"
+    }
   }}
   let(:options) { full_options }
   let(:expected_lead_data) {{
@@ -27,8 +34,13 @@ describe Travis::API::V3::Services::Leads::Create, set_app: true do
     }],
 
     "custom"          => {
-      "utm_source" => options['utm_source'],
+      "lead_source" => options['lead_source'],
       "team_size"  => options['team_size'],
+      "utm_source" => options['utm_fields']['utm_source'],
+      "utm_campaign" => options['utm_fields']['utm_campaign'],
+      "utm_medium" => options['utm_fields']['utm_medium'],
+      "utm_term" => options['utm_fields']['utm_term'],
+      "utm_content" => options['utm_fields']['utm_content']
     }
   }}
 
@@ -60,7 +72,7 @@ describe Travis::API::V3::Services::Leads::Create, set_app: true do
       status: stubbed_response_status,
       body: JSON.dump({ "data" => [
         { "name" => "team_size", "id" => "23456" },
-        { "name" => "utm_source", "id" => "34567" },
+        { "name" => "lead_source", "id" => "34567" },
       ]}),
       headers: stubbed_response_headers
     )
@@ -80,7 +92,7 @@ describe Travis::API::V3::Services::Leads::Create, set_app: true do
       "team_size" => full_options['team_size'],
       "phone" => full_options['phone'],
       "message" => full_options['message'],
-      "utm_source" => full_options['utm_source']
+      "lead_source" => full_options['lead_source']
     }}
     let(:expected_lead_data) {{
       "@type"         => "error",
@@ -103,7 +115,7 @@ describe Travis::API::V3::Services::Leads::Create, set_app: true do
       "email" => full_options['email'],
       "team_size" => full_options['team_size'],
       "phone" => full_options['phone'],
-      "utm_source" => full_options['utm_source']
+      "lead_source" => full_options['lead_source']
     }}
     let(:expected_lead_data) {{
       "@type"         => "error",
@@ -126,7 +138,7 @@ describe Travis::API::V3::Services::Leads::Create, set_app: true do
       "team_size" => full_options['team_size'],
       "phone" => full_options['phone'],
       "message" => full_options['message'],
-      "utm_source" => full_options['utm_source']
+      "lead_source" => full_options['lead_source']
     }}
     let(:expected_lead_data) {{
       "@type"         => "error",
@@ -150,7 +162,7 @@ describe Travis::API::V3::Services::Leads::Create, set_app: true do
       "team_size" => full_options['team_size'],
       "phone" => full_options['phone'],
       "message" => full_options['message'],
-      "utm_source" => full_options['utm_source']
+      "lead_source" => full_options['lead_source']
     }}
     let(:expected_lead_data) {{
       "@type"         => "error",
@@ -174,7 +186,7 @@ describe Travis::API::V3::Services::Leads::Create, set_app: true do
       "team_size" => 'invalid team size',
       "phone" => full_options['phone'],
       "message" => full_options['message'],
-      "utm_source" => full_options['utm_source']
+      "lead_source" => full_options['lead_source']
     }}
     let(:expected_lead_data) {{
       "@type"         => "error",
@@ -198,7 +210,7 @@ describe Travis::API::V3::Services::Leads::Create, set_app: true do
       "team_size" => -5,
       "phone" => full_options['phone'],
       "message" => full_options['message'],
-      "utm_source" => full_options['utm_source']
+      "lead_source" => full_options['lead_source']
     }}
     let(:expected_lead_data) {{
       "@type"         => "error",


### PR DESCRIPTION
For https://travisci.assembla.com/spaces/Web/tickets/220/details

I would like to launch this update just a bit ahead of https://github.com/travis-ci/travis-web/pull/2175. I tested this update against what's currently in production for `travis-web` and it functions fine, it just won't capture the `lead_source` until the 2175 updates are in place on `travis-web`.