### PR TITLE
Whitelist form3tech within uri

### DIFF
--- a/lib/travis/api/app/endpoint/authorization.rb
+++ b/lib/travis/api/app/endpoint/authorization.rb
@@ -448,7 +448,12 @@ class Travis::Api::App
 
         def target_ok?(target_origin)
           test_target_origin = URI.decode(target_origin).downcase
-          return if SUSPICIOUS_CODES.any? { |word| test_target_origin.include?(word) }
+          SUSPICIOUS_CODES.each do |word|
+            if word == "form"
+              test_target_origin = test_target_origin.gsub("form3tech", "")
+            end
+            return if test_target_origin.include?(word)
+          end
           return unless uri = Addressable::URI.parse(target_origin)
           if allowed_https_targets.include?(uri.host)
             uri.scheme == 'https'

--- a/spec/unit/endpoint/authorization_spec.rb
+++ b/spec/unit/endpoint/authorization_spec.rb
@@ -72,7 +72,7 @@ describe Travis::Api::App::Endpoint::Authorization do
       context 'when redirect uri is correct' do
         let(:state) { 'github-state:::https://travis-ci.com/?any=params' }
 
-        it 'it does allow redirect' do
+        it 'does allow redirect' do
           response = get "/auth/handshake?code=1234&state=#{URI.encode(state)}"
           expect(response.status).to eq(200)
         end
@@ -90,6 +90,25 @@ describe Travis::Api::App::Endpoint::Authorization do
 
       context 'when script tag is injected into redirect uri' do
         let(:state) { 'github-state:::https://travis-ci.com/<sCrIpt' }
+
+        it 'does not allow redirect' do
+          response = get "/auth/handshake?code=1234&state=#{URI.encode(state)}"
+          expect(response.status).to eq(401)
+          expect(response.body).to eq("target URI not allowed")
+        end
+      end
+
+      context 'when form3tech is present within redirect uri' do
+        let(:state) { 'github-state:::https://travis-ci.com/form3tech' }
+
+        it 'does allow redirect' do
+          response = get "/auth/handshake?code=1234&state=#{URI.encode(state)}"
+          expect(response.status).to eq(200)
+        end
+      end
+
+      context 'when form3tech is present within redirect uri and form tag is injected into redirect uri' do
+        let(:state) { 'github-state:::https://travis-ci.com/form3tech/<form' }
 
         it 'does not allow redirect' do
           response = get "/auth/handshake?code=1234&state=#{URI.encode(state)}"


### PR DESCRIPTION
Form3 is a valid company name, not an HTML `<form>` tag, and so `form3tech` should not be treated as suspicious.