### PR TITLE
Travis CLI fix for enterprise logs

### DIFF
--- a/lib/travis/remote_log.rb
+++ b/lib/travis/remote_log.rb
@@ -105,7 +105,7 @@ module Travis
           part_numbers: part_numbers
         ).map(&:as_json)
       else
-        ret['body'] = archived_log_content || content
+        ret['body'] =  archived? ? archived_log_content : content
       end
 
       { 'log' => ret }


### PR DESCRIPTION
Enterprise logs are not stored remotely, the fix fetches the logs from DB