### PR TITLE
Build priority feature on an Organization. 

### DIFF
--- a/lib/travis/api/v3/models/organization.rb
+++ b/lib/travis/api/v3/models/organization.rb
@@ -26,7 +26,7 @@ module Travis::API::V3
     end
 
     def build_priorities_enabled?
-      !!Travis::Features.owner_active?(:build_priorities_org, self)
+      Travis::Features.owner_active?(:build_priorities_org, self)
     end
 
     alias members users

--- a/lib/travis/api/v3/models/organization.rb
+++ b/lib/travis/api/v3/models/organization.rb
@@ -25,6 +25,10 @@ module Travis::API::V3
       Models::Build.where(owner_type: 'Organization', owner_id: id)
     end
 
+    def build_priorities_enabled?
+      !!Travis::Features.owner_active?(:build_priorities_org, self)
+    end
+
     alias members users
   end
 end

--- a/lib/travis/api/v3/permissions/build.rb
+++ b/lib/travis/api/v3/permissions/build.rb
@@ -9,5 +9,9 @@ module Travis::API::V3
     def restart?
       restartable?
     end
+
+    def prioritize?
+      writable? && build_priorities?
+    end
   end
 end

--- a/lib/travis/api/v3/permissions/build.rb
+++ b/lib/travis/api/v3/permissions/build.rb
@@ -11,7 +11,7 @@ module Travis::API::V3
     end
 
     def prioritize?
-      writable? && build_priorities?
+      write? && build_priorities?
     end
   end
 end

--- a/lib/travis/api/v3/permissions/generic.rb
+++ b/lib/travis/api/v3/permissions/generic.rb
@@ -75,5 +75,14 @@ module Travis::API::V3
       access_control.adminable? object
     end
 
+    def writable?
+      access_control.writable? object
+    end
+
+    def build_priorities?
+      return false if object.owner_type != 'Organization'
+      object.owner.build_priorities_enabled?
+    end
+
   end
 end

--- a/lib/travis/api/v3/permissions/generic.rb
+++ b/lib/travis/api/v3/permissions/generic.rb
@@ -75,10 +75,6 @@ module Travis::API::V3
       access_control.adminable? object
     end
 
-    def writable?
-      access_control.writable? object
-    end
-
     def build_priorities?
       return false if object.owner_type != 'Organization'
       object.owner.build_priorities_enabled?

--- a/lib/travis/api/v3/renderer/owner.rb
+++ b/lib/travis/api/v3/renderer/owner.rb
@@ -5,7 +5,7 @@ module Travis::API::V3
     include Renderer::AvatarURL
 
     representation(:minimal,    :id, :login, :vcs_type)
-    representation(:standard,   :id, :login, :name, :github_id, :vcs_id, :vcs_type, :avatar_url, :education, :allow_migration, :allow_build_priorities)
+    representation(:standard,   :id, :login, :name, :github_id, :vcs_id, :vcs_type, :avatar_url, :education, :allow_migration)
     representation(:additional, :repositories, :installation)
 
     def initialize(*)
@@ -27,10 +27,6 @@ module Travis::API::V3
 
     def allow_migration
       !!Travis::Features.owner_active?(:allow_migration, @model)
-    end
-
-    def allow_build_priorities
-      !!Travis::Features.owner_active?(:build_priorities_org, @model)
     end
   end
 end

--- a/spec/v3/services/build/find_spec.rb
+++ b/spec/v3/services/build/find_spec.rb
@@ -5,6 +5,7 @@ describe Travis::API::V3::Services::Build::Find, set_app: true do
   let(:stages) { build.stages }
   let(:jobs)   { Travis::API::V3::Models::Build.find(build.id).jobs }
   let(:parsed_body) { JSON.load(body) }
+  let(:org) { Travis::API::V3::Models::Organization.new(login: 'example-org') }
 
   before do
     build.update_attributes(sender_id: repo.owner.id, sender_type: 'User')
@@ -42,7 +43,8 @@ describe Travis::API::V3::Services::Build::Find, set_app: true do
       "@permissions"        => {
         "read"              => true,
         "cancel"            => false,
-        "restart"           => false},
+        "restart"           => false,
+        "prioritize"        => false},
       "id"                  => build.id,
       "number"              => build.number,
       "state"               => build.state,
@@ -140,7 +142,8 @@ describe Travis::API::V3::Services::Build::Find, set_app: true do
       "@permissions"        => {
         "read"              => true,
         "cancel"            => true,
-        "restart"           => true},
+        "restart"           => true,
+        "prioritize"        => false},
       "id"                  => build.id,
       "number"              => build.number,
       "state"               => build.state,
@@ -230,7 +233,8 @@ describe Travis::API::V3::Services::Build::Find, set_app: true do
       "@permissions"        => {
         "read"              => true,
         "cancel"            => false,
-        "restart"           => false},
+        "restart"           => false,
+        "prioritize"        => false},
       "id"                  => build.id,
       "number"              => build.number,
       "state"               => build.state,

--- a/spec/v3/services/builds/find_spec.rb
+++ b/spec/v3/services/builds/find_spec.rb
@@ -66,7 +66,8 @@ describe Travis::API::V3::Services::Builds::Find, set_app: true do
         "@permissions"        => {
           "read"              => true,
           "cancel"            => false,
-          "restart"           => false },
+          "restart"           => false,
+          "prioritize"        => false },
         "id"                  => build.id,
         "number"              => "3",
         "state"               => "configured",
@@ -184,7 +185,8 @@ describe Travis::API::V3::Services::Builds::Find, set_app: true do
         "@permissions"        => {
           "read"              => true,
           "cancel"            => false,
-          "restart"           => false },
+          "restart"           => false,
+          "prioritize"        => false},
         "id"                  => build.id,
         "number"              => "3",
         "state"               => "configured",
@@ -306,7 +308,8 @@ describe Travis::API::V3::Services::Builds::Find, set_app: true do
         "@permissions"        => {
           "read"              => true,
           "cancel"            => true,
-          "restart"           => true },
+          "restart"           => true,
+          "prioritize"        => false },
         "id"                  => build.id,
         "number"              => "3",
         "state"               => "configured",

--- a/spec/v3/services/builds/for_current_user_spec.rb
+++ b/spec/v3/services/builds/for_current_user_spec.rb
@@ -48,7 +48,8 @@ describe Travis::API::V3::Services::Builds::ForCurrentUser, set_app: true do
         "@permissions"        => {
           "read"              => true,
           "cancel"            => false,
-          "restart"           => false },
+          "restart"           => false,
+          "prioritize"        => false },
         "id"                  => build.id,
         "number"              => "3",
         "state"               => "configured",

--- a/spec/v3/services/installation/find_spec.rb
+++ b/spec/v3/services/installation/find_spec.rb
@@ -56,7 +56,6 @@ describe Travis::API::V3::Services::Installation::Find, set_app: true do
         "synced_at" => nil,
         "education" => nil,
         "allow_migration" => false,
-        "allow_build_priorities" => false,
         "recently_signed_up" => false,
         "secure_user_hash" => nil,
       }

--- a/spec/v3/services/organization/find_spec.rb
+++ b/spec/v3/services/organization/find_spec.rb
@@ -23,7 +23,6 @@ describe Travis::API::V3::Services::Organization::Find, set_app: true do
       "avatar_url"       => nil,
       "education"        => false,
       "allow_migration"  => false,
-      "allow_build_priorities" => false,
     }}
   end
 
@@ -53,7 +52,6 @@ describe Travis::API::V3::Services::Organization::Find, set_app: true do
       "avatar_url"       => nil,
       "education"        => true,
       "allow_migration"  => true,
-      "allow_build_priorities" => true,
     }}
   end
 

--- a/spec/v3/services/organizations/for_current_user_spec.rb
+++ b/spec/v3/services/organizations/for_current_user_spec.rb
@@ -59,7 +59,6 @@ describe Travis::API::V3::Services::Organizations::ForCurrentUser, set_app: true
         "avatar_url"      => nil,
         "education"       => false,
         "allow_migration" => false,
-        "allow_build_priorities" => false,
       }]
     }}
   end

--- a/spec/v3/services/owner/find_spec.rb
+++ b/spec/v3/services/owner/find_spec.rb
@@ -23,7 +23,6 @@ describe Travis::API::V3::Services::Owner::Find, set_app: true do
         "avatar_url"       => nil,
         "education"        => false,
         "allow_migration"  => false,
-        "allow_build_priorities" => false
       }}
     end
 
@@ -44,7 +43,6 @@ describe Travis::API::V3::Services::Owner::Find, set_app: true do
         "avatar_url"       => nil,
         "education"        => false,
         "allow_migration"  => false,
-        "allow_build_priorities" => false
       }}
     end
 
@@ -70,7 +68,6 @@ describe Travis::API::V3::Services::Owner::Find, set_app: true do
         "avatar_url"          => nil,
         "education"           => false,
         "allow_migration"     => false,
-        "allow_build_priorities" => false,
         "repositories"        => [{
           "@type"             => "repository",
           "@href"             => "/v3/repo/#{repo.id}",
@@ -140,7 +137,6 @@ describe Travis::API::V3::Services::Owner::Find, set_app: true do
         "avatar_url"        => nil,
         "education"         => false,
         "allow_migration"   => false,
-        "allow_build_priorities" => false,
         "repositories"      => [{
           "@type"           => "repository",
           "@href"           => "/v3/repo/#{repo.id}",
@@ -205,7 +201,6 @@ describe Travis::API::V3::Services::Owner::Find, set_app: true do
         "avatar_url"       => nil,
         "education"        => false,
         "allow_migration"  => false,
-        "allow_build_priorities" => false,
       }}
     end
 
@@ -230,7 +225,6 @@ describe Travis::API::V3::Services::Owner::Find, set_app: true do
         "avatar_url"     => nil,
         "education"      => false,
         "allow_migration"=> false,
-        "allow_build_priorities" => false,
         "@warnings"      => [{
           "@type"        => "warning",
           "message"      => "query parameter organization.id not safelisted, ignored",
@@ -265,7 +259,6 @@ describe Travis::API::V3::Services::Owner::Find, set_app: true do
         "synced_at"      => nil,
         "education"      => nil,
         "allow_migration"=> false,
-        "allow_build_priorities" => false,
         "recently_signed_up"=>false,
         "secure_user_hash" => nil,
       }}
@@ -291,7 +284,6 @@ describe Travis::API::V3::Services::Owner::Find, set_app: true do
         "is_syncing"     => nil,
         "synced_at"      => nil,
         "allow_migration"=> false,
-        "allow_build_priorities" => false,
         "recently_signed_up"=>false,
         "secure_user_hash" => nil,
       }}
@@ -317,7 +309,6 @@ describe Travis::API::V3::Services::Owner::Find, set_app: true do
         "is_syncing"       => nil,
         "synced_at"        => nil,
         "allow_migration"  => false,
-        "allow_build_priorities" => false,
         "recently_signed_up"=>false,
         "secure_user_hash" => nil,
       }}
@@ -347,7 +338,6 @@ describe Travis::API::V3::Services::Owner::Find, set_app: true do
         "is_syncing"       => nil,
         "synced_at"        => nil,
         "allow_migration"  => false,
-        "allow_build_priorities" => false,
         "recently_signed_up"=>false,
         "secure_user_hash" => nil,
         "@warnings"        => [{

--- a/spec/v3/services/repositories/for_owner_spec.rb
+++ b/spec/v3/services/repositories/for_owner_spec.rb
@@ -165,7 +165,8 @@ describe Travis::API::V3::Services::Repositories::ForOwner, set_app: true do
           "@permissions"   =>{
             "read"         =>true,
             "cancel"       =>true,
-            "restart"      =>true},
+            "restart"      =>true,
+            "prioritize"   =>false},
           "id"             =>build.id,
           "number"         =>"#{build.number}",
           "state"          =>"configured",
@@ -279,7 +280,8 @@ describe Travis::API::V3::Services::Repositories::ForOwner, set_app: true do
           "@permissions"        => {
             "read"    => true,
             "cancel"  => true,
-            "restart" => true
+            "restart" => true,
+            "prioritize"=> false
           },
           "id"                  => build.id,
           "number"              => "#{build.number}",

--- a/spec/v3/services/user/current_spec.rb
+++ b/spec/v3/services/user/current_spec.rb
@@ -24,7 +24,6 @@ describe Travis::API::V3::Services::User::Current, set_app: true do
       "synced_at"        => user.synced_at,
       "education"        => nil,
       "allow_migration"  => false,
-      "allow_build_priorities" => false,
       "recently_signed_up"=>false,
       "secure_user_hash" => nil
     }}

--- a/spec/v3/services/user/find_spec.rb
+++ b/spec/v3/services/user/find_spec.rb
@@ -29,7 +29,6 @@ describe Travis::API::V3::Services::User::Find, set_app: true do
       "synced_at"        => user.synced_at,
       "education"        => true,
       "allow_migration"  => false,
-      "allow_build_priorities" => false,
       "recently_signed_up"=>false,
       "secure_user_hash" => nil,
     }}


### PR DESCRIPTION
Checked build priority features for an organisation with below  - 
- User has access to the push permission.
- The build owner (Organization), has access to the priority feature.
And removed "allow_build_priorities" which is added Previously.