### PR TITLE
Remove deployment based on `CI_NODE_INDEX=0`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,11 +38,4 @@ jobs:
       install: echo skip
       before_script: echo skip
       script: make ship
-      if: commit_message =~ /ship:docker/ OR env(SHIP_DOCKER) = true
-
-deploy:
-  - provider: script
-    script: make ship
-    on:
-      branch: master
-      condition: CI_NODE_INDEX=0
+      if: commit_message =~ /ship:docker/ OR env(SHIP_DOCKER) = true or branch = master


### PR DESCRIPTION
Instead of relying on unreliable `CI_NODE_INDEX=0` to decide whether
or not to deploy to Docker Hub, we make use of the existing shipping
logic by simply adding the `branch` condition to the :ship: stage.