### PR TITLE
Use `Addressable::URI#inferred_port` for determining port

### DIFF
--- a/lib/travis/api/app/endpoint/authorization.rb
+++ b/lib/travis/api/app/endpoint/authorization.rb
@@ -455,7 +455,7 @@ class Travis::Api::App
           elsif uri.host =~ /\A(.+\.)?travis-ci\.(com|org)\Z/
             uri.scheme == 'https'
           elsif uri.host == 'localhost' or uri.host == '127.0.0.1'
-            uri.port > 1023
+            uri.inferred_port.to_i > 1023
           end
         end
 


### PR DESCRIPTION
`#port` is often `nil`:

    [10] pry(main)> URI.parse("http://localhost").port
    => 80
    [11] pry(main)> Addressable::URI.parse("http://localhost").port
    => nil
    [12] pry(main)> Addressable::URI.parse("http://localhost").inferred_port
    => 80

Some URIs will still return `nil`, so we protect against those with `#to_i`.