### PR TITLE
jobs endpoint query boost

### DIFF
--- a/lib/travis/api/v3/queries/jobs.rb
+++ b/lib/travis/api/v3/queries/jobs.rb
@@ -1,8 +1,8 @@
 module Travis::API::V3
   class Queries::Jobs < Query
     params :state, :created_by, :active, prefix: :job
-    sortable_by :id
-    default_sort "id:desc"
+    sortable_by :id, :state
+    default_sort "id:desc,state"
 
     ACTIVE_STATES = %w(created queued received started).freeze
 


### PR DESCRIPTION
PG stops to use indexes when LIMIT is used in SQL query.
The workaround is described here http://datamangling.com/2014/01/17/limit-1-and-performance-in-a-postgres-query/
Columns, which are used in WHERE clause and have indexes should be sorted.