### PR TITLE
Serve JSON data for archived job log requests, regardless of the User-Agent value

### DIFF
--- a/lib/travis/api/app/endpoint/jobs.rb
+++ b/lib/travis/api/app/endpoint/jobs.rb
@@ -108,7 +108,6 @@ class Travis::Api::App
           elsif accepts?('application/json')
             Travis.logger.info "serving json"
             attach_log_token if job.try(:private?)
-            Travis.logger.info "archived_log_content=#{resource.archived_log_content}"
             respond_with resource.archived_log_content.as_json
           else
             status 406

--- a/lib/travis/api/app/endpoint/jobs.rb
+++ b/lib/travis/api/app/endpoint/jobs.rb
@@ -80,8 +80,6 @@ class Travis::Api::App
       get '/:job_id/log', scope: [:public, :log] do
         resource = service(:find_log, job_id: params[:job_id]).run
         job = Job.find(params[:job_id])
-        Travis.logger.info "serving log for #{params[:job_id]}"
-        Travis.logger.info "resource=#{resource}"
 
         if (job.try(:private?) || !allow_public?) && !has_permission?(job)
           halt 404
@@ -106,7 +104,6 @@ class Travis::Api::App
               redirect archived_log_path, 307
             end
           elsif accepts?('application/json')
-            Travis.logger.info "serving json"
             attach_log_token if job.try(:private?)
             respond_with resource.as_json
           else

--- a/lib/travis/api/app/endpoint/jobs.rb
+++ b/lib/travis/api/app/endpoint/jobs.rb
@@ -109,7 +109,13 @@ class Travis::Api::App
             Travis.logger.info "serving json"
             attach_log_token if job.try(:private?)
             Travis.logger.info "archived_log_content=#{resource.archived_log_content}"
-            {"body" => resource.archived_log_content}.to_json
+            {
+              "log" => {
+                "id" => resource.id,
+                "job_id" => params[:job_id],
+                "body" => resource.archived_log_content
+              }
+            }.to_json
           else
             status 406
           end

--- a/lib/travis/api/app/endpoint/jobs.rb
+++ b/lib/travis/api/app/endpoint/jobs.rb
@@ -109,7 +109,7 @@ class Travis::Api::App
             Travis.logger.info "serving json"
             attach_log_token if job.try(:private?)
             Travis.logger.info "archived_log_content=#{resource.archived_log_content}"
-            respond_with resource.archived_content.as_json
+            respond_with resource.archived_log_content.as_json
           else
             status 406
           end

--- a/lib/travis/api/app/endpoint/jobs.rb
+++ b/lib/travis/api/app/endpoint/jobs.rb
@@ -109,13 +109,7 @@ class Travis::Api::App
             Travis.logger.info "serving json"
             attach_log_token if job.try(:private?)
             Travis.logger.info "archived_log_content=#{resource.archived_log_content}"
-            {
-              "log" => {
-                "id" => resource.id,
-                "job_id" => params[:job_id],
-                "body" => resource.archived_log_content
-              }
-            }.to_json
+            respond_with resource.archived_content.as_json
           else
             status 406
           end

--- a/lib/travis/api/app/endpoint/jobs.rb
+++ b/lib/travis/api/app/endpoint/jobs.rb
@@ -80,6 +80,8 @@ class Travis::Api::App
       get '/:job_id/log', scope: [:public, :log] do
         resource = service(:find_log, job_id: params[:job_id]).run
         job = Job.find(params[:job_id])
+        Travis.logger.info "serving log for #{params[:job_id]}"
+        Travis.logger.info "resource=#{resource}"
 
         if (job.try(:private?) || !allow_public?) && !has_permission?(job)
           halt 404
@@ -104,7 +106,9 @@ class Travis::Api::App
               redirect archived_log_path, 307
             end
           elsif accepts?('application/json')
+            Travis.logger.info "serving json"
             attach_log_token if job.try(:private?)
+            Travis.logger.info "archived_log_content=#{resource.archived_log_content}"
             respond_with({"body" => resource.archived_log_content}.to_json)
           else
             status 406

--- a/lib/travis/api/app/endpoint/jobs.rb
+++ b/lib/travis/api/app/endpoint/jobs.rb
@@ -94,7 +94,7 @@ class Travis::Api::App
         elsif resource.archived?
           # the way we use responders makes it hard to validate proper format
           # automatically here, so we need to check it explicitly
-          if accepts?('text/plain') || request.user_agent.to_s.start_with?('Travis')
+          if accepts?('text/plain')
             archived_log_path = resource.archived_url
 
             if params[:cors_hax]

--- a/lib/travis/api/app/endpoint/jobs.rb
+++ b/lib/travis/api/app/endpoint/jobs.rb
@@ -109,7 +109,7 @@ class Travis::Api::App
             Travis.logger.info "serving json"
             attach_log_token if job.try(:private?)
             Travis.logger.info "archived_log_content=#{resource.archived_log_content}"
-            respond_with({"body" => resource.archived_log_content}.to_json)
+            {"body" => resource.archived_log_content}.to_json
           else
             status 406
           end

--- a/lib/travis/api/app/endpoint/jobs.rb
+++ b/lib/travis/api/app/endpoint/jobs.rb
@@ -103,6 +103,9 @@ class Travis::Api::App
             else
               redirect archived_log_path, 307
             end
+          elsif accepts?('application/json')
+            attach_log_token if job.try(:private?)
+            respond_with({"body" => resource.archived_log_content}.to_json)
           else
             status 406
           end

--- a/lib/travis/api/app/endpoint/jobs.rb
+++ b/lib/travis/api/app/endpoint/jobs.rb
@@ -105,7 +105,7 @@ class Travis::Api::App
             else
               redirect archived_log_path, 307
             end
-          elsif accepts?('application/json') || accepts?('application/vnd.travis-ci.2+json')
+          elsif accepts?('application/json')
             Travis.logger.info "serving json"
             attach_log_token if job.try(:private?)
             Travis.logger.info "archived_log_content=#{resource.archived_log_content}"

--- a/lib/travis/api/app/endpoint/jobs.rb
+++ b/lib/travis/api/app/endpoint/jobs.rb
@@ -105,7 +105,7 @@ class Travis::Api::App
             else
               redirect archived_log_path, 307
             end
-          elsif accepts?('application/json')
+          elsif accepts?('application/json') || accepts?('application/vnd.travis-ci.2+json')
             Travis.logger.info "serving json"
             attach_log_token if job.try(:private?)
             Travis.logger.info "archived_log_content=#{resource.archived_log_content}"

--- a/lib/travis/api/app/endpoint/jobs.rb
+++ b/lib/travis/api/app/endpoint/jobs.rb
@@ -108,7 +108,7 @@ class Travis::Api::App
           elsif accepts?('application/json')
             Travis.logger.info "serving json"
             attach_log_token if job.try(:private?)
-            respond_with resource.archived_log_content.as_json
+            respond_with resource.as_json
           else
             status 406
           end

--- a/lib/travis/api/app/endpoint/logs.rb
+++ b/lib/travis/api/app/endpoint/logs.rb
@@ -18,7 +18,7 @@ class Travis::Api::App
           # automatically here, so we need to check it explicitly
           if accepts?('text/plain') || request.user_agent.to_s.start_with?('Travis')
             redirect resource.archived_url, 307
-          elsif accepts?('application.json') || accepts?('application/vnd.travis-ci.2+json')
+          elsif accepts?('application/json') || accepts?('application/vnd.travis-ci.2+json')
             {
               "log" => {
                 "id" => resource.id,

--- a/lib/travis/api/app/endpoint/logs.rb
+++ b/lib/travis/api/app/endpoint/logs.rb
@@ -19,13 +19,7 @@ class Travis::Api::App
           if accepts?('text/plain')
             redirect resource.archived_url, 307
           elsif accepts?('application/json')
-            {
-              "log" => {
-                "id" => resource.id,
-                "job_id" => resource.job_id,
-                "body" => resource.archived_log_content
-              }
-            }.to_json
+            respond_with resource.as_json
           else
             status 406
           end

--- a/lib/travis/api/app/endpoint/logs.rb
+++ b/lib/travis/api/app/endpoint/logs.rb
@@ -19,7 +19,13 @@ class Travis::Api::App
           if accepts?('text/plain') || request.user_agent.to_s.start_with?('Travis')
             redirect resource.archived_url, 307
           elsif accepts?('application.json') || accepts?('application/vnd.travis-ci.2+json')
-            {"body" => resource.archived_log_content}.to_json
+            {
+              "log" => {
+                "id" => resource.id,
+                "job_id" => resource.job_id,
+                "body" => resource.archived_log_content
+              }
+            }.to_json
           else
             status 406
           end

--- a/lib/travis/api/app/endpoint/logs.rb
+++ b/lib/travis/api/app/endpoint/logs.rb
@@ -18,7 +18,7 @@ class Travis::Api::App
           # automatically here, so we need to check it explicitly
           if accepts?('text/plain') || request.user_agent.to_s.start_with?('Travis')
             redirect resource.archived_url, 307
-          elsif accepts?('application/json') || accepts?('application/vnd.travis-ci.2+json')
+          elsif accepts?('application/json')
             {
               "log" => {
                 "id" => resource.id,

--- a/lib/travis/api/app/endpoint/logs.rb
+++ b/lib/travis/api/app/endpoint/logs.rb
@@ -19,7 +19,7 @@ class Travis::Api::App
           if accepts?('text/plain') || request.user_agent.to_s.start_with?('Travis')
             redirect resource.archived_url, 307
           elsif accepts?('application.json')
-            respond_with({"body" => resource.archived_log_content}.to_json)
+            {"body" => resource.archived_log_content}.to_json
           else
             status 406
           end

--- a/lib/travis/api/app/endpoint/logs.rb
+++ b/lib/travis/api/app/endpoint/logs.rb
@@ -18,7 +18,7 @@ class Travis::Api::App
           # automatically here, so we need to check it explicitly
           if accepts?('text/plain') || request.user_agent.to_s.start_with?('Travis')
             redirect resource.archived_url, 307
-          elsif accepts?('application.json')
+          elsif accepts?('application.json') || accepts?('application/vnd.travis-ci.2+json')
             {"body" => resource.archived_log_content}.to_json
           else
             status 406

--- a/lib/travis/api/app/endpoint/logs.rb
+++ b/lib/travis/api/app/endpoint/logs.rb
@@ -18,6 +18,8 @@ class Travis::Api::App
           # automatically here, so we need to check it explicitly
           if accepts?('text/plain') || request.user_agent.to_s.start_with?('Travis')
             redirect resource.archived_url, 307
+          elsif accepts?('application.json')
+            respond_with({"body" => resource.archived_log_content}.to_json)
           else
             status 406
           end

--- a/lib/travis/api/app/endpoint/logs.rb
+++ b/lib/travis/api/app/endpoint/logs.rb
@@ -16,7 +16,7 @@ class Travis::Api::App
         elsif resource.archived?
           # the way we use responders makes it hard to validate proper format
           # automatically here, so we need to check it explicitly
-          if accepts?('text/plain') || request.user_agent.to_s.start_with?('Travis')
+          if accepts?('text/plain')
             redirect resource.archived_url, 307
           elsif accepts?('application/json')
             {

--- a/lib/travis/api/app/helpers/accept.rb
+++ b/lib/travis/api/app/helpers/accept.rb
@@ -68,6 +68,7 @@ class Travis::Api::App
 
       def accepts?(mime_type)
         # TODO shouldn't this really use acceptable_formats?
+        Travis.logger.info "accept_entries=#{accept_entries}"
         accept_entries.any? { |e| e.accepts?(mime_type) }
       end
 

--- a/lib/travis/api/app/helpers/accept.rb
+++ b/lib/travis/api/app/helpers/accept.rb
@@ -68,7 +68,6 @@ class Travis::Api::App
 
       def accepts?(mime_type)
         # TODO shouldn't this really use acceptable_formats?
-        Travis.logger.info "accept_entries=#{accept_entries}"
         accept_entries.any? { |e| e.accepts?(mime_type) }
       end
 

--- a/lib/travis/remote_log.rb
+++ b/lib/travis/remote_log.rb
@@ -249,6 +249,7 @@ module Travis
 
       def fetch_archived_log_content(job_id)
         file = fetch_archived(job_id)
+        Travis.logger.info "file=#{file}"
         return "" if file.nil?
         file.body
       end

--- a/lib/travis/remote_log.rb
+++ b/lib/travis/remote_log.rb
@@ -75,6 +75,10 @@ module Travis
       @archived_url ||= remote.fetch_archived_url(job_id, expires: expires)
     end
 
+    def archived_log_content
+      @archived_content ||= remote.fetch_archived_log_content(job_id)
+    end
+
     def to_json(chunked: false, after: nil, part_numbers: [])
       as_json(
         chunked: chunked,
@@ -243,6 +247,12 @@ module Travis
         file.url(expires)
       end
 
+      def fetch_archived_log_content(job_id)
+        file = fetch_archived(job_id)
+        return "" if file.nil?
+        file.body
+      end
+
       private def fetch_archived(job_id)
         candidates = s3.directories.get(
           bucket_name,
@@ -268,7 +278,7 @@ module Travis
       def_delegators :client, :find_by_job_id, :find_by_id,
         :find_id_by_job_id, :find_parts_by_job_id, :write_content_for_job_id
 
-      def_delegators :archive_client, :fetch_archived_url
+      def_delegators :archive_client, :fetch_archived_url, :fetch_archived_log_content
 
       attr_accessor :platform
 

--- a/lib/travis/remote_log.rb
+++ b/lib/travis/remote_log.rb
@@ -249,7 +249,6 @@ module Travis
 
       def fetch_archived_log_content(job_id)
         file = fetch_archived(job_id)
-        Travis.logger.info "file=#{file}"
         return "" if file.nil?
         file.body
       end

--- a/lib/travis/remote_log.rb
+++ b/lib/travis/remote_log.rb
@@ -105,7 +105,7 @@ module Travis
           part_numbers: part_numbers
         ).map(&:as_json)
       else
-        ret['body'] = content
+        ret['body'] = archived_log_content || content
       end
 
       { 'log' => ret }

--- a/spec/auth/v2.1/jobs_spec.rb
+++ b/spec/auth/v2.1/jobs_spec.rb
@@ -22,8 +22,6 @@ describe 'v2.1 jobs', auth_helpers: true, api_version: :'v2.1', set_app: true do
               <ID>75aa57f09aa0c8caeab4f8c24e99d10f8e7faeebf76c078efc7c6caea54ba06a</ID>
               <DisplayName>mtd@amazon.com</DisplayName>
           </Owner>
-          <body>#{archived_content}
-          </body>
       </Contents>
     </ListBucketResult>"
   }

--- a/spec/auth/v2.1/jobs_spec.rb
+++ b/spec/auth/v2.1/jobs_spec.rb
@@ -26,27 +26,11 @@ describe 'v2.1 jobs', auth_helpers: true, api_version: :'v2.1', set_app: true do
   let(:log_url) { "#{Travis.config[:logs_api][:url]}/logs/1?by=id&source=api" }
 
   before do
-    Fog.mock!
-    storage = Fog::Storage.new({
-      aws_access_key_id: 'key',
-      aws_secret_access_key: 'secret',
-      provider: 'AWS'
-    })
-    bucket = storage.directories.create(key: 'archive.travis-ci.org')
-    file = bucket.files.create(
-      key: "jobs/#{job.id}/log.txt",
-      body: archived_content
-    )
     remote = double('remote')
     allow(Travis::RemoteLog::Remote).to receive(:new).and_return(remote)
     allow(remote).to receive(:find_by_job_id).and_return(Travis::RemoteLog.new(log_from_api))
     allow(remote).to receive(:find_by_id).and_return(Travis::RemoteLog.new(log_from_api))
     allow(remote).to receive(:fetch_archived_url).and_return('https://s3.amazonaws.com/STUFFS')
-  end
-
-  after do
-    Fog.unmock!
-    Fog::Mock.reset
   end
 
   before { Job.update_all(state: :started) }

--- a/spec/auth/v2.1/jobs_spec.rb
+++ b/spec/auth/v2.1/jobs_spec.rb
@@ -4,28 +4,6 @@ describe 'v2.1 jobs', auth_helpers: true, api_version: :'v2.1', set_app: true do
   let(:job)  { repo.builds.first.matrix.first }
   let(:log)  { %({"job_id": #{job.id}, "content": "content"}) }
 
-  let(:xml_content) {
-    "<?xml version=\"1.0\" encoding=\"UTF-8\"?>
-    <ListBucketResult xmlns=\"http://s3.amazonaws.com/doc/2006-03-01/\">
-    <Name>bucket</Name>
-    <Prefix/>
-    <Marker/>
-    <MaxKeys>1000</MaxKeys>
-    <IsTruncated>false</IsTruncated>
-      <Contents>
-          <Key>jobs/#{job.id}/log.txt</Key>
-          <LastModified>2009-10-12T17:50:30.000Z</LastModified>
-          <ETag>&quot;hgb9dede5f27731c9771645a39863328&quot;</ETag>
-          <Size>20308738</Size>
-          <StorageClass>STANDARD</StorageClass>
-          <Owner>
-              <ID>75aa57f09aa0c8caeab4f8c24e99d10f8e7faeebf76c078efc7c6caea54ba06a</ID>
-              <DisplayName>mtd@amazon.com</DisplayName>
-          </Owner>
-      </Contents>
-    </ListBucketResult>"
-  }
-
   let :log_from_api do
     {
       aggregated_at: Time.now,

--- a/spec/auth/v2.1/jobs_spec.rb
+++ b/spec/auth/v2.1/jobs_spec.rb
@@ -48,10 +48,6 @@ describe 'v2.1 jobs', auth_helpers: true, api_version: :'v2.1', set_app: true do
   let(:log_url) { "#{Travis.config[:logs_api][:url]}/logs/1?by=id&source=api" }
 
   before do
-    stub_request(:get, log_url).to_return(status: 200, body: %({"job_id": #{job.id}, "content": "content"}))
-    stub_request(:get, "https://s3.amazonaws.com/archive.travis-ci.com/?prefix=jobs/#{job.id}/log.txt").
-      to_return(status: 200, body: xml_content, headers: {})
-
     Fog.mock!
     storage = Fog::Storage.new({
       aws_access_key_id: 'key',

--- a/spec/auth/v2.1/jobs_spec.rb
+++ b/spec/auth/v2.1/jobs_spec.rb
@@ -4,8 +4,79 @@ describe 'v2.1 jobs', auth_helpers: true, api_version: :'v2.1', set_app: true do
   let(:job)  { repo.builds.first.matrix.first }
   let(:log)  { %({"job_id": #{job.id}, "content": "content"}) }
 
-  let(:log_url) { "#{Travis.config[:logs_api][:url]}/logs/#{job.id}?by=job_id&source=api" }
-  before { stub_request(:get, log_url).to_return(status: 200, body: log) }
+  let(:xml_content) {
+    "<?xml version=\"1.0\" encoding=\"UTF-8\"?>
+    <ListBucketResult xmlns=\"http://s3.amazonaws.com/doc/2006-03-01/\">
+    <Name>bucket</Name>
+    <Prefix/>
+    <Marker/>
+    <MaxKeys>1000</MaxKeys>
+    <IsTruncated>false</IsTruncated>
+      <Contents>
+          <Key>jobs/#{job.id}/log.txt</Key>
+          <LastModified>2009-10-12T17:50:30.000Z</LastModified>
+          <ETag>&quot;hgb9dede5f27731c9771645a39863328&quot;</ETag>
+          <Size>20308738</Size>
+          <StorageClass>STANDARD</StorageClass>
+          <Owner>
+              <ID>75aa57f09aa0c8caeab4f8c24e99d10f8e7faeebf76c078efc7c6caea54ba06a</ID>
+              <DisplayName>mtd@amazon.com</DisplayName>
+          </Owner>
+          <body>#{archived_content}
+          </body>
+      </Contents>
+    </ListBucketResult>"
+  }
+
+  let :log_from_api do
+    {
+      aggregated_at: Time.now,
+      archive_verified: true,
+      archived_at: Time.now,
+      archiving: false,
+      content: 'hello world. this is a really cool log',
+      created_at: Time.now,
+      id: 1,
+      job_id: job.id,
+      purged_at: nil,
+      removed_at: nil,
+      removed_by_id: nil,
+      updated_at: Time.now
+    }
+  end
+
+  let(:archived_content) { "$ git clean -fdx\nRemoving Gemfile.lock\n$ git fetch" }
+
+  let(:log_url) { "#{Travis.config[:logs_api][:url]}/logs/1?by=id&source=api" }
+
+  before do
+    stub_request(:get, log_url).to_return(status: 200, body: %({"job_id": #{job.id}, "content": "content"}))
+    stub_request(:get, "https://s3.amazonaws.com/archive.travis-ci.com/?prefix=jobs/#{job.id}/log.txt").
+      to_return(status: 200, body: xml_content, headers: {})
+
+    Fog.mock!
+    storage = Fog::Storage.new({
+      aws_access_key_id: 'key',
+      aws_secret_access_key: 'secret',
+      provider: 'AWS'
+    })
+    bucket = storage.directories.create(key: 'archive.travis-ci.org')
+    file = bucket.files.create(
+      key: "jobs/#{job.id}/log.txt",
+      body: archived_content
+    )
+    remote = double('remote')
+    allow(Travis::RemoteLog::Remote).to receive(:new).and_return(remote)
+    allow(remote).to receive(:find_by_job_id).and_return(Travis::RemoteLog.new(log_from_api))
+    allow(remote).to receive(:find_by_id).and_return(Travis::RemoteLog.new(log_from_api))
+    allow(remote).to receive(:fetch_archived_url).and_return('https://s3.amazonaws.com/STUFFS')
+  end
+
+  after do
+    Fog.unmock!
+    Fog::Mock.reset
+  end
+
   before { Job.update_all(state: :started) }
 
   # TODO

--- a/spec/auth/v2.1/logs_spec.rb
+++ b/spec/auth/v2.1/logs_spec.rb
@@ -5,8 +5,78 @@ describe 'v2.1 logs', auth_helpers: true, api_version: :'v2.1', set_app: true do
   let(:job)   { build.matrix.first }
   let(:log)   { double(id: 1) }
 
+  let(:xml_content) {
+    "<?xml version=\"1.0\" encoding=\"UTF-8\"?>
+    <ListBucketResult xmlns=\"http://s3.amazonaws.com/doc/2006-03-01/\">
+    <Name>bucket</Name>
+    <Prefix/>
+    <Marker/>
+    <MaxKeys>1000</MaxKeys>
+    <IsTruncated>false</IsTruncated>
+      <Contents>
+          <Key>jobs/#{job.id}/log.txt</Key>
+          <LastModified>2009-10-12T17:50:30.000Z</LastModified>
+          <ETag>&quot;hgb9dede5f27731c9771645a39863328&quot;</ETag>
+          <Size>20308738</Size>
+          <StorageClass>STANDARD</StorageClass>
+          <Owner>
+              <ID>75aa57f09aa0c8caeab4f8c24e99d10f8e7faeebf76c078efc7c6caea54ba06a</ID>
+              <DisplayName>mtd@amazon.com</DisplayName>
+          </Owner>
+          <body>#{archived_content}
+          </body>
+      </Contents>
+    </ListBucketResult>"
+  }
+
+  let :log_from_api do
+    {
+      aggregated_at: Time.now,
+      archive_verified: true,
+      archived_at: Time.now,
+      archiving: false,
+      content: 'hello world. this is a really cool log',
+      created_at: Time.now,
+      id: 1,
+      job_id: job.id,
+      purged_at: nil,
+      removed_at: nil,
+      removed_by_id: nil,
+      updated_at: Time.now
+    }
+  end
+
+  let(:archived_content) { "$ git clean -fdx\nRemoving Gemfile.lock\n$ git fetch" }
+
   let(:log_url) { "#{Travis.config[:logs_api][:url]}/logs/1?by=id&source=api" }
-  before { stub_request(:get, log_url).to_return(status: 200, body: %({"job_id": #{job.id}, "content": "content"})) }
+
+  before do
+    stub_request(:get, log_url).to_return(status: 200, body: %({"job_id": #{job.id}, "content": "content"}))
+    stub_request(:get, "https://s3.amazonaws.com/archive.travis-ci.com/?prefix=jobs/#{job.id}/log.txt").
+      to_return(status: 200, body: xml_content, headers: {})
+
+    Fog.mock!
+    storage = Fog::Storage.new({
+      aws_access_key_id: 'key',
+      aws_secret_access_key: 'secret',
+      provider: 'AWS'
+    })
+    bucket = storage.directories.create(key: 'archive.travis-ci.org')
+    file = bucket.files.create(
+      key: "jobs/#{job.id}/log.txt",
+      body: archived_content
+    )
+    remote = double('remote')
+    allow(Travis::RemoteLog::Remote).to receive(:new).and_return(remote)
+    allow(remote).to receive(:find_by_job_id).and_return(Travis::RemoteLog.new(log_from_api))
+    allow(remote).to receive(:find_by_id).and_return(Travis::RemoteLog.new(log_from_api))
+    allow(remote).to receive(:fetch_archived_url).and_return('https://s3.amazonaws.com/STUFFS')
+  end
+
+  after do
+    Fog.unmock!
+    Fog::Mock.reset
+  end
 
   describe 'in public mode, with a private repo', mode: :public, repo: :private do
     describe 'GET /logs/%{log.id}' do

--- a/spec/auth/v2.1/logs_spec.rb
+++ b/spec/auth/v2.1/logs_spec.rb
@@ -5,28 +5,6 @@ describe 'v2.1 logs', auth_helpers: true, api_version: :'v2.1', set_app: true do
   let(:job)   { build.matrix.first }
   let(:log)   { double(id: 1) }
 
-  let(:xml_content) {
-    "<?xml version=\"1.0\" encoding=\"UTF-8\"?>
-    <ListBucketResult xmlns=\"http://s3.amazonaws.com/doc/2006-03-01/\">
-    <Name>bucket</Name>
-    <Prefix/>
-    <Marker/>
-    <MaxKeys>1000</MaxKeys>
-    <IsTruncated>false</IsTruncated>
-      <Contents>
-          <Key>jobs/#{job.id}/log.txt</Key>
-          <LastModified>2009-10-12T17:50:30.000Z</LastModified>
-          <ETag>&quot;hgb9dede5f27731c9771645a39863328&quot;</ETag>
-          <Size>20308738</Size>
-          <StorageClass>STANDARD</StorageClass>
-          <Owner>
-              <ID>75aa57f09aa0c8caeab4f8c24e99d10f8e7faeebf76c078efc7c6caea54ba06a</ID>
-              <DisplayName>mtd@amazon.com</DisplayName>
-          </Owner>
-      </Contents>
-    </ListBucketResult>"
-  }
-
   let :log_from_api do
     {
       aggregated_at: Time.now,

--- a/spec/auth/v2.1/logs_spec.rb
+++ b/spec/auth/v2.1/logs_spec.rb
@@ -23,8 +23,6 @@ describe 'v2.1 logs', auth_helpers: true, api_version: :'v2.1', set_app: true do
               <ID>75aa57f09aa0c8caeab4f8c24e99d10f8e7faeebf76c078efc7c6caea54ba06a</ID>
               <DisplayName>mtd@amazon.com</DisplayName>
           </Owner>
-          <body>#{archived_content}
-          </body>
       </Contents>
     </ListBucketResult>"
   }

--- a/spec/auth/v2.1/logs_spec.rb
+++ b/spec/auth/v2.1/logs_spec.rb
@@ -49,10 +49,6 @@ describe 'v2.1 logs', auth_helpers: true, api_version: :'v2.1', set_app: true do
   let(:log_url) { "#{Travis.config[:logs_api][:url]}/logs/1?by=id&source=api" }
 
   before do
-    stub_request(:get, log_url).to_return(status: 200, body: %({"job_id": #{job.id}, "content": "content"}))
-    stub_request(:get, "https://s3.amazonaws.com/archive.travis-ci.com/?prefix=jobs/#{job.id}/log.txt").
-      to_return(status: 200, body: xml_content, headers: {})
-
     Fog.mock!
     storage = Fog::Storage.new({
       aws_access_key_id: 'key',

--- a/spec/auth/v2.1/logs_spec.rb
+++ b/spec/auth/v2.1/logs_spec.rb
@@ -27,27 +27,11 @@ describe 'v2.1 logs', auth_helpers: true, api_version: :'v2.1', set_app: true do
   let(:log_url) { "#{Travis.config[:logs_api][:url]}/logs/1?by=id&source=api" }
 
   before do
-    Fog.mock!
-    storage = Fog::Storage.new({
-      aws_access_key_id: 'key',
-      aws_secret_access_key: 'secret',
-      provider: 'AWS'
-    })
-    bucket = storage.directories.create(key: 'archive.travis-ci.org')
-    file = bucket.files.create(
-      key: "jobs/#{job.id}/log.txt",
-      body: archived_content
-    )
     remote = double('remote')
     allow(Travis::RemoteLog::Remote).to receive(:new).and_return(remote)
     allow(remote).to receive(:find_by_job_id).and_return(Travis::RemoteLog.new(log_from_api))
     allow(remote).to receive(:find_by_id).and_return(Travis::RemoteLog.new(log_from_api))
     allow(remote).to receive(:fetch_archived_url).and_return('https://s3.amazonaws.com/STUFFS')
-  end
-
-  after do
-    Fog.unmock!
-    Fog::Mock.reset
   end
 
   describe 'in public mode, with a private repo', mode: :public, repo: :private do

--- a/spec/auth/v2/jobs_spec.rb
+++ b/spec/auth/v2/jobs_spec.rb
@@ -24,8 +24,6 @@ describe 'v2 jobs', auth_helpers: true, api_version: :v2, set_app: true do
               <ID>75aa57f09aa0c8caeab4f8c24e99d10f8e7faeebf76c078efc7c6caea54ba06a</ID>
               <DisplayName>mtd@amazon.com</DisplayName>
           </Owner>
-          <body>#{archived_content}
-          </body>
       </Contents>
     </ListBucketResult>"
   }

--- a/spec/auth/v2/jobs_spec.rb
+++ b/spec/auth/v2/jobs_spec.rb
@@ -50,10 +50,6 @@ describe 'v2 jobs', auth_helpers: true, api_version: :v2, set_app: true do
   let(:log_url) { "#{Travis.config[:logs_api][:url]}/logs/1?by=id&source=api" }
 
   before do
-    stub_request(:get, log_url).to_return(status: 200, body: %({"job_id": #{job.id}, "content": "content"}))
-    stub_request(:get, "https://s3.amazonaws.com/archive.travis-ci.com/?prefix=jobs/#{job.id}/log.txt").
-      to_return(status: 200, body: xml_content, headers: {})
-
     Fog.mock!
     storage = Fog::Storage.new({
       aws_access_key_id: 'key',

--- a/spec/auth/v2/jobs_spec.rb
+++ b/spec/auth/v2/jobs_spec.rb
@@ -6,28 +6,6 @@ describe 'v2 jobs', auth_helpers: true, api_version: :v2, set_app: true do
 
   let(:log_url) { "#{Travis.config[:logs_api][:url]}/logs/#{job.id}?by=job_id&source=api" }
 
-  let(:xml_content) {
-    "<?xml version=\"1.0\" encoding=\"UTF-8\"?>
-    <ListBucketResult xmlns=\"http://s3.amazonaws.com/doc/2006-03-01/\">
-    <Name>bucket</Name>
-    <Prefix/>
-    <Marker/>
-    <MaxKeys>1000</MaxKeys>
-    <IsTruncated>false</IsTruncated>
-      <Contents>
-          <Key>jobs/#{job.id}/log.txt</Key>
-          <LastModified>2009-10-12T17:50:30.000Z</LastModified>
-          <ETag>&quot;hgb9dede5f27731c9771645a39863328&quot;</ETag>
-          <Size>20308738</Size>
-          <StorageClass>STANDARD</StorageClass>
-          <Owner>
-              <ID>75aa57f09aa0c8caeab4f8c24e99d10f8e7faeebf76c078efc7c6caea54ba06a</ID>
-              <DisplayName>mtd@amazon.com</DisplayName>
-          </Owner>
-      </Contents>
-    </ListBucketResult>"
-  }
-
   let :log_from_api do
     {
       aggregated_at: Time.now,

--- a/spec/auth/v2/jobs_spec.rb
+++ b/spec/auth/v2/jobs_spec.rb
@@ -28,27 +28,11 @@ describe 'v2 jobs', auth_helpers: true, api_version: :v2, set_app: true do
   let(:log_url) { "#{Travis.config[:logs_api][:url]}/logs/1?by=id&source=api" }
 
   before do
-    Fog.mock!
-    storage = Fog::Storage.new({
-      aws_access_key_id: 'key',
-      aws_secret_access_key: 'secret',
-      provider: 'AWS'
-    })
-    bucket = storage.directories.create(key: 'archive.travis-ci.org')
-    file = bucket.files.create(
-      key: "jobs/#{job.id}/log.txt",
-      body: archived_content
-    )
     remote = double('remote')
     allow(Travis::RemoteLog::Remote).to receive(:new).and_return(remote)
     allow(remote).to receive(:find_by_job_id).and_return(Travis::RemoteLog.new(log_from_api))
     allow(remote).to receive(:find_by_id).and_return(Travis::RemoteLog.new(log_from_api))
     allow(remote).to receive(:fetch_archived_url).and_return('https://s3.amazonaws.com/STUFFS')
-  end
-
-  after do
-    Fog.unmock!
-    Fog::Mock.reset
   end
 
   before { Job.update_all(state: :started) }

--- a/spec/auth/v2/jobs_spec.rb
+++ b/spec/auth/v2/jobs_spec.rb
@@ -5,7 +5,80 @@ describe 'v2 jobs', auth_helpers: true, api_version: :v2, set_app: true do
   let(:log)  { %({"job_id": #{job.id}, "content": "content"}) }
 
   let(:log_url) { "#{Travis.config[:logs_api][:url]}/logs/#{job.id}?by=job_id&source=api" }
-  before { stub_request(:get, log_url).to_return(status: 200, body: log) }
+
+  let(:xml_content) {
+    "<?xml version=\"1.0\" encoding=\"UTF-8\"?>
+    <ListBucketResult xmlns=\"http://s3.amazonaws.com/doc/2006-03-01/\">
+    <Name>bucket</Name>
+    <Prefix/>
+    <Marker/>
+    <MaxKeys>1000</MaxKeys>
+    <IsTruncated>false</IsTruncated>
+      <Contents>
+          <Key>jobs/#{job.id}/log.txt</Key>
+          <LastModified>2009-10-12T17:50:30.000Z</LastModified>
+          <ETag>&quot;hgb9dede5f27731c9771645a39863328&quot;</ETag>
+          <Size>20308738</Size>
+          <StorageClass>STANDARD</StorageClass>
+          <Owner>
+              <ID>75aa57f09aa0c8caeab4f8c24e99d10f8e7faeebf76c078efc7c6caea54ba06a</ID>
+              <DisplayName>mtd@amazon.com</DisplayName>
+          </Owner>
+          <body>#{archived_content}
+          </body>
+      </Contents>
+    </ListBucketResult>"
+  }
+
+  let :log_from_api do
+    {
+      aggregated_at: Time.now,
+      archive_verified: true,
+      archived_at: Time.now,
+      archiving: false,
+      content: 'hello world. this is a really cool log',
+      created_at: Time.now,
+      id: 1,
+      job_id: job.id,
+      purged_at: nil,
+      removed_at: nil,
+      removed_by_id: nil,
+      updated_at: Time.now
+    }
+  end
+
+  let(:archived_content) { "$ git clean -fdx\nRemoving Gemfile.lock\n$ git fetch" }
+
+  let(:log_url) { "#{Travis.config[:logs_api][:url]}/logs/1?by=id&source=api" }
+
+  before do
+    stub_request(:get, log_url).to_return(status: 200, body: %({"job_id": #{job.id}, "content": "content"}))
+    stub_request(:get, "https://s3.amazonaws.com/archive.travis-ci.com/?prefix=jobs/#{job.id}/log.txt").
+      to_return(status: 200, body: xml_content, headers: {})
+
+    Fog.mock!
+    storage = Fog::Storage.new({
+      aws_access_key_id: 'key',
+      aws_secret_access_key: 'secret',
+      provider: 'AWS'
+    })
+    bucket = storage.directories.create(key: 'archive.travis-ci.org')
+    file = bucket.files.create(
+      key: "jobs/#{job.id}/log.txt",
+      body: archived_content
+    )
+    remote = double('remote')
+    allow(Travis::RemoteLog::Remote).to receive(:new).and_return(remote)
+    allow(remote).to receive(:find_by_job_id).and_return(Travis::RemoteLog.new(log_from_api))
+    allow(remote).to receive(:find_by_id).and_return(Travis::RemoteLog.new(log_from_api))
+    allow(remote).to receive(:fetch_archived_url).and_return('https://s3.amazonaws.com/STUFFS')
+  end
+
+  after do
+    Fog.unmock!
+    Fog::Mock.reset
+  end
+
   before { Job.update_all(state: :started) }
 
   # TODO

--- a/spec/auth/v2/logs_spec.rb
+++ b/spec/auth/v2/logs_spec.rb
@@ -5,28 +5,6 @@ describe 'v2 logs', auth_helpers: true, api_version: :v2, set_app: true do
   let(:job)   { build.matrix.first }
   let(:log)   { double(id: 1) }
 
-  let(:xml_content) {
-    "<?xml version=\"1.0\" encoding=\"UTF-8\"?>
-    <ListBucketResult xmlns=\"http://s3.amazonaws.com/doc/2006-03-01/\">
-    <Name>bucket</Name>
-    <Prefix/>
-    <Marker/>
-    <MaxKeys>1000</MaxKeys>
-    <IsTruncated>false</IsTruncated>
-      <Contents>
-          <Key>jobs/#{job.id}/log.txt</Key>
-          <LastModified>2009-10-12T17:50:30.000Z</LastModified>
-          <ETag>&quot;hgb9dede5f27731c9771645a39863328&quot;</ETag>
-          <Size>20308738</Size>
-          <StorageClass>STANDARD</StorageClass>
-          <Owner>
-              <ID>75aa57f09aa0c8caeab4f8c24e99d10f8e7faeebf76c078efc7c6caea54ba06a</ID>
-              <DisplayName>mtd@amazon.com</DisplayName>
-          </Owner>
-      </Contents>
-    </ListBucketResult>"
-  }
-
   let :log_from_api do
     {
       aggregated_at: Time.now,

--- a/spec/auth/v2/logs_spec.rb
+++ b/spec/auth/v2/logs_spec.rb
@@ -23,8 +23,6 @@ describe 'v2 logs', auth_helpers: true, api_version: :v2, set_app: true do
               <ID>75aa57f09aa0c8caeab4f8c24e99d10f8e7faeebf76c078efc7c6caea54ba06a</ID>
               <DisplayName>mtd@amazon.com</DisplayName>
           </Owner>
-          <body>#{archived_content}
-          </body>
       </Contents>
     </ListBucketResult>"
   }

--- a/spec/auth/v2/logs_spec.rb
+++ b/spec/auth/v2/logs_spec.rb
@@ -49,10 +49,6 @@ describe 'v2 logs', auth_helpers: true, api_version: :v2, set_app: true do
   let(:log_url) { "#{Travis.config[:logs_api][:url]}/logs/1?by=id&source=api" }
 
   before do
-    stub_request(:get, log_url).to_return(status: 200, body: %({"job_id": #{job.id}, "content": "content"}))
-    stub_request(:get, "https://s3.amazonaws.com/archive.travis-ci.com/?prefix=jobs/#{job.id}/log.txt").
-      to_return(status: 200, body: xml_content, headers: {})
-
     Fog.mock!
     storage = Fog::Storage.new({
       aws_access_key_id: 'key',

--- a/spec/auth/v2/logs_spec.rb
+++ b/spec/auth/v2/logs_spec.rb
@@ -27,27 +27,11 @@ describe 'v2 logs', auth_helpers: true, api_version: :v2, set_app: true do
   let(:log_url) { "#{Travis.config[:logs_api][:url]}/logs/1?by=id&source=api" }
 
   before do
-    Fog.mock!
-    storage = Fog::Storage.new({
-      aws_access_key_id: 'key',
-      aws_secret_access_key: 'secret',
-      provider: 'AWS'
-    })
-    bucket = storage.directories.create(key: 'archive.travis-ci.org')
-    file = bucket.files.create(
-      key: "jobs/#{job.id}/log.txt",
-      body: archived_content
-    )
     remote = double('remote')
     allow(Travis::RemoteLog::Remote).to receive(:new).and_return(remote)
     allow(remote).to receive(:find_by_job_id).and_return(Travis::RemoteLog.new(log_from_api))
     allow(remote).to receive(:find_by_id).and_return(Travis::RemoteLog.new(log_from_api))
     allow(remote).to receive(:fetch_archived_url).and_return('https://s3.amazonaws.com/STUFFS')
-  end
-
-  after do
-    Fog.unmock!
-    Fog::Mock.reset
   end
 
   describe 'in public mode, with a private repo', mode: :public, repo: :private do

--- a/spec/auth/v2/logs_spec.rb
+++ b/spec/auth/v2/logs_spec.rb
@@ -5,8 +5,78 @@ describe 'v2 logs', auth_helpers: true, api_version: :v2, set_app: true do
   let(:job)   { build.matrix.first }
   let(:log)   { double(id: 1) }
 
+  let(:xml_content) {
+    "<?xml version=\"1.0\" encoding=\"UTF-8\"?>
+    <ListBucketResult xmlns=\"http://s3.amazonaws.com/doc/2006-03-01/\">
+    <Name>bucket</Name>
+    <Prefix/>
+    <Marker/>
+    <MaxKeys>1000</MaxKeys>
+    <IsTruncated>false</IsTruncated>
+      <Contents>
+          <Key>jobs/#{job.id}/log.txt</Key>
+          <LastModified>2009-10-12T17:50:30.000Z</LastModified>
+          <ETag>&quot;hgb9dede5f27731c9771645a39863328&quot;</ETag>
+          <Size>20308738</Size>
+          <StorageClass>STANDARD</StorageClass>
+          <Owner>
+              <ID>75aa57f09aa0c8caeab4f8c24e99d10f8e7faeebf76c078efc7c6caea54ba06a</ID>
+              <DisplayName>mtd@amazon.com</DisplayName>
+          </Owner>
+          <body>#{archived_content}
+          </body>
+      </Contents>
+    </ListBucketResult>"
+  }
+
+  let :log_from_api do
+    {
+      aggregated_at: Time.now,
+      archive_verified: true,
+      archived_at: Time.now,
+      archiving: false,
+      content: 'hello world. this is a really cool log',
+      created_at: Time.now,
+      id: 1,
+      job_id: job.id,
+      purged_at: nil,
+      removed_at: nil,
+      removed_by_id: nil,
+      updated_at: Time.now
+    }
+  end
+
+  let(:archived_content) { "$ git clean -fdx\nRemoving Gemfile.lock\n$ git fetch" }
+
   let(:log_url) { "#{Travis.config[:logs_api][:url]}/logs/1?by=id&source=api" }
-  before { stub_request(:get, log_url).to_return(status: 200, body: %({"job_id": #{job.id}, "content": "content"})) }
+
+  before do
+    stub_request(:get, log_url).to_return(status: 200, body: %({"job_id": #{job.id}, "content": "content"}))
+    stub_request(:get, "https://s3.amazonaws.com/archive.travis-ci.com/?prefix=jobs/#{job.id}/log.txt").
+      to_return(status: 200, body: xml_content, headers: {})
+
+    Fog.mock!
+    storage = Fog::Storage.new({
+      aws_access_key_id: 'key',
+      aws_secret_access_key: 'secret',
+      provider: 'AWS'
+    })
+    bucket = storage.directories.create(key: 'archive.travis-ci.org')
+    file = bucket.files.create(
+      key: "jobs/#{job.id}/log.txt",
+      body: archived_content
+    )
+    remote = double('remote')
+    allow(Travis::RemoteLog::Remote).to receive(:new).and_return(remote)
+    allow(remote).to receive(:find_by_job_id).and_return(Travis::RemoteLog.new(log_from_api))
+    allow(remote).to receive(:find_by_id).and_return(Travis::RemoteLog.new(log_from_api))
+    allow(remote).to receive(:fetch_archived_url).and_return('https://s3.amazonaws.com/STUFFS')
+  end
+
+  after do
+    Fog.unmock!
+    Fog::Mock.reset
+  end
 
   describe 'in public mode, with a private repo', mode: :public, repo: :private do
     describe 'GET /logs/%{log.id}' do

--- a/spec/integration/v2/jobs_spec.rb
+++ b/spec/integration/v2/jobs_spec.rb
@@ -24,8 +24,6 @@ describe 'Jobs', set_app: true do
               <ID>75aa57f09aa0c8caeab4f8c24e99d10f8e7faeebf76c078efc7c6caea54ba06a</ID>
               <DisplayName>mtd@amazon.com</DisplayName>
           </Owner>
-          <body>#{archived_content}
-          </body>
       </Contents>
     </ListBucketResult>"
   }

--- a/spec/integration/v2/jobs_spec.rb
+++ b/spec/integration/v2/jobs_spec.rb
@@ -6,28 +6,6 @@ describe 'Jobs', set_app: true do
   let(:job) { jobs.first }
   let(:headers) { { 'HTTP_ACCEPT' => 'application/vnd.travis-ci.2+json' } }
 
-  let(:xml_content) {
-    "<?xml version=\"1.0\" encoding=\"UTF-8\"?>
-    <ListBucketResult xmlns=\"http://s3.amazonaws.com/doc/2006-03-01/\">
-    <Name>bucket</Name>
-    <Prefix/>
-    <Marker/>
-    <MaxKeys>1000</MaxKeys>
-    <IsTruncated>false</IsTruncated>
-      <Contents>
-          <Key>jobs/#{job.id}/log.txt</Key>
-          <LastModified>2009-10-12T17:50:30.000Z</LastModified>
-          <ETag>&quot;hgb9dede5f27731c9771645a39863328&quot;</ETag>
-          <Size>20308738</Size>
-          <StorageClass>STANDARD</StorageClass>
-          <Owner>
-              <ID>75aa57f09aa0c8caeab4f8c24e99d10f8e7faeebf76c078efc7c6caea54ba06a</ID>
-              <DisplayName>mtd@amazon.com</DisplayName>
-          </Owner>
-      </Contents>
-    </ListBucketResult>"
-  }
-
   let :log_from_api do
     {
       aggregated_at: Time.now,

--- a/spec/integration/v2/jobs_spec.rb
+++ b/spec/integration/v2/jobs_spec.rb
@@ -51,10 +51,6 @@ describe 'Jobs', set_app: true do
   let(:log_url) { "#{Travis.config[:logs_api][:url]}/logs/1?by=id&source=api" }
 
   before do
-    stub_request(:get, log_url).to_return(status: 200, body: %({"job_id": #{job.id}, "content": "content"}))
-    stub_request(:get, "https://s3.amazonaws.com/archive.travis-ci.com/?prefix=jobs/#{job.id}/log.txt").
-      to_return(status: 200, body: xml_content, headers: {})
-
     Fog.mock!
     storage = Fog::Storage.new({
       aws_access_key_id: 'key',

--- a/spec/integration/v2/jobs_spec.rb
+++ b/spec/integration/v2/jobs_spec.rb
@@ -29,17 +29,6 @@ describe 'Jobs', set_app: true do
   let(:log_url) { "#{Travis.config[:logs_api][:url]}/logs/1?by=id&source=api" }
 
   before do
-    Fog.mock!
-    storage = Fog::Storage.new({
-      aws_access_key_id: 'key',
-      aws_secret_access_key: 'secret',
-      provider: 'AWS'
-    })
-    bucket = storage.directories.create(key: 'archive.travis-ci.org')
-    file = bucket.files.create(
-      key: "jobs/#{job.id}/log.txt",
-      body: archived_content
-    )
     remote = double('remote')
     allow(Travis::RemoteLog::Remote).to receive(:new).and_return(remote)
     allow(remote).to receive(:find_by_job_id).and_return(Travis::RemoteLog.new(log_from_api))
@@ -48,11 +37,6 @@ describe 'Jobs', set_app: true do
     allow(remote).to receive(:fetch_archived_log_content).and_return(archived_content)
     allow(remote).to receive(:write_content_for_job_id).and_return(remote)
     allow(remote).to receive(:send).and_return(remote) # ignore attribute updates
-  end
-
-  after do
-    Fog.unmock!
-    Fog::Mock.reset
   end
 
   it '/jobs?queue=builds.common' do

--- a/spec/integration/visibility_spec.rb
+++ b/spec/integration/visibility_spec.rb
@@ -38,11 +38,6 @@ describe 'visibilty', set_app: true do
   before { builds[0].update_attributes(private: false) }
   before { jobs[0].update_attributes(private: false) }
   before :each do
-    stub_request(:get, %r(https://s3\.amazonaws\.com/archive\.travis-ci\.(org|com)/\?prefix=jobs/\d+/log.txt)).
-      to_return(status: 200, body: xml_content, headers: {})
-    stub_request(:get, %r(https://bucket\.s3\.amazonaws\.com/jobs/\d+/log.txt)).
-      to_return(status: 200, body: archived_content, headers: {})
-
     Fog.mock!
     storage = Fog::Storage.new({
       aws_access_key_id: 'key',

--- a/spec/integration/visibility_spec.rb
+++ b/spec/integration/visibility_spec.rb
@@ -8,27 +8,6 @@ describe 'visibilty', set_app: true do
   let(:body)     { JSON.parse(response.body).deep_symbolize_keys }
   let(:job_id)   { 42864 }
   let(:archived_content) { 'hello world!'}
-  let(:xml_content) {
-    "<?xml version=\"1.0\" encoding=\"UTF-8\"?>
-    <ListBucketResult xmlns=\"http://s3.amazonaws.com/doc/2006-03-01/\">
-    <Name>bucket</Name>
-    <Prefix/>
-    <Marker/>
-    <MaxKeys>1000</MaxKeys>
-    <IsTruncated>false</IsTruncated>
-      <Contents>
-          <Key>jobs/#{job_id}/log.txt</Key>
-          <LastModified>2009-10-12T17:50:30.000Z</LastModified>
-          <ETag>&quot;hgb9dede5f27731c9771645a39863328&quot;</ETag>
-          <Size>20308738</Size>
-          <StorageClass>STANDARD</StorageClass>
-          <Owner>
-              <ID>75aa57f09aa0c8caeab4f8c24e99d10f8e7faeebf76c078efc7c6caea54ba06a</ID>
-              <DisplayName>mtd@amazon.com</DisplayName>
-          </Owner>
-      </Contents>
-    </ListBucketResult>"
-  }
 
   before { repo.update_attributes(private: false) }
   before { requests.update_all(private: true) }

--- a/spec/lib/travis/remote_log_spec.rb
+++ b/spec/lib/travis/remote_log_spec.rb
@@ -198,7 +198,6 @@ describe Travis::RemoteLog do
     now = double('now')
     allow(now).to receive(:utc).and_return(now)
     allow(now).to receive(:to_s).and_return('whenebber')
-    allow(now).to receive(:-).with(0).and_return(Time.now.to_i)
     allow(Time).to receive(:now).and_return(now)
 
     allow(subject).to receive(:removed_by).and_return(user)

--- a/spec/lib/travis/remote_log_spec.rb
+++ b/spec/lib/travis/remote_log_spec.rb
@@ -44,9 +44,6 @@ describe Travis::RemoteLog do
     )
 
     allow_any_instance_of(Travis::RemoteLog::ArchiveClient).to receive(:fetch_archived).and_return(file)
-
-    stub_request(:get, %r[https://s3\.amazonaws\.com/archive\.travis-ci\.org/\?prefix=jobs/#{job_id}/log\.txt]).
-      to_return(status: 200, body: xml_content, headers: {})
   end
 
   after do

--- a/spec/lib/travis/remote_log_spec.rb
+++ b/spec/lib/travis/remote_log_spec.rb
@@ -177,6 +177,7 @@ describe Travis::RemoteLog do
     now = double('now')
     allow(now).to receive(:utc).and_return(now)
     allow(now).to receive(:to_s).and_return('whenebber')
+    allow(now).to receive(:-).with(0).and_return(Time.now.to_i)
     allow(Time).to receive(:now).and_return(now)
 
     allow(subject).to receive(:removed_by).and_return(user)

--- a/spec/lib/travis/remote_log_spec.rb
+++ b/spec/lib/travis/remote_log_spec.rb
@@ -2,11 +2,56 @@ require 'travis/remote_log'
 
 describe Travis::RemoteLog do
   subject { described_class.new(attrs) }
-  let(:attrs) { { id: 4, content: 'huh', job_id: 5 } }
+  let(:job_id) { 5 }
+  let(:attrs) { { id: 4, content: archived_content, job_id: job_id } }
+  let(:archived_content) { 'hello world' }
+  let(:xml_content) {
+    "<?xml version=\"1.0\" encoding=\"UTF-8\"?>
+    <ListBucketResult xmlns=\"http://s3.amazonaws.com/doc/2006-03-01/\">
+    <Name>bucket</Name>
+    <Prefix/>
+    <Marker/>
+    <MaxKeys>1000</MaxKeys>
+    <IsTruncated>false</IsTruncated>
+      <Contents>
+          <Key>jobs/#{job_id}/log.txt</Key>
+          <LastModified>2009-10-12T17:50:30.000Z</LastModified>
+          <ETag>&quot;hgb9dede5f27731c9771645a39863328&quot;</ETag>
+          <Size>20308738</Size>
+          <StorageClass>STANDARD</StorageClass>
+          <Owner>
+              <ID>75aa57f09aa0c8caeab4f8c24e99d10f8e7faeebf76c078efc7c6caea54ba06a</ID>
+              <DisplayName>mtd@amazon.com</DisplayName>
+          </Owner>
+      </Contents>
+    </ListBucketResult>"
+  }
 
   before :each do
     described_class::Remote.instance_variable_set(:@clients, nil)
     described_class::Remote.instance_variable_set(:@archive_clients, nil)
+
+    Fog.mock!
+    storage = Fog::Storage.new({
+      aws_access_key_id: 'key',
+      aws_secret_access_key: 'secret',
+      provider: 'AWS'
+    })
+    bucket = storage.directories.create(key: 'archive.travis-ci.org')
+    file = bucket.files.create(
+      key: "jobs/#{job_id}/log.txt",
+      body: archived_content
+    )
+
+    allow_any_instance_of(Travis::RemoteLog::ArchiveClient).to receive(:fetch_archived).and_return(file)
+
+    stub_request(:get, %r[https://s3\.amazonaws\.com/archive\.travis-ci\.org/\?prefix=jobs/#{job_id}/log\.txt]).
+      to_return(status: 200, body: xml_content, headers: {})
+  end
+
+  after do
+    Fog.unmock!
+    Fog::Mock.reset
   end
 
   it 'has a default client' do

--- a/spec/lib/travis/remote_log_spec.rb
+++ b/spec/lib/travis/remote_log_spec.rb
@@ -5,27 +5,6 @@ describe Travis::RemoteLog do
   let(:job_id) { 5 }
   let(:attrs) { { id: 4, content: archived_content, job_id: job_id } }
   let(:archived_content) { 'hello world' }
-  let(:xml_content) {
-    "<?xml version=\"1.0\" encoding=\"UTF-8\"?>
-    <ListBucketResult xmlns=\"http://s3.amazonaws.com/doc/2006-03-01/\">
-    <Name>bucket</Name>
-    <Prefix/>
-    <Marker/>
-    <MaxKeys>1000</MaxKeys>
-    <IsTruncated>false</IsTruncated>
-      <Contents>
-          <Key>jobs/#{job_id}/log.txt</Key>
-          <LastModified>2009-10-12T17:50:30.000Z</LastModified>
-          <ETag>&quot;hgb9dede5f27731c9771645a39863328&quot;</ETag>
-          <Size>20308738</Size>
-          <StorageClass>STANDARD</StorageClass>
-          <Owner>
-              <ID>75aa57f09aa0c8caeab4f8c24e99d10f8e7faeebf76c078efc7c6caea54ba06a</ID>
-              <DisplayName>mtd@amazon.com</DisplayName>
-          </Owner>
-      </Contents>
-    </ListBucketResult>"
-  }
 
   before :each do
     described_class::Remote.instance_variable_set(:@clients, nil)


### PR DESCRIPTION
## Current Behavior
Once the job logs are archived, they are served from S3 as plain text.
1. Requests with `Accept: application/json` results in 406:

    ```sh-session
    $ curl -H "Accept: application/json" -sSfL https://api.travis-ci.org/jobs/43135435/log
    curl: (22) The requested URL returned error: 406 Not Acceptable
    ```
1. _**unless**_ the `User-Agent` string starts with `Travis`:
    <details>
    <summary>JSON requests with "User-Agent: Travis foo"</summary>
    <pre>
    $ curl -H "Accept: application/json" -H "User-Agent: Travis foo" -svSfL https://api.travis-ci.org/jobs/43135435/log
    *   Trying 54.243.143.241:443...
    * TCP_NODELAY set
    * Connected to api.travis-ci.org (54.243.143.241) port 443 (#0)
    * ALPN, offering http/1.1
    * successfully set certificate verify locations:
    *   CAfile: /Users/asari/opt/anaconda3/ssl/cacert.pem
      CApath: none
    * TLSv1.3 (OUT), TLS handshake, Client hello (1):
    * TLSv1.3 (IN), TLS handshake, Server hello (2):
    * TLSv1.2 (IN), TLS handshake, Certificate (11):
    * TLSv1.2 (IN), TLS handshake, Server key exchange (12):
    * TLSv1.2 (IN), TLS handshake, Server finished (14):
    * TLSv1.2 (OUT), TLS handshake, Client key exchange (16):
    * TLSv1.2 (OUT), TLS change cipher, Change cipher spec (1):
    * TLSv1.2 (OUT), TLS handshake, Finished (20):
    * TLSv1.2 (IN), TLS handshake, Finished (20):
    * SSL connection using TLSv1.2 / ECDHE-RSA-AES128-GCM-SHA256
    * ALPN, server did not agree to a protocol
    * Server certificate:
    *  subject: OU=Domain Control Validated; OU=EssentialSSL Wildcard; CN=*.travis-ci.org
    *  start date: Jun 26 00:00:00 2018 GMT
    *  expire date: Aug 24 23:59:59 2020 GMT
    *  subjectAltName: host "api.travis-ci.org" matched cert's "*.travis-ci.org"
    *  issuer: C=GB; ST=Greater Manchester; L=Salford; O=COMODO CA Limited; CN=COMODO RSA Domain Validation Secure Server CA
    *  SSL certificate verify ok.
    > GET /jobs/43135435/log HTTP/1.1
    > Host: api.travis-ci.org
    > Accept: application/json
    > User-Agent: Travis foo
    >
    * Mark bundle as not supporting multiuse
    < HTTP/1.1 307 Temporary Redirect
    < Connection: keep-alive
    < Server: nginx
    < Date: Mon, 16 Mar 2020 18:45:18 GMT
    < Content-Type: application/json
    < Content-Length: 0
    < Strict-Transport-Security: max-age=31536000
    < X-Endpoint: Travis::Api::App::Endpoint::Jobs
    < X-Pattern: /:job_id/log
    < X-Oauth-Scopes: public
    < X-Accepted-Oauth-Scopes: public
    < Vary: Accept,Accept-Encoding
    < Location: https://s3.amazonaws.com/archive.travis-ci.org/jobs/43135435/log.txt?X-Amz-Expires=30&X-Amz-Date=20200316T184518Z&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAJRYRXRSVGNKPKO5A/20200316/us-east-1/s3/aws4_request&X-Amz-SignedHeaders=host&X-Amz-Signature=f84e731f1fd549fcda47b09988c5e1fb539c7c7e10fe8d132d8a262011d3e63d
    < X-Rack-Cache: miss
    < X-Request-Id: 97509008-26e9-4856-b8a0-5f1097bb485e
    < Access-Control-Allow-Origin: *
    < Access-Control-Allow-Credentials: true
    < Access-Control-Expose-Headers: Content-Type, Cache-Control, Expires, Etag, Last-Modified, X-Request-ID
    < Via: 1.1 vegur
    <
    * Connection #0 to host api.travis-ci.org left intact
    * Issue another request to this URL: 'https://s3.amazonaws.com/archive.travis-ci.org/jobs/43135435/log.txt?X-Amz-Expires=30&X-Amz-Date=20200316T184518Z&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAJRYRXRSVGNKPKO5A/20200316/us-east-1/s3/aws4_request&X-Amz-SignedHeaders=host&X-Amz-Signature=f84e731f1fd549fcda47b09988c5e1fb539c7c7e10fe8d132d8a262011d3e63d'
    *   Trying 52.216.146.181:443...
    * TCP_NODELAY set
    * Connected to s3.amazonaws.com (52.216.146.181) port 443 (#1)
    * ALPN, offering http/1.1
    * successfully set certificate verify locations:
    *   CAfile: /Users/asari/opt/anaconda3/ssl/cacert.pem
      CApath: none
    * TLSv1.3 (OUT), TLS handshake, Client hello (1):
    * TLSv1.3 (IN), TLS handshake, Server hello (2):
    * TLSv1.2 (IN), TLS handshake, Certificate (11):
    * TLSv1.2 (IN), TLS handshake, Server key exchange (12):
    * TLSv1.2 (IN), TLS handshake, Server finished (14):
    * TLSv1.2 (OUT), TLS handshake, Client key exchange (16):
    * TLSv1.2 (OUT), TLS change cipher, Change cipher spec (1):
    * TLSv1.2 (OUT), TLS handshake, Finished (20):
    * TLSv1.2 (IN), TLS handshake, Finished (20):
    * SSL connection using TLSv1.2 / ECDHE-RSA-AES128-GCM-SHA256
    * ALPN, server did not agree to a protocol
    * Server certificate:
    *  subject: C=US; ST=Washington; L=Seattle; O=Amazon.com, Inc.; CN=s3.amazonaws.com
    *  start date: Nov  9 00:00:00 2019 GMT
    *  expire date: Dec  2 12:00:00 2020 GMT
    *  subjectAltName: host "s3.amazonaws.com" matched cert's "s3.amazonaws.com"
    *  issuer: C=US; O=DigiCert Inc; OU=www.digicert.com; CN=DigiCert Baltimore CA-2 G2
    *  SSL certificate verify ok.
    > GET /archive.travis-ci.org/jobs/43135435/log.txt?X-Amz-Expires=30&X-Amz-Date=20200316T184518Z&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=XXXX&X-Amz-SignedHeaders=host&X-Amz-Signature=XXX HTTP/1.1
    > Host: s3.amazonaws.com
    > Accept: application/json
    > User-Agent: Travis foo
    >
    * Mark bundle as not supporting multiuse
    < HTTP/1.1 200 OK
    < x-amz-id-2: BN7NiEoox7vvnpDLYscfUzOsC3AenHONO48gcM+wbHZdCcSKGvhRUxU+xd2aXyfljK5eEkvFcNk=
    < x-amz-request-id: 2AAF5C4487E1534C
    < Date: Mon, 16 Mar 2020 18:45:19 GMT
    < Last-Modified: Fri, 05 Dec 2014 20:39:31 GMT
    < ETag: "89a775a9ba80ceb816ace5d85acf2d7f"
    < x-amz-storage-class: STANDARD_IA
    < x-amz-version-id: null
    < Accept-Ranges: bytes
    < Content-Type: text/plain
    < Content-Length: 414529
    < Server: AmazonS3
    ⋮
    </pre>
    </details>
    in which case the content returned is <tt>text/plain</tt>, which betrays the user's request.

This divergence in behavior based on `User-Agent` value is wrong and confusing.

## Solution
This PR addresses both of these problems by serving a proper JSON data when requested, regardless of the `User-Agent` value.

## Effects
This supersedes https://github.com/travis-ci/travis.rb/pull/718 and resolves https://github.com/travis-ci/travis.rb/issues/578