### PR TITLE
Make statement timeouts configurable

### DIFF
--- a/lib/travis/api/v3/queries/builds.rb
+++ b/lib/travis/api/v3/queries/builds.rb
@@ -8,7 +8,7 @@ module Travis::API::V3
     default_sort "number:desc,id:desc"
 
     def find(repository)
-      ActiveRecord::Base.connection.execute "SET statement_timeout = '300s';"
+      ActiveRecord::Base.connection.execute "SET statement_timeout = '#{Travis.config.db.max_statement_timeout_in_seconds}s';"
       sort filter(repository.builds)
     end
 

--- a/lib/travis/api/v3/queries/jobs.rb
+++ b/lib/travis/api/v3/queries/jobs.rb
@@ -35,7 +35,7 @@ module Travis::API::V3
     end
 
     def for_user(user)
-      ActiveRecord::Base.connection.execute "SET statement_timeout = '300s';"
+      ActiveRecord::Base.connection.execute "SET statement_timeout = '#{Travis.config.db.max_statement_timeout_in_seconds}s';"
       jobs = V3::Models::Job.joins("INNER JOIN permissions ON permissions.repository_id=jobs.repository_id")
                             .where("permissions.user_id = #{user.id}")
       sort filter(jobs)

--- a/lib/travis/config/defaults.rb
+++ b/lib/travis/config/defaults.rb
@@ -48,6 +48,7 @@ module Travis
             database:             { adapter: 'postgresql', database: "travis_#{Travis.env}", encoding: 'unicode', min_messages: 'warning', variables: { statement_timeout: 10_000 } },
             fallback_logs_api:    { url: fallback_logs_api_auth_url, token: fallback_logs_api_auth_token },
             logs_api:             { url: logs_api_url, token: logs_api_auth_token },
+            db:                   { max_statement_timeout_in_seconds: 15 },
             log_options:          { s3: { access_key_id: '', secret_access_key: ''}},
             s3:                   { access_key_id: '', secret_access_key: ''},
             pusher:               { app_id: 'app-id', key: 'key', secret: 'secret' },


### PR DESCRIPTION
This avoids hard-coding the timeouts directly in the code and unlocks the ability to experiment without needing to deploy.