### PR TITLE
Sync only passed space and repository

### DIFF
--- a/lib/travis/api/app/endpoint/assembla.rb
+++ b/lib/travis/api/app/endpoint/assembla.rb
@@ -12,7 +12,7 @@ class Travis::Api::App
     class Assembla < Endpoint
       include Travis::Api::App::JWTUtils
 
-      REQUIRED_JWT_FIELDS = %w[name email login space_id id refresh_token].freeze
+      REQUIRED_JWT_FIELDS = %w[name email login space_id repository_id id refresh_token].freeze
       CLUSTER_HEADER = 'HTTP_X_ASSEMBLA_CLUSTER'.freeze
 
       set prefix: '/assembla'

--- a/lib/travis/remote_vcs/user.rb
+++ b/lib/travis/remote_vcs/user.rb
@@ -35,9 +35,11 @@ module Travis
         end
       end
 
-      def sync(user_id:)
+      def sync(user_id:, space_id: nil, repository_id: nil)
         request(:post, __method__) do |req|
           req.url "users/#{user_id}/sync_data"
+          req.params['space_id'] = space_id if space_id
+          req.params['repository_id'] = repository_id if repository_id
         end && true
       end
 

--- a/lib/travis/services/assembla_user_service.rb
+++ b/lib/travis/services/assembla_user_service.rb
@@ -38,7 +38,7 @@ module Travis
       private
 
       def sync_user(user_id)
-        Travis::RemoteVCS::User.new.sync(user_id: user_id)
+        Travis::RemoteVCS::User.new.sync(user_id: user_id, space_id: @payload['space_id'], repository_id: @payload['repository_id'])
       rescue => e
         raise SyncError, "Failed to sync user: #{e.message}"
       end

--- a/spec/travis/remote_vcs/user_spec.rb
+++ b/spec/travis/remote_vcs/user_spec.rb
@@ -49,6 +49,32 @@ describe Travis::RemoteVCS::User do
     end
   end
 
+  describe '#sync' do
+    let(:user_id) { 123 }
+    let(:space_id) { 456 }
+    let(:repository_id) { 789 }
+    let(:instance) { described_class.new }
+    let(:req) { double(:request) }
+    let(:params) { double(:params) }
+
+    subject { instance.sync(user_id: user_id, space_id: space_id, repository_id: repository_id) }
+
+    before do
+      allow(req).to receive(:url)
+      allow(req).to receive(:params).and_return(params)
+      allow(params).to receive(:[]=)
+    end
+
+    it 'performs POST to VCS with proper params' do
+      expect(instance).to receive(:request).with(:post, :sync).and_yield(req)
+      expect(req).to receive(:url).with("users/#{user_id}/sync_data")
+      expect(params).to receive(:[]=).with('space_id', space_id)
+      expect(params).to receive(:[]=).with('repository_id', repository_id)
+
+      expect(subject).to be true
+    end
+  end
+
   describe '#authenticate' do
     let(:user) { described_class.new }
     let(:provider) { 'assembla' }

--- a/spec/unit/endpoint/assembla_spec.rb
+++ b/spec/unit/endpoint/assembla_spec.rb
@@ -14,6 +14,7 @@ RSpec.describe Travis::Api::App::Endpoint::Assembla, set_app: true do
       'space_id' => 'space123',
       'id' => 'assembla_vcs_user_id',
       'access_token' => 'test_access_token',
+      'repository_id' => 'repository123',
       'refresh_token' => 'test_refresh_token'
     }
   end


### PR DESCRIPTION
This PR updates the login endpoint to accept a repository_id parameter, which is then passed to travis-vcs to fetch data for the specified repository. When repository_id is provided in the login request, the system forwards this parameter to travis-vcs, enabling targeted repository data fetching instead of processing all repositories