### PR TITLE
CRON: interval randomization

### DIFF
--- a/lib/travis/api/app/schedulers/schedule_cron_jobs.rb
+++ b/lib/travis/api/app/schedulers/schedule_cron_jobs.rb
@@ -8,6 +8,10 @@ class Travis::Api::App
       register :schedule_cron_jobs
 
       def self.run
+        interval = Travis::API::V3::Models::Cron::SCHEDULER_INTERVAL.to_i
+        if !!ENV['TRAVIS_CRON_RANDOM_INTERVAL']
+          interval += rand(ENV['TRAVIS_CRON_RANDOM_INTERVAL'].to_i)
+        end
         loop do
           begin
             Travis::Lock.exclusive("enqueue_cron_jobs", options) do
@@ -16,7 +20,7 @@ class Travis::Api::App
           rescue Travis::Lock::Redis::LockError => e
             Travis.logger.error e.message
           end
-          sleep(Travis::API::V3::Models::Cron::SCHEDULER_INTERVAL)
+          sleep(interval)
         end
       end
 


### PR DESCRIPTION
allow randomization of cron check task sleep time - for specific
envs with multiple cron tasks