### PR TITLE
s/configs/config

### DIFF
--- a/lib/travis/api/v3/queries/request_config.rb
+++ b/lib/travis/api/v3/queries/request_config.rb
@@ -2,7 +2,7 @@ require 'json'
 require 'faraday'
 
 module Travis::API::V3
-  class Queries::RequestConfigs < Query
+  class Queries::RequestConfig < Query
     attr_reader :user, :repo
 
     def expand(user, repo)

--- a/lib/travis/api/v3/routes.rb
+++ b/lib/travis/api/v3/routes.rb
@@ -174,7 +174,7 @@ module Travis::API::V3
       resource :request do
         route '/request/{request.id}'
         get  :find
-        post :configs
+        post :config
 
         resource :messages do
           route '/messages'

--- a/lib/travis/api/v3/services/request/config.rb
+++ b/lib/travis/api/v3/services/request/config.rb
@@ -1,5 +1,5 @@
 module Travis::API::V3
-  class Services::Request::Configs < Service
+  class Services::Request::Config < Service
     result_type :request_configs
     params :ref, :config, :mode, :data
 
@@ -7,7 +7,7 @@ module Travis::API::V3
       repository = check_login_and_find(:repository)
       access_control.permissions(repository).create_request!
       user = access_control.user
-      result query(:request_configs).expand(user, repo)
+      result query(:request_config).expand(user, repo)
     end
 
     private

--- a/spec/v3/services/request/config_spec.rb
+++ b/spec/v3/services/request/config_spec.rb
@@ -1,4 +1,4 @@
-describe Travis::API::V3::Services::Request::Configs, set_app: true do
+describe Travis::API::V3::Services::Request::Config, set_app: true do
   let(:repo) { FactoryBot.create(:repository_without_last_build, owner_name: 'svenfuchs', name: 'minimal') }
   let(:request) { Travis::API::V3::Models::Request.last }
   let(:env_var) { { id: nil, name: 'ONE', value: Travis::Settings::EncryptedValue.new('one'), public: true, branch: 'foo', repository_id: repo.id } }
@@ -41,7 +41,7 @@ describe Travis::API::V3::Services::Request::Configs, set_app: true do
     let(:headers) { { 'HTTP_AUTHORIZATION' => "token #{token}" } }
 
     before { Travis::API::V3::Models::Permission.create(repository: repo, user: repo.owner, push: true) }
-    before { post("/v3/repo/#{repo.id}/request/configs", params, headers) }
+    before { post("/v3/repo/#{repo.id}/request/config", params, headers) }
 
     it { expect(status).to eq 200 }
 


### PR DESCRIPTION
we're posting one request config, which gets expanded in to multiple configs that still include just one request config (plus raw configs, and job configs)