### PR TITLE
Fix missing host

### DIFF
--- a/lib/travis/api/v3/query.rb
+++ b/lib/travis/api/v3/query.rb
@@ -244,7 +244,7 @@ module Travis::API::V3
     end
 
     def host_timeout
-      return extended_timeout if slow_hosts.any? { |sh| host.match?(sh) }
+      return extended_timeout if slow_hosts.any? { |sh| host && host.match?(sh) }
       default_timeout
     end
 


### PR DESCRIPTION
The `HTTP_ORIGIN` header is not always present. This should fix #1014.