### PR TITLE
Do not return negative duration

### DIFF
--- a/lib/travis/model/job.rb
+++ b/lib/travis/model/job.rb
@@ -113,6 +113,7 @@ class Job < Travis::Model
   end
 
   def duration
+    return 0 if started_at && finished_at && started_at > finished_at
     started_at && finished_at ? finished_at - started_at : nil
   end
 

--- a/spec/lib/model/job_spec.rb
+++ b/spec/lib/model/job_spec.rb
@@ -36,7 +36,7 @@ describe Job do
       job.duration.should be_nil
     end
 
-    it 'returns nil if finished_at is after started_at' do
+    it 'returns nil if started_at is after finished_at' do
       job = Job.new(started_at: 10.seconds.ago, finished_at: 20.seconds.ago)
       job.duration.should be 0
     end

--- a/spec/lib/model/job_spec.rb
+++ b/spec/lib/model/job_spec.rb
@@ -36,6 +36,11 @@ describe Job do
       job.duration.should be_nil
     end
 
+    it 'returns nil if finished_at is after started_at' do
+      job = Job.new(started_at: 10.seconds.ago, finished_at: 20.seconds.ago)
+      job.duration.should be 0
+    end
+
     it 'returns the duration if both started_at and finished_at are populated' do
       job = Job.new(started_at: 20.seconds.ago, finished_at: 10.seconds.ago)
       job.duration.should be_within(0.1).of(10)


### PR DESCRIPTION
Sometimes, when clock is out of sync on different microservices, `finished_at` may be before `started_at` (usually it happens, when build is canceled right away), which results in negative duration. 

We will return 0 in this case.