### PR TITLE
Removed push permission for prioritize flag on Build and Job level

### DIFF
--- a/lib/travis/api/v3/permissions/build.rb
+++ b/lib/travis/api/v3/permissions/build.rb
@@ -11,7 +11,7 @@ module Travis::API::V3
     end
 
     def prioritize?
-      build_priorities?
+      read? && build_priorities?
     end
   end
 end

--- a/lib/travis/api/v3/permissions/build.rb
+++ b/lib/travis/api/v3/permissions/build.rb
@@ -11,7 +11,7 @@ module Travis::API::V3
     end
 
     def prioritize?
-      write? && build_priorities?
+      build_priorities?
     end
   end
 end

--- a/lib/travis/api/v3/permissions/job.rb
+++ b/lib/travis/api/v3/permissions/job.rb
@@ -19,7 +19,7 @@ module Travis::API::V3
     end
 
     def prioritize?
-      write? && build_priorities?
+      build_priorities?
     end
   end
 end

--- a/lib/travis/api/v3/permissions/job.rb
+++ b/lib/travis/api/v3/permissions/job.rb
@@ -19,7 +19,7 @@ module Travis::API::V3
     end
 
     def prioritize?
-      build_priorities?
+      read? && build_priorities?
     end
   end
 end


### PR DESCRIPTION
We have removed this check as it will block in giving a feature in PRD, ie: Show the prioritize button in disabled state when the user is not having push access.