### PR TITLE
Disable SSL on k8s production env

### DIFF
--- a/lib/travis/api/app.rb
+++ b/lib/travis/api/app.rb
@@ -136,7 +136,7 @@ module Travis::Api
           use Travis::Api::App::Middleware::OpenCensus
         end
 
-        use Rack::SSL if Endpoint.production?
+        use Rack::SSL if Endpoint.production? && !ENV['DOCKER']
         use ActiveRecord::ConnectionAdapters::ConnectionManagement
         use ActiveRecord::QueryCache
 


### PR DESCRIPTION
Temporary solution disabling ssl redirect for docker env