### PR TITLE
Force UTF-8 when retrieving archived log

### DIFF
--- a/lib/travis/remote_log.rb
+++ b/lib/travis/remote_log.rb
@@ -250,7 +250,7 @@ module Travis
       def fetch_archived_log_content(job_id)
         file = fetch_archived(job_id)
         return "" if file.nil?
-        file.body
+        file.body.force_encoding("UTF-8")
       end
 
       private def fetch_archived(job_id)


### PR DESCRIPTION
This resulted in internal server error:

    $ curl -sSfL -H "Accept: application/json" https://api.travis-ci.org/logs/267373386
    curl: (22) The requested URL returned error: 500 Internal Server Error