### PR TITLE
Replace netaddr by ipaddress to resolve security vulnerability

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -35,7 +35,7 @@ gem 'metriks-librato_metrics', git: 'https://github.com/eric/metriks-librato_met
 gem 'librato-metrics'
 gem 'simplecov'
 gem 'stackprof'
-gem 'netaddr'
+gem "ipaddress", "~> 0.8.3"
 gem 'nakayoshi_fork'
 gem 'sidekiq'
 gem 'redis-namespace'
@@ -96,3 +96,4 @@ group :development do
   gem 'rerun'
   gem 'rb-fsevent', '~> 0.9.1'
 end
+

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -268,7 +268,6 @@ GEM
     nakayoshi_fork (0.0.3)
     net-http-persistent (2.9.4)
     net-http-pipeline (1.0.1)
-    netaddr (1.5.1)
     nokogiri (1.10.4)
       mini_portile2 (~> 2.4.0)
     opencensus (0.3.1)
@@ -424,6 +423,7 @@ DEPENDENCIES
   google-api-client (~> 0.9.4)
   hashdiff
   hashr
+  ipaddress (~> 0.8.3)
   jemalloc!
   knapsack
   libhoney
@@ -438,7 +438,6 @@ DEPENDENCIES
   multi_json
   mustermann
   nakayoshi_fork
-  netaddr
   opencensus
   opencensus-stackdriver
   pg (~> 0.21)

--- a/lib/travis/api/attack.rb
+++ b/lib/travis/api/attack.rb
@@ -1,5 +1,5 @@
 require 'rack/attack'
-require 'netaddr'
+require 'ipaddress'
 require 'metriks'
 
 ActiveSupport::Notifications.subscribe('rack.attack') do |name, start, finish, request_id, req|
@@ -44,8 +44,8 @@ class Rack::Attack
   ]
 
   GITHUB_CIDRS = [
-    NetAddr::CIDR.create('192.30.252.0/22'),
-    NetAddr::CIDR.create('185.199.108.0/22'),
+    IPAddress.parse('192.30.252.0/22'),
+    IPAddress.parse('185.199.108.0/22'),
   ]
 
   safelist('build_status_image') do |request|
@@ -54,7 +54,9 @@ class Rack::Attack
 
   # https://help.github.com/articles/github-s-ip-addresses/
   safelist('github_request_ip') do |request|
-    request.ip && NetAddr::CIDR.create(request.ip).version == 4 && GITHUB_CIDRS.any? { |block| block.contains?(request.ip) }
+    request.ip && IPAddress(request.ip).ipv4? && GITHUB_CIDRS.any? { |block|
+      block.include?(IPAddress(request.ip))
+    }
   end
 
   ####


### PR DESCRIPTION
This PR aims to fix [this vulnerability](https://github.com/travis-ci/travis-api/network/alert/Gemfile.lock/netaddr/open). It appeared that the version of `netaddr` where the vulnerability is fixed is a complete rewrite of the library and is not backward compatible, so it's impossible to just update. That's why I replaced it with another gem that seems even better to me.