### PR TITLE
Remove duplicate parameters from ServiceIndex

### DIFF
--- a/lib/travis/api/v3/service_index.rb
+++ b/lib/travis/api/v3/service_index.rb
@@ -133,7 +133,7 @@ module Travis::API::V3
               :request_method => request_method,
               :uri_template => prefix + template
             }
-            action[:accepted_params] = factory.accepted_params if ['POST'.freeze, 'PATCH'.freeze].include? request_method
+            action[:accepted_params] = factory.accepted_params.uniq if ['POST'.freeze, 'PATCH'.freeze].include? request_method
             list << action
           end
 


### PR DESCRIPTION
In particular, `Queries::Cron` defines two identical sets of
parameters with different prefixes. This results in duplicates in the
ServiceIndex:

    $ curl -s -H "Travis-API-Version: 3" -H "Accept: application/json" https://api.travis-ci.com | jq .resources.cron.actions.create[].accepted_params
    [
      "cron.interval",
      "cron.dont_run_if_recent_build_exists",
      "cron.interval",
      "cron.dont_run_if_recent_build_exists"
    ]
    [
      "cron.interval",
      "cron.dont_run_if_recent_build_exists",
      "cron.interval",
      "cron.dont_run_if_recent_build_exists"
    ]
    [
      "cron.interval",
      "cron.dont_run_if_recent_build_exists",
      "cron.interval",
      "cron.dont_run_if_recent_build_exists"
    ]
    [
      "cron.interval",
      "cron.dont_run_if_recent_build_exists",
      "cron.interval",
      "cron.dont_run_if_recent_build_exists"
    ]

We avoid this confusion by removing duplicates.