### PR TITLE
Fix lead source issue

### DIFF
--- a/lib/travis/api/v3/services/leads/create.rb
+++ b/lib/travis/api/v3/services/leads/create.rb
@@ -35,7 +35,8 @@ module Travis::API::V3
           emails: [{ type: "office", email: email }],
           phones: phones
         }],
-        "custom.#{lead_source_field['id']}": lead_source || 'Travis API',
+        # lead_source does not exist yet on production CloseIO account
+        # "custom.#{lead_source_field['id']}": lead_source || 'Travis API',
       }
 
       lead_data["custom.#{team_size_field['id']}"] = team_size if team_size


### PR DESCRIPTION
`lead_source` does not exist as a custom field on the production CloseIO account, and I don't have the necessary permissions to create it. So commenting out for now.