### PR TITLE
Tweak User-Agent meters

### DIFF
--- a/lib/travis/api/app/middleware/user_agent_tracker.rb
+++ b/lib/travis/api/app/middleware/user_agent_tracker.rb
@@ -25,7 +25,7 @@ class Travis::Api::App
       before(agent: /^.+$/) do
         agent = UserAgent.parse(request.user_agent)
         case agent.browser
-        when *WEB_BROWSERS                   then mark_browser
+        when *WEB_BROWSERS                   then mark_browser(agent)
         when "curl", "Wget"                  then mark(:console, agent.browser)
         when "travis-api-wrapper"            then mark(:script, :node_js, agent.browser)
         when "TravisPy"                      then mark(:script, :python,  agent.browser)
@@ -36,10 +36,13 @@ class Travis::Api::App
         end
       end
 
-      def mark_browser
+      def mark_browser(agent)
         # allows a JavaScript Client to set X-User-Agent, for instance to "travis-web" in travis-web
-        x_agent = UserAgent.parse(env['HTTP_X_USER_AGENT'] || 'unknown').browser
-        mark(:browser, x_agent)
+        if env['HTTP_X_USER_AGENT']
+          mark :browser, UserAgent.parse(env['HTTP_X_USER_AGENT']).browser
+        else
+          mark :browser, agent.browser
+        end
       end
 
       def mark_travis(agent)

--- a/lib/travis/api/app/middleware/user_agent_tracker.rb
+++ b/lib/travis/api/app/middleware/user_agent_tracker.rb
@@ -11,8 +11,14 @@ class Travis::Api::App
         "Opera", "Mozilla"
       ]
 
+      attr_reader :metrik_prefix
+
+      before do
+        @metrik_prefix = request.env['HTTP_TRAVIS_API_VERSION'] || 'api.v2'
+      end
+
       before(agent: /^$/) do
-        ::Metriks.meter("api.v2.user_agent.missing").mark
+        ::Metriks.meter("#{metrik_prefix}.user_agent.missing").mark
         halt(400, "error" => "missing User-Agent header") if Travis::Features.feature_active?(:require_user_agent)
       end
 
@@ -54,7 +60,7 @@ class Travis::Api::App
       end
 
       def mark(*keys)
-        key = "api.v2.user_agent." << keys.map { |k| k.to_s.downcase.gsub(/[^a-z0-9\-\.]+/, '_') }.join('.')
+        key = "#{metrik_prefix}.user_agent." << keys.map { |k| k.to_s.downcase.gsub(/[^a-z0-9\-\.]+/, '_') }.join('.')
         ::Metriks.meter(key).mark
       end
     end

--- a/lib/travis/api/app/middleware/user_agent_tracker.rb
+++ b/lib/travis/api/app/middleware/user_agent_tracker.rb
@@ -14,7 +14,11 @@ class Travis::Api::App
       attr_reader :metrik_prefix
 
       before do
-        @metrik_prefix = request.env['HTTP_TRAVIS_API_VERSION'] || 'api.v2'
+        @metrik_prefix = if version = request.env['HTTP_TRAVIS_API_VERSION']
+          "api.v#{version}"
+        else
+          "api.v2"
+        end
       end
 
       before(agent: /^$/) do

--- a/spec/unit/middleware/user_agent_tracker_spec.rb
+++ b/spec/unit/middleware/user_agent_tracker_spec.rb
@@ -33,7 +33,7 @@ describe Travis::Api::App::Middleware::UserAgentTracker do
     let(:agent) { "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_9_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/39.0.2171.36 Safari/537.36" }
 
     specify 'without X-User-Agent' do
-      expect_meter("api.v2.user_agent.browser.unknown")
+      expect_meter("api.v2.user_agent.browser.chrome")
       get
     end
 


### PR DESCRIPTION
* Honor the request's `User-Agent` browser value _*unless*_ `X-User-Agent` is also set
* If the request contains `Travis-API-Version` header, record that for metering