### PR TITLE
Allow us to override auth host via env var

### DIFF
--- a/lib/travis/api/app/endpoint/authorization.rb
+++ b/lib/travis/api/app/endpoint/authorization.rb
@@ -378,7 +378,8 @@ class Travis::Api::App
         def get_token(endpoint, values)
           # Get base URL for when we setup Faraday since otherwise it'll ignore no_proxy
           url = URI.parse(endpoint)
-          base_url = "#{url.scheme}://#{url.host}"
+          # Allow us to override via an ENV var
+          base_url = "#{url.scheme}://#{ENV['AUTH_HANDSHAKE_HOST'] || url.host}"
           http_options = {url: base_url, ssl: Travis.config.ssl.to_h.merge(Travis.config.github.ssl || {}).compact}
 
           conn = Faraday.new(http_options) do |conn|

--- a/lib/travis/api/app/endpoint/authorization.rb
+++ b/lib/travis/api/app/endpoint/authorization.rb
@@ -148,7 +148,7 @@ class Travis::Api::App
 
         def oauth_endpoint
           proxy = Travis.config.oauth2.proxy
-          proxy ? File.join(proxy, request.fullpath) : url
+          proxy ? File.join(proxy, request.fullpath) : (ENV['AUTH_HANDSHAKE_HOST'] || url)
         end
 
         def log_with_request_id(line)
@@ -162,7 +162,7 @@ class Travis::Api::App
           values   = {
             client_id:    config[:client_id],
             scope:        config[:scope],
-            redirect_uri: ENV['AUTH_HANDSHAKE_HOST'] || oauth_endpoint
+            redirect_uri: oauth_endpoint
           }
 
           log_with_request_id("[handshake] Starting handshake")

--- a/lib/travis/api/app/endpoint/authorization.rb
+++ b/lib/travis/api/app/endpoint/authorization.rb
@@ -162,7 +162,7 @@ class Travis::Api::App
           values   = {
             client_id:    config[:client_id],
             scope:        config[:scope],
-            redirect_uri: oauth_endpoint
+            redirect_uri: ENV['AUTH_HANDSHAKE_HOST'] || oauth_endpoint
           }
 
           log_with_request_id("[handshake] Starting handshake")
@@ -378,8 +378,7 @@ class Travis::Api::App
         def get_token(endpoint, values)
           # Get base URL for when we setup Faraday since otherwise it'll ignore no_proxy
           url = URI.parse(endpoint)
-          # Allow us to override via an ENV var
-          base_url = "#{url.scheme}://#{ENV['AUTH_HANDSHAKE_HOST'] || url.host}"
+          base_url = "#{url.scheme}://#{url.host}"
           http_options = {url: base_url, ssl: Travis.config.ssl.to_h.merge(Travis.config.github.ssl || {}).compact}
 
           conn = Faraday.new(http_options) do |conn|


### PR DESCRIPTION
This allows us to place API at a different subdomain to facilitate deployment of an API Gateway without breaking the current auth flow.