### PR TITLE
[Plans] Add referral_source

### DIFF
--- a/lib/travis/api/v3/services/leads/create.rb
+++ b/lib/travis/api/v3/services/leads/create.rb
@@ -4,11 +4,11 @@ require 'closeio'
 module Travis::API::V3
   class Services::Leads::Create < Service
     result_type :leads
-    params :name, :email, :team_size, :phone, :message, :lead_source, :utm_fields
+    params :name, :email, :team_size, :phone, :message, :referral_source, :utm_fields
 
     def run!
       # Get params
-      name, email, team_size, phone, message, lead_source, utm_fields = params.values_at('name', 'email', 'team_size', 'phone', 'message', 'lead_source', 'utm_fields')
+      name, email, team_size, phone, message, referral_source, utm_fields = params.values_at('name', 'email', 'team_size', 'phone', 'message', 'referral_source', 'utm_fields')
       team_size = team_size.to_i unless team_size.nil?
       name = name.strip unless name.nil?
       message = message.strip unless message.nil?
@@ -23,7 +23,7 @@ module Travis::API::V3
       api_client = Closeio::Client.new(Travis.config.closeio.key)
       custom_fields = api_client.list_custom_fields
       team_size_field = fetch_custom_field(custom_fields, 'team_size')
-      lead_source_field = fetch_custom_field(custom_fields, 'lead_source')
+      referral_source_field = fetch_custom_field(custom_fields, 'referral_source')
 
       phones = []
       phones.push({ type: "office", phone: phone }) unless phone.nil?
@@ -38,7 +38,7 @@ module Travis::API::V3
       }
 
       lead_data["custom.#{team_size_field['id']}"] = team_size if team_size_field && team_size
-      lead_data["custom.#{lead_source_field['id']}"] = lead_source || 'Travis API' if lead_source_field
+      lead_data["custom.#{referral_source_field['id']}"] = referral_source || 'Travis API' if referral_source_field
 
       # Handle UTM fields
       supported_utm_fields = ['utm_source', 'utm_campaign', 'utm_medium', 'utm_term', 'utm_content']

--- a/lib/travis/api/v3/services/leads/create.rb
+++ b/lib/travis/api/v3/services/leads/create.rb
@@ -35,11 +35,10 @@ module Travis::API::V3
           emails: [{ type: "office", email: email }],
           phones: phones
         }],
-        # lead_source does not exist yet on production CloseIO account
-        # "custom.#{lead_source_field['id']}": lead_source || 'Travis API',
       }
 
-      lead_data["custom.#{team_size_field['id']}"] = team_size if team_size
+      lead_data["custom.#{team_size_field['id']}"] = team_size if team_size_field && team_size
+      lead_data["custom.#{lead_source_field['id']}"] = lead_source || 'Travis API' if lead_source_field
 
       # Handle UTM fields
       supported_utm_fields = ['utm_source', 'utm_campaign', 'utm_medium', 'utm_term', 'utm_content']

--- a/spec/v3/services/leads/create_spec.rb
+++ b/spec/v3/services/leads/create_spec.rb
@@ -10,7 +10,7 @@ describe Travis::API::V3::Services::Leads::Create, set_app: true do
     "team_size" => "123",
     "phone" => "+1 123-456-7890",
     "message" => "Interested in CI",
-    "lead_source" => "Custom Source",
+    "referral_source" => "Custom Source",
     "utm_fields" => {
       "utm_source" => "Custom UTM source",
       "utm_campaign" => "Custom UTM campaign",
@@ -34,7 +34,7 @@ describe Travis::API::V3::Services::Leads::Create, set_app: true do
     }],
 
     "custom"          => {
-      "lead_source" => options['lead_source'],
+      "referral_source" => options['referral_source'],
       "team_size"  => options['team_size'],
       "utm_source" => options['utm_fields']['utm_source'],
       "utm_campaign" => options['utm_fields']['utm_campaign'],
@@ -72,7 +72,7 @@ describe Travis::API::V3::Services::Leads::Create, set_app: true do
       status: stubbed_response_status,
       body: JSON.dump({ "data" => [
         { "name" => "team_size", "id" => "23456" },
-        { "name" => "lead_source", "id" => "34567" },
+        { "name" => "referral_source", "id" => "34567" },
       ]}),
       headers: stubbed_response_headers
     )
@@ -92,7 +92,7 @@ describe Travis::API::V3::Services::Leads::Create, set_app: true do
       "team_size" => full_options['team_size'],
       "phone" => full_options['phone'],
       "message" => full_options['message'],
-      "lead_source" => full_options['lead_source']
+      "referral_source" => full_options['referral_source']
     }}
     let(:expected_lead_data) {{
       "@type"         => "error",
@@ -115,7 +115,7 @@ describe Travis::API::V3::Services::Leads::Create, set_app: true do
       "email" => full_options['email'],
       "team_size" => full_options['team_size'],
       "phone" => full_options['phone'],
-      "lead_source" => full_options['lead_source']
+      "referral_source" => full_options['referral_source']
     }}
     let(:expected_lead_data) {{
       "@type"         => "error",
@@ -138,7 +138,7 @@ describe Travis::API::V3::Services::Leads::Create, set_app: true do
       "team_size" => full_options['team_size'],
       "phone" => full_options['phone'],
       "message" => full_options['message'],
-      "lead_source" => full_options['lead_source']
+      "referral_source" => full_options['referral_source']
     }}
     let(:expected_lead_data) {{
       "@type"         => "error",
@@ -162,7 +162,7 @@ describe Travis::API::V3::Services::Leads::Create, set_app: true do
       "team_size" => full_options['team_size'],
       "phone" => full_options['phone'],
       "message" => full_options['message'],
-      "lead_source" => full_options['lead_source']
+      "referral_source" => full_options['referral_source']
     }}
     let(:expected_lead_data) {{
       "@type"         => "error",
@@ -186,7 +186,7 @@ describe Travis::API::V3::Services::Leads::Create, set_app: true do
       "team_size" => 'invalid team size',
       "phone" => full_options['phone'],
       "message" => full_options['message'],
-      "lead_source" => full_options['lead_source']
+      "referral_source" => full_options['referral_source']
     }}
     let(:expected_lead_data) {{
       "@type"         => "error",
@@ -210,7 +210,7 @@ describe Travis::API::V3::Services::Leads::Create, set_app: true do
       "team_size" => -5,
       "phone" => full_options['phone'],
       "message" => full_options['message'],
-      "lead_source" => full_options['lead_source']
+      "referral_source" => full_options['referral_source']
     }}
     let(:expected_lead_data) {{
       "@type"         => "error",


### PR DESCRIPTION
I commented out the `lead_source` code because that custom field didn't exist on the production `close` account and it was causing problems. Now Jan added the field, so I'm reintroducing the code for the field. Except that now it's going to be named `referral_source`, at the request of the marketing team. I've also added a check to make sure the field exists before we try to do anything with it.