### PR TITLE
Stop billing requests on org domain

### DIFF
--- a/lib/travis/api/enqueue/services/restart_model.rb
+++ b/lib/travis/api/enqueue/services/restart_model.rb
@@ -32,7 +32,7 @@ module Travis
 
         def billing?
           # there is no billing for .org
-          return true if ENV["TRAVIS_SITE"] == 'org'
+          return true if Travis.config.org?
 
           @_billing_ok ||= begin
             jobs = target.is_a?(Job) ? [target] : target.matrix

--- a/lib/travis/api/enqueue/services/restart_model.rb
+++ b/lib/travis/api/enqueue/services/restart_model.rb
@@ -31,6 +31,9 @@ module Travis
         end
 
         def billing?
+          # there is no billing for .org
+          return true if ENV["TRAVIS_SITE"] == 'org'
+
           @_billing_ok ||= begin
             jobs = target.is_a?(Job) ? [target] : target.matrix
 

--- a/spec/lib/travis/api/enqueue/services/restart_model_spec.rb
+++ b/spec/lib/travis/api/enqueue/services/restart_model_spec.rb
@@ -10,6 +10,7 @@ describe Travis::Enqueue::Services::RestartModel do
   before do
     Travis.config.billing.url = 'http://localhost:9292/'
     Travis.config.billing.auth_key = 'secret'
+    ENV['TRAVIS_SITE'] = 'com'
   end
 
   after do

--- a/spec/lib/travis/api/enqueue/services/restart_model_spec.rb
+++ b/spec/lib/travis/api/enqueue/services/restart_model_spec.rb
@@ -10,7 +10,6 @@ describe Travis::Enqueue::Services::RestartModel do
   before do
     Travis.config.billing.url = 'http://localhost:9292/'
     Travis.config.billing.auth_key = 'secret'
-    ENV['TRAVIS_SITE'] = 'com'
   end
 
   after do

--- a/spec/v3/services/job/restart_spec.rb
+++ b/spec/v3/services/job/restart_spec.rb
@@ -238,6 +238,7 @@ describe Travis::API::V3::Services::Job::Restart, set_app: true do
           stub_request(:post, /http:\/\/localhost:9292\/(users|organizations)\/(.+)\/authorize_build/).to_return(
             body: MultiJson.dump(error: 'Plan not found'), status: 404
           )
+          Travis.config.host = 'travis-ci.com'
         end
 
         it 'restarts the job' do
@@ -251,6 +252,7 @@ describe Travis::API::V3::Services::Job::Restart, set_app: true do
           stub_request(:post, /http:\/\/localhost:9292\/(users|organizations)\/(.+)\/authorize_build/).to_return(
             body: MultiJson.dump(allowed: false, rejection_code: :no_build_credits), status: 403
           )
+          Travis.config.host = 'travis-ci.com'
         end
 
         it 'does not restart the job' do


### PR DESCRIPTION
There is no billing on .ORG so this PR will stop the build restart request from checking if the customer has active plan/subscription.