### PR TITLE
Hot Fix - build history

### DIFF
--- a/lib/travis/api/v3/models/build.rb
+++ b/lib/travis/api/v3/models/build.rb
@@ -31,7 +31,7 @@ module Travis::API::V3
       class_name:  'Travis::API::V3::Models::Job'.freeze
 
     has_one :branch,
-      foreign_key: [:repository_id, :name],
+      foreign_key: :last_build_id,
       primary_key: [:repository_id, :branch],
       class_name:  'Travis::API::V3::Models::Branch'.freeze
 


### PR DESCRIPTION
The build history was not loading correctly. A workaround involved first clicking on "requests" and then navigating back to the build history tab. 